### PR TITLE
Remove return Keyword in Sector Code

### DIFF
--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -181,7 +181,7 @@ impl<'a> Lexer<'a> {
                 }
             },
             '/' => {
-                return Token {
+                Token {
                     token_type: TokenType::DIV,
                     lexeme: "/".to_string(),
                     line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -159,7 +159,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 } else {
-                    return Token {
+                    Token {
                         token_type: TokenType::MINUS,
                         lexeme: "-".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -619,7 +619,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "i16384" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeInt(IntegerType::I16384),
                             lexeme: "i16384".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -255,7 +255,7 @@ impl<'a> Lexer<'a> {
                 }
             },
             '}' => {
-                return Token {
+                Token {
                     token_type: TokenType::RBRACE,
                     lexeme: "}".to_string(),
                     line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -269,7 +269,7 @@ impl<'a> Lexer<'a> {
                 }
             },
             ']' => {
-                return Token {
+                Token {
                     token_type: TokenType::RBRACK,
                     lexeme: "]".to_string(),
                     line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -507,7 +507,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "print" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::PRINT,
                             lexeme: "print".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -409,7 +409,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "var" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::VAR,
                             lexeme: "var".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -248,7 +248,7 @@ impl<'a> Lexer<'a> {
                 }
             },
             '{' => {
-                return Token {
+                Token {
                     token_type: TokenType::LBRACE,
                     lexeme: "{".to_string(),
                     line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -307,7 +307,7 @@ impl<'a> Lexer<'a> {
             },
             '|' => {
                 if self.match_next('|') {
-                    return Token {
+                    Token {
                         token_type: TokenType::LogicalOr,
                         lexeme: "||".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -813,7 +813,7 @@ impl<'a> Lexer<'a> {
                     }
                 };
 
-                return Token {
+                Token {
                     token_type,
                     lexeme: num_str, // Save real string to lexeme
                     line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -535,7 +535,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "i4" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeInt(IntegerType::I4),
                             lexeme: "i4".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -385,7 +385,7 @@ impl<'a> Lexer<'a> {
                 }
             },
             ',' => {
-                return Token {
+                Token {
                     token_type: TokenType::COMMA,
                     lexeme: ",".to_string(),
                     line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -528,7 +528,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "isz" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeInt(IntegerType::ISZ),
                             lexeme: "isz".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -479,7 +479,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "xnand" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::XNAND,
                             lexeme: "xnand".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -598,7 +598,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "i2048" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeInt(IntegerType::I2048),
                             lexeme: "i2048".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -219,7 +219,7 @@ impl<'a> Lexer<'a> {
             },
             '>' => {
                 if self.match_next('=') {
-                    return Token {
+                    Token {
                         token_type: TokenType::RchevrEq,
                         lexeme: ">=".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -570,7 +570,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "i128" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeInt(IntegerType::I128),
                             lexeme: "i128".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -765,7 +765,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "f32768" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeFloat(FloatType::F32768),
                             lexeme: "f32768".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -423,7 +423,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "if" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::IF,
                             lexeme: "if".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -328,7 +328,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 } else if self.match_next('&') {
-                    return Token {
+                    Token {
                         token_type: TokenType::NAND,
                         lexeme: "!&".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -437,7 +437,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "while" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::WHILE,
                             lexeme: "while".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -465,7 +465,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "rol" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::ROL,
                             lexeme: "rol".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -334,7 +334,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 } else if self.match_next('|') {
-                    return Token {
+                    Token {
                         token_type: TokenType::NOR,
                         lexeme: "!|".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -292,7 +292,7 @@ impl<'a> Lexer<'a> {
             },
             '&' => {
                 if self.match_next('&') {
-                    return Token {
+                    Token {
                         token_type: TokenType::LogicalAnd,
                         lexeme: "&&".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -743,7 +743,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "f4096" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeFloat(FloatType::F4096),
                             lexeme: "f4096".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -605,7 +605,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "i4096" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeInt(IntegerType::I4096),
                             lexeme: "i4096".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -356,7 +356,7 @@ impl<'a> Lexer<'a> {
             },
             '~' => {
                 if self.match_next('^') {
-                    return Token {
+                    Token {
                         token_type: TokenType::XNOR,
                         lexeme: "~^".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -584,7 +584,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "i512" => {
-                        return Token {
+                       Token {
                             token_type: TokenType::TypeInt(IntegerType::I512),
                             lexeme: "i512".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -521,7 +521,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "println" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::PRINTLN,
                             lexeme: "println".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -283,7 +283,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 } else {
-                    return Token {
+                    Token {
                         token_type: TokenType::EQUAL,
                         lexeme: "=".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -138,7 +138,7 @@ impl<'a> Lexer<'a> {
         match c {
             '+' => {
                 if self.match_next('+') {
-                    return Token {
+                    Token {
                         token_type: TokenType::INCREMENT,
                         lexeme: "++".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -430,7 +430,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "else" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::ELSE,
                             lexeme: "else".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -577,7 +577,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "i256" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeInt(IntegerType::I256),
                             lexeme: "i256".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -203,7 +203,7 @@ impl<'a> Lexer<'a> {
             },
             '<' => {
                 if self.match_next('=') {
-                    return Token {
+                    Token {
                         token_type: TokenType::LchevrEq,
                         lexeme: "<=".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -371,7 +371,7 @@ impl<'a> Lexer<'a> {
             },
             '?' => {
                 if self.match_next('?') {
-                    return Token {
+                    Token {
                         token_type: TokenType::NullCoalesce,
                         lexeme: "??".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -322,7 +322,7 @@ impl<'a> Lexer<'a> {
             },
             '!' => {
                 if self.match_next('=') {
-                    return Token {
+                    Token {
                         token_type: TokenType::NotEqual,
                         lexeme: "!=".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -779,7 +779,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     _ => {
-                        return Token {
+                        Token {
                             token_type: TokenType::IDENTIFIER(identifier.clone()),
                             lexeme: identifier,
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -542,7 +542,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "i8" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeInt(IntegerType::I8),
                             lexeme: "i8".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -500,7 +500,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "continue" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::CONTINUE,
                             lexeme: "continue".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -174,7 +174,7 @@ impl<'a> Lexer<'a> {
                 }
             } ,
             '.' => {
-                return Token {
+                Token {
                     token_type: TokenType::DOT,
                     lexeme: ".".to_string(),
                     line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -277,7 +277,7 @@ impl<'a> Lexer<'a> {
             },
             '=' => {
                 if self.match_next('=') {
-                    return Token {
+                    Token {
                         token_type: TokenType::EqualTwo,
                         lexeme: "==".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -549,7 +549,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "i16" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeInt(IntegerType::I16),
                             lexeme: "i16".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -514,7 +514,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "input" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::INPUT,
                             lexeme: "input".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -612,7 +612,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "i8192" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeInt(IntegerType::I8192),
                             lexeme: "i8192".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -225,7 +225,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 } else {
-                    return Token {
+                    Token {
                         token_type: TokenType::RCHEVR,
                         lexeme: ">".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -167,7 +167,7 @@ impl<'a> Lexer<'a> {
                 }
             },
             '*' => {
-                return Token {
+                Token {
                     token_type: TokenType::STAR,
                     lexeme: "*".to_string(),
                     line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -313,7 +313,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 } else {
-                    return Token {
+                    Token {
                         token_type: TokenType::BitwiseOr,
                         lexeme: "|".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -241,7 +241,7 @@ impl<'a> Lexer<'a> {
                 }
             },
             ')' => {
-                return Token {
+                Token {
                     token_type: TokenType::RPAREN,
                     lexeme: ")".to_string(),
                     line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -153,7 +153,7 @@ impl<'a> Lexer<'a> {
             },
             '-' => {
                 if self.match_next('-') {
-                    return Token {
+                    Token {
                         token_type: TokenType::DECREMENT,
                         lexeme: "--".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -444,7 +444,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "for" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::FOR,
                             lexeme: "for".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -392,7 +392,7 @@ impl<'a> Lexer<'a> {
                 }
             },
             '"' => {
-                return Token {
+                Token {
                     token_type: TokenType::STRING(self.string()),
                     lexeme: String::new(), // Set as needed
                     line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -195,7 +195,7 @@ impl<'a> Lexer<'a> {
                 }
             },
             ':' => {
-                return Token {
+                Token {
                     token_type: TokenType::COLON,
                     lexeme: ":".to_string(),
                     line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -751,7 +751,7 @@ impl<'a> Lexer<'a> {
 
                     },
                     "f8192" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeFloat(FloatType::F8192),
                             lexeme: "f8192".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -493,7 +493,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "return" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::RETURN,
                             lexeme: "return".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -563,7 +563,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "i64" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeInt(IntegerType::I64),
                             lexeme: "i64".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -458,7 +458,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "is" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::IS,
                             lexeme: "is".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -362,7 +362,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 } else {
-                    return Token {
+                    Token {
                         token_type: TokenType::BitwiseNot,
                         lexeme: "~".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -486,7 +486,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "import" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::IMPORT,
                             lexeme: "import".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -472,7 +472,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "ror" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::ROR,
                             lexeme: "ror".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -556,7 +556,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "i32" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeInt(IntegerType::I32),
                             lexeme: "i32".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -188,7 +188,7 @@ impl<'a> Lexer<'a> {
                 }
             },
             ';' => {
-                return Token {
+                Token {
                     token_type: TokenType::SEMICOLON,
                     lexeme: ";".to_string(),
                     line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -377,7 +377,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 } else {
-                    return Token {
+                     Token {
                         token_type: TokenType::CONDITION,
                         lexeme: "?".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -402,7 +402,7 @@ impl<'a> Lexer<'a> {
                 let identifier = self.identifier();
                 match identifier.as_str() {
                     "fun" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::FUN,
                             lexeme: "fun".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -144,7 +144,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 } else {
-                    return Token {
+                    Token {
                         token_type: TokenType::PLUS,
                         lexeme: "+".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -416,7 +416,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "const" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::CONST,
                             lexeme: "const".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -340,7 +340,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 } else {
-                    return Token {
+                    Token {
                         token_type: TokenType::NOT,
                         lexeme: "!".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -234,7 +234,7 @@ impl<'a> Lexer<'a> {
 
             },
             '(' => {
-                return Token {
+                Token {
                     token_type: TokenType::LPAREN,
                     lexeme: "(".to_string(),
                     line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -348,7 +348,7 @@ impl<'a> Lexer<'a> {
                 }
             },
             '^' => {
-                return Token {
+                Token {
                     token_type: TokenType::XOR,
                     lexeme: "^".to_string(),
                     line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -209,7 +209,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 } else {
-                    return Token {
+                    Token {
                         token_type: TokenType::LCHEVR,
                         lexeme: "<".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -262,7 +262,7 @@ impl<'a> Lexer<'a> {
                 }
             },
             '[' => {
-                return Token {
+                Token {
                     token_type: TokenType::LBRACK,
                     lexeme: "[".to_string(),
                     line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -298,7 +298,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 } else {
-                    return Token {
+                    Token {
                         token_type: TokenType::BitwiseAnd,
                         lexeme: "&".to_string(),
                         line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -591,7 +591,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "i1024" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeInt(IntegerType::I1024),
                             lexeme: "i1024".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -772,7 +772,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "str" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeString,
                             lexeme: "str".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -736,7 +736,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     },
                     "f2048" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeFloat(FloatType::F2048),
                             lexeme: "f2048".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -451,7 +451,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "in" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::IN,
                             lexeme: "in".to_string(),
                             line: self.line,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -758,7 +758,7 @@ impl<'a> Lexer<'a> {
                         }
                     },
                     "f16384" => {
-                        return Token {
+                        Token {
                             token_type: TokenType::TypeFloat(FloatType::F16384),
                             lexeme: "f16384".to_string(),
                             line: self.line,


### PR DESCRIPTION
The return keyword was removed from the sector-specific code because it was not functioning as intended. This change ensures proper execution of the code without unnecessary disruptions caused by the faulty keyword.