### PR TITLE
Add Module and Class Token Support

### DIFF
--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -458,6 +458,13 @@ impl<'a> Lexer<'a> {
                             line: self.line,
                         }
                     },
+                    "module" => {
+                        Token {
+                            token_type: TokenType::Module,
+                            lexeme: "module".to_string(),
+                            line: self.line,
+                        }
+                    },
                     "in" => {
                         Token {
                             token_type: TokenType::IN,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -465,6 +465,13 @@ impl<'a> Lexer<'a> {
                             line: self.line,
                         }
                     },
+                    "class" => {
+                        Token {
+                            token_type: TokenType::Class,
+                            lexeme: "class".to_string(),
+                            line: self.line,
+                        }
+                    },
                     "in" => {
                         Token {
                             token_type: TokenType::IN,

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -116,6 +116,7 @@ pub enum TokenType {
     PRINT,
     PRINTLN,
     Module,
+    Class,
     Match,
     LogicalAnd,            // &&
     BitwiseAnd,            // &

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -115,6 +115,7 @@ pub enum TokenType {
     INPUT,
     PRINT,
     PRINTLN,
+    Module,
     Match,
     LogicalAnd,            // &&
     BitwiseAnd,            // &


### PR DESCRIPTION
- Introduced the `Module` token to support module constructs.  
- Introduced the `Class` token to handle class definitions.  
- Implemented logic to isolate the `module` keyword as a token.  
- Added functionality to separate and handle the `class` keyword as a token.  
- Merged updates into the main master branch.
