### PR TITLE
Last Pull Request of 2024: Refactor String Handling Function to Extract Values

### DIFF
--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -395,7 +395,7 @@ impl<'a> Lexer<'a> {
                 let string_value = self.string();
                 Token {
                     token_type: TokenType::STRING(string_value.clone()),
-                    lexeme: String::new(), // Set as needed
+                    lexeme: format!("\"{}\"", string_value),
                     line: self.line,
                 }
             },

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -394,7 +394,7 @@ impl<'a> Lexer<'a> {
             '"' => {
                 let string_value = self.string();
                 Token {
-                    token_type: TokenType::STRING(self.string()),
+                    token_type: TokenType::STRING(string_value.clone()),
                     lexeme: String::new(), // Set as needed
                     line: self.line,
                 }

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -392,6 +392,7 @@ impl<'a> Lexer<'a> {
                 }
             },
             '"' => {
+                let string_value = self.string();
                 Token {
                     token_type: TokenType::STRING(self.string()),
                     lexeme: String::new(), // Set as needed


### PR DESCRIPTION
Refactored the function for extracting values inside a string. The change replaces self.string() with string_value.clone() to enhance efficiency and clarity. Additionally, the handling of string literals now includes the surrounding quotation marks ("), ensuring accurate representation of the full string.