### PR TITLE
Revert and Refactor: Restore Existing Code and Add Tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,8 @@ fn run_wave_file(file_path: &str) {
         .map(|token| token.lexeme.clone())
         .unwrap_or_default();
 
+    let params = extract_parameters(&tokens);
+
     let mut peekable_tokens = tokens.iter().peekable();
 
     let params = extract_parameters(&mut peekable_tokens);

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,8 +96,6 @@ fn run_wave_file(file_path: &str) {
 
     let mut peekable_tokens = tokens.iter().peekable();
 
-    let params = extract_parameters(&mut peekable_tokens);
-
     let body = extract_body(&mut peekable_tokens);
 
     let ast = function(function_name, params, body);

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -32,7 +32,7 @@ pub fn extract_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNo
                     continue;
                 };
 
-                // 타입 추출
+                // Type Extraction
                 let param_type = match tokens.next() {
                     Some(Token { token_type: TokenType::TypeInt(_), lexeme, .. }) => lexeme.clone(),
                     Some(Token { token_type: TokenType::TypeFloat(_), lexeme, .. }) => lexeme.clone(),

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -193,8 +193,6 @@ fn parse_var(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
     None
 }
 
- */
-
 // PRINTLN parsing
 fn parse_println(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
     if let Some(Token { token_type: TokenType::LPAREN, .. }) = tokens.next() {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -109,33 +109,6 @@ pub fn extract_body<'a>(tokens: &mut Peekable<Iter<'a, Token>>) -> Vec<ASTNode> 
     body
 }
 
-pub fn parse_function(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
-    let function_name = if let Some(Token { token_type: TokenType::IDENTIFIER(name), .. }) = tokens.next() {
-        name.clone()
-    } else {
-        return None;
-    };
-
-    let parameters = if let Some(Token { token_type: TokenType::LPAREN, .. }) = tokens.next() {
-        extract_parameters(tokens)
-    } else {
-        vec![]
-    };
-
-    let body = if let Some(Token { token_type: TokenType::LBRACE, .. }) = tokens.next() {
-        extract_body(tokens)
-    } else {
-        vec![]
-    };
-
-    Some(ASTNode::Function(FunctionNode {
-        name: function_name,
-        parameters,
-        body,
-    }))
-}
-
-/*
 // VAR parsing
 fn parse_var(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
     if let Some(Token { token_type: TokenType::IDENTIFIER(name), .. }) = tokens.next() {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -75,7 +75,6 @@ pub fn extract_body<'a>(tokens: &mut Peekable<Iter<'a, Token>>) -> Vec<ASTNode> 
                     body.push(ast_node);
                 }
             }
-             */
             TokenType::PRINTLN => {
                 if let Some(ast_node) = parse_println(tokens) {
                     body.push(ast_node);

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -69,7 +69,7 @@ pub fn extract_body<'a>(tokens: &mut Peekable<Iter<'a, Token>>) -> Vec<ASTNode> 
 
     while let Some(token) = tokens.next() {
         match &token.token_type {
-            /*
+            TokenType::EOF => break,
             TokenType::VAR => {
                 if let Some(ast_node) = parse_var(tokens) {
                     body.push(ast_node);

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -51,14 +51,10 @@ pub fn extract_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNo
                     None
                 };
 
-                params.push(ParameterNode {
-                    name,
-                    param_type,
-                    initial_value,
-                });
-            }
-            _ => continue,
+            params.push(ParameterNode { name, param_type, initial_value });
+            i += 6; // Move to the next token
         }
+        i += 1;
     }
 
     params

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -40,16 +40,20 @@ pub fn extract_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNo
                     _ => "unknown".to_string(),
                 };
 
-                let initial_value = if let Some(Token { token_type: TokenType::EQUAL, .. }) = tokens.peek() {
-                    tokens.next();
-                    if let Some(Token { lexeme, .. }) = tokens.next() {
-                        Some(lexeme.clone())
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
+            // parameter type
+            let param_type = if let Some(TokenType::TypeInt(_)) = tokens.get(i + 3)
+                .map(|t| &t.token_type) {
+                tokens[i + 3].lexeme.clone()
+            } else {
+                "unknown".to_string() // If you don't have type information, you don't know
+            };
+
+            let initial_value = if let Some(TokenType::EQUAL) = tokens.get(i + 4)
+                .map(|t| &t.token_type) {
+                Some(tokens[i + 5].lexeme.clone())
+            } else {
+                None
+            };
 
             params.push(ParameterNode { name, param_type, initial_value });
             i += 6; // Move to the next token

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -22,23 +22,14 @@ pub fn param(parameter: String, param_type: String, initial_value: Option<String
 pub fn extract_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode> {
     let mut params = vec![];
 
-    while let Some(token) = tokens.next() {
-        match &token.token_type {
-            TokenType::RPAREN => break,
-            TokenType::VAR => {
-                let name = if let Some(Token { token_type: TokenType::IDENTIFIER(name), .. }) = tokens.next() {
-                    name.clone()
-                } else {
-                    continue;
-                };
-
-                // Type Extraction
-                let param_type = match tokens.next() {
-                    Some(Token { token_type: TokenType::TypeInt(_), lexeme, .. }) => lexeme.clone(),
-                    Some(Token { token_type: TokenType::TypeFloat(_), lexeme, .. }) => lexeme.clone(),
-                    Some(Token { token_type: TokenType::STRING(_), lexeme, .. }) => lexeme.clone(),
-                    _ => "unknown".to_string(),
-                };
+    while i < tokens.len() {
+        if matches!(tokens[i].token_type, TokenType::VAR) {
+            // parameter name
+            let name = if let Some(TokenType::IDENTIFIER(name)) = tokens.get(i + 1).map(|t| &t.token_type) {
+                name.clone()
+            } else {
+                continue; // Skip if no name exists
+            };
 
             // parameter type
             let param_type = if let Some(TokenType::TypeInt(_)) = tokens.get(i + 3)

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -19,7 +19,7 @@ pub fn param(parameter: String, param_type: String, initial_value: Option<String
     }
 }
 
-pub fn extract_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode> {
+pub fn extract_parameters(tokens: &Vec<Token>) -> Vec<ParameterNode> {
     let mut params = vec![];
     let mut i = 0;
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -21,6 +21,7 @@ pub fn param(parameter: String, param_type: String, initial_value: Option<String
 
 pub fn extract_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode> {
     let mut params = vec![];
+    let mut i = 0;
 
     while i < tokens.len() {
         if matches!(tokens[i].token_type, TokenType::VAR) {

--- a/test/test4.wave
+++ b/test/test4.wave
@@ -1,1 +1,4 @@
-fun main(var i :i32768 = 0; var j :i4 = 2; var e :i32 = 10;) { }
+fun main(var i :i32768 = 0; var j :i4 = 2; var e :i32 = 10;) {
+    var b :i32 = 5;
+    println("Hello World");
+}


### PR DESCRIPTION
- Reverted recent changes and restored the existing parsing logic.
- Removed `parse_function` and adjusted the code to handle parameters as before.
- Replaced `Peekable` with `Vec` for the token handling.
- Added test code to validate the current functionality.
