### PR TITLE
Add Wave Version and Update CLI Description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "Wave"
-version = "0.1.0"
+version = "0.0.2-pre-alpha"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,5 @@
 version = 3
 
 [[package]]
-name = "Wave"
+name = "wave"
 version = "0.0.2-pre-alpha"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "Wave"
+name = "wave"
 version = "0.0.2-pre-alpha"
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Wave"
-version = "0.1.0"
+version = "0.0.2-pre-alpha"
 edition = "2021"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,8 @@ fn run_wave_file(file_path: &str) {
     let tokens = lexer.tokenize();
     eprintln!("Tokens: {}", format_tokens(&tokens));
 
-    let function_name = tokens.iter()
+    let function_name = tokens
+        .iter()
         .find(|token| matches!(token.token_type, TokenType::IDENTIFIER(_)))
         .map(|token| token.lexeme.clone())
         .unwrap_or_default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,10 @@ fn main() {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 2 {
-        eprintln!("Usage: {} <path_to_wave_file>", args[0]);
+        eprintln!("Usage: wave <command> [arguments]");
+        eprintln!("Commands:");
+        eprintln!("  run <file>    Execute the specified Wave file");
+        eprintln!("  --version     Show the CLI version");
         process::exit(1);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,13 +51,10 @@ fn main() {
         process::exit(1);
     }
 
-    let file_path = &args[1];
-
-    let code = match fs::read_to_string(file_path) {
-        Ok(content) => content,
-        Err(err) => {
-            eprintln!("Error reading file {}: {}", file_path, err);
-            process::exit(1);
+    match args[1].as_str() {
+        "--version" => {
+            println!("v{}", VERSION);
+            return;
         }
         "run" => {
             if args.len() < 3 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,8 @@ fn format_ast(ast: &AST) -> String {
 }
  */
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 fn main() {
     let args: Vec<String> = env::args().collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,30 @@ fn main() {
             eprintln!("Error reading file {}: {}", file_path, err);
             process::exit(1);
         }
+        "run" => {
+            if args.len() < 3 {
+                eprintln!("Usage: wave run <file>");
+                process::exit(1);
+            }
+
+            let file_path = &args[2];
+            run_wave_file(file_path);
+        }
+        _ => {
+            eprintln!("Unknown command: {}", args[1]);
+            eprintln!("Use 'wave --version' or 'wave run <file>'");
+            process::exit(1);
+        }
+    }
+}
+
+fn run_wave_file(file_path: &str) {
+    let code = match fs::read_to_string(file_path) {
+        Ok(content) => content,
+        Err(err) => {
+            eprintln!("Error reading file {}: {}", file_path, err);
+            process::exit(1);
+        }
     };
 
     let mut lexer = Lexer::new(code.as_str());


### PR DESCRIPTION
- Introduced `--version` flag in the CLI to display the current version of Wave.
- Enhanced CLI description for better user clarity.
- Changed text to lowercase where necessary for consistency.
- Updated comments to English to improve accessibility.
