### PR TITLE
Enhance `println` Parsing Logic & Code Comments

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -259,7 +259,7 @@ fn parse_var(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
 
 // PRINTLN parsing
 fn parse_println<'a, T: Iterator<Item=&'a Token>>(tokens: &mut Peekable<T>) -> Option<ASTNode> {
-    let token = tokens.peek()?; // tokens.peek()은 Option<&Token>을 반환함
+    let token = tokens.peek()?; // talkens.peek() returns Option<&Token>
 
     if token.token_type != TokenType::PRINTLN {
         println!("Error: Expected 'println'");

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -258,13 +258,31 @@ fn parse_var(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
 }
 
 // PRINTLN parsing
-fn parse_println(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
-    if let Some(Token { token_type: TokenType::LPAREN, .. }) = tokens.next() {
-        if let Some(Token { token_type: TokenType::STRING(ref content), .. }) = tokens.next() {
-            if let Some(Token { token_type: TokenType::RPAREN, .. }) = tokens.next() {
-                return Some(ASTNode::Statement(StatementNode::Println(content.clone())));
-            }
-        }
+fn parse_println<'a, T: Iterator<Item=&'a Token>>(tokens: &mut Peekable<T>) -> Option<ASTNode> {
+    let token = tokens.peek()?; // tokens.peek()은 Option<&Token>을 반환함
+
+    if token.token_type != TokenType::PRINTLN {
+        println!("Error: Expected 'println'");
+        return None;
+    }
+    tokens.next(); // Consume PRINTLN
+
+    if tokens.peek()?.token_type != TokenType::LPAREN {
+        println!("Error: Expected '(' after 'println'");
+        return None;
+    }
+    tokens.next(); // Consume '('
+
+    let content = if let Some(Token { token_type: TokenType::STRING(content), .. }) = tokens.next() {
+        content.clone() // String이므로 clone() 필요
+    } else {
+        println!("Error: Expected string literal in 'println'");
+        return None;
+    };
+
+    if tokens.peek()?.token_type != TokenType::RPAREN {
+        println!("Error: Expected closing ')'");
+        return None;
     }
     None
 }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -284,7 +284,9 @@ fn parse_println<'a, T: Iterator<Item=&'a Token>>(tokens: &mut Peekable<T>) -> O
         println!("Error: Expected closing ')'");
         return None;
     }
-    None
+    tokens.next(); // Consume ')'
+
+    Some(ASTNode::Statement(StatementNode::Println(content)))
 }
 
 // PRINT parsing

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -274,7 +274,7 @@ fn parse_println<'a, T: Iterator<Item=&'a Token>>(tokens: &mut Peekable<T>) -> O
     tokens.next(); // Consume '('
 
     let content = if let Some(Token { token_type: TokenType::STRING(content), .. }) = tokens.next() {
-        content.clone() // String이므로 clone() 필요
+        content.clone() // Need clone() because it is String
     } else {
         println!("Error: Expected string literal in 'println'");
         return None;


### PR DESCRIPTION
### 🚀 **Purpose and Functionality of Changes:**  
This pull request improves the parsing logic for `println` function calls and enhances the clarity of the codebase by adding English comments. The key modifications include:  

- **Improved Parsing for `println` Calls**:  
  - Adjustments were made to ensure correct parsing of `println()` during variable initialization.  
  - Edge cases related to parsing the closing parenthesis `)` were refined for better accuracy.  

- **English Comments for Code Clarity**:  
  - Added and refined English comments throughout the parsing logic to improve readability and maintainability.  

---

### 🛠️ **Programming Language Used:**  
- **Rust**: The core implementation of Wave continues to be developed in Rust, ensuring performance and memory safety.  

---

### 📚 **Libraries Used:**  
- **None**

---

### 🏗️ **Frameworks Used:**  
- **Wave**: The internal parsing system of Wave has been enhanced with these updates.  

---

### 💡 **Technologies or Methodologies Applied:**  
- **Parsing Optimization**: Adjusted handling of function call syntax, specifically improving robustness around `println()`.  
- **Syntax Consistency**: Ensured that `println` parsing adheres to the same standards as other function calls.  
- **Improved Code Readability**: Introduced English comments to make the parsing logic easier to understand for future contributors.  

---

### 🎯 **Impact of the Change:**  
- **More Reliable Function Parsing**: Prevents potential misinterpretations of `println()` syntax.  
- **Better Documentation**: English comments make the codebase easier to navigate.  
- **Improved Debugging**: Clearer parsing logic simplifies the identification of syntax errors.  

---

### 🔧 **How to Test:**  
1. Write a `println()` statement inside a variable initialization and ensure correct parsing.  
2. Verify that parsing works with different function call formats.  
3. Review added comments for clarity and correctness.  

---