### PR TITLE
Implement Conditional Branching with Comparison Operators and Enhance Debugging

### DIFF
--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -353,6 +353,15 @@ fn generate_expression_ir<'a>(
                 Operator::NotEqual => builder
                     .build_int_compare(inkwell::IntPredicate::NE, left_val, right_val, "cmptmp")
                     .unwrap(),
+
+                Operator::GreaterEqual => builder
+                    .build_int_compare(inkwell::IntPredicate::SGE, left_val, right_val, "cmptmp")
+                    .unwrap(),
+                Operator::LessEqual => builder
+                    .build_int_compare(inkwell::IntPredicate::SLE, left_val, right_val, "cmptmp")
+                    .unwrap(),
+
+
                 _ => panic!("Unsupported binary operator in generate_expression_ir"),
             }
         }

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -166,7 +166,15 @@ pub unsafe fn generate_ir(ast: &ASTNode) -> String {
                     if let Some(else_ifs) = else_if_blocks {
                         for else_if in else_ifs.iter() {
                             if let ASTNode::Statement(StatementNode::If { condition, body, .. }) = else_if {
-                                let cond_val = generate_expression_ir(&context, &builder, condition, &mut variables);
+                                let cond_val_raw = generate_expression_ir(&context, &builder, condition, &mut variables);
+                                let zero = cond_val_raw.get_type().const_zero();
+                                let cond_val = builder.build_int_compare(
+                                    inkwell::IntPredicate::NE,
+                                    cond_val_raw,
+                                    zero,
+                                    "else_if_cmp"
+                                ).unwrap();
+
                                 let block = context.append_basic_block(function, "else_if_then");
                                 blocks.push((cond_val, block, body));
                             }

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -152,6 +152,13 @@ pub unsafe fn generate_ir(ast: &ASTNode) -> String {
 
                     // if 본문
                     let condition_value = generate_expression_ir(&context, &builder, condition, &mut variables);
+                    let zero = condition_value.get_type().const_zero();
+                    let condition_bool = builder.build_int_compare(
+                        inkwell::IntPredicate::NE,
+                        condition_value,
+                        zero,
+                        "condition_cmp"
+                    ).unwrap();
                     let then_block = context.append_basic_block(function, "if_then");
                     blocks.push((condition_value, then_block, body));
 

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -192,7 +192,7 @@ pub unsafe fn generate_ir(ast: &ASTNode) -> String {
 
                     // Create a branch
                     for (i, (cond_value, then_block, body)) in blocks.iter().enumerate() {
-                        let current_block = builder.get_insert_block().unwrap();
+                        // Create a conditional branch at the current location
                         let next_cond_block = if i + 1 < blocks.len() {
                             context.append_basic_block(function, &format!("cond_{}", i + 1))
                         } else if let Some((else_block, _)) = &else_block_ir {

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -203,7 +203,7 @@ pub unsafe fn generate_ir(ast: &ASTNode) -> String {
 
                         builder.build_conditional_branch(*cond_value, *then_block, next_cond_block);
 
-                        // then block code
+                        // Run then block
                         builder.position_at_end(*then_block);
                         for stmt in *body {
                             generate_statement_ir(&context, &builder, stmt, &mut variables);

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -220,7 +220,7 @@ pub unsafe fn generate_ir(ast: &ASTNode) -> String {
                         builder.build_unconditional_branch(merge_block);
                     }
 
-                    // 마지막 merge 블록 위치
+                    // Move position to merge block at the end
                     builder.position_at_end(merge_block);
                 }
                 ASTNode::Statement(StatementNode::While { condition, body }) => {

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -209,8 +209,6 @@ pub unsafe fn generate_ir(ast: &ASTNode) -> String {
                             generate_statement_ir(&context, &builder, stmt, &mut variables);
                         }
                         builder.build_unconditional_branch(merge_block);
-
-                        builder.position_at_end(next_cond_block);
                     }
 
                     // else block

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -160,7 +160,7 @@ pub unsafe fn generate_ir(ast: &ASTNode) -> String {
                         "condition_cmp"
                     ).unwrap();
                     let then_block = context.append_basic_block(function, "if_then");
-                    blocks.push((condition_value, then_block, body));
+                    blocks.push((condition_bool, then_block, body));
 
                     // else if Blocks (Option<Box<Vec<ASTNode>>>)
                     if let Some(else_ifs) = else_if_blocks {

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -323,6 +323,22 @@ fn generate_expression_ir<'a>(
                 Operator::Subtract => builder.build_int_sub(left_val, right_val, "subtmp").unwrap(),
                 Operator::Multiply => builder.build_int_mul(left_val, right_val, "multmp").unwrap(),
                 Operator::Divide => builder.build_int_signed_div(left_val, right_val, "divtmp").unwrap(),
+
+                Operator::Greater => builder
+                    .build_int_compare(inkwell::IntPredicate::SGT, left_val, right_val, "cmptmp")
+                    .unwrap(),
+
+                Operator::Less => builder
+                    .build_int_compare(inkwell::IntPredicate::SLT, left_val, right_val, "cmptmp")
+                    .unwrap(),
+
+                Operator::Equal => builder
+                    .build_int_compare(inkwell::IntPredicate::EQ, left_val, right_val, "cmptmp")
+                    .unwrap(),
+
+                Operator::NotEqual => builder
+                    .build_int_compare(inkwell::IntPredicate::NE, left_val, right_val, "cmptmp")
+                    .unwrap(),
                 _ => panic!("Unsupported binary operator in generate_expression_ir"),
             }
         }

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -213,6 +213,7 @@ pub unsafe fn generate_ir(ast: &ASTNode) -> String {
 
                     // else block
                     if let Some((else_block, else_body)) = else_block_ir {
+                        builder.position_at_end(else_block);
                         for stmt in else_body.iter() {
                             generate_statement_ir(&context, &builder, stmt, &mut variables);
                         }

--- a/src/parser/format.rs
+++ b/src/parser/format.rs
@@ -85,6 +85,7 @@ where
                     TokenType::Rchevr => Operator::Greater,
                     TokenType::RchevrEq => Operator::GreaterEqual,
                     TokenType::Lchevr => Operator::Less,
+                    TokenType::LchevrEq => Operator::LessEqual,
                     _ => unreachable!(),
                 };
                 tokens.next();

--- a/src/parser/format.rs
+++ b/src/parser/format.rs
@@ -35,7 +35,8 @@ pub fn parse_expression<'a, T>(tokens: &mut Peekable<T>) -> Option<Expression>
 where
     T: Iterator<Item = &'a Token>,
 {
-    parse_logical_expression(tokens)
+    let expr = parse_logical_expression(tokens)?;
+    Some(expr)
 }
 
 pub fn parse_logical_expression<'a, T>(tokens: &mut Peekable<T>) -> Option<Expression>

--- a/src/parser/format.rs
+++ b/src/parser/format.rs
@@ -83,6 +83,7 @@ where
                     TokenType::EqualTwo => Operator::Equal,
                     TokenType::NotEqual => Operator::NotEqual,
                     TokenType::Rchevr => Operator::Greater,
+                    TokenType::RchevrEq => Operator::GreaterEqual,
                     TokenType::Lchevr => Operator::Less,
                     _ => unreachable!(),
                 };

--- a/src/parser/format.rs
+++ b/src/parser/format.rs
@@ -78,7 +78,9 @@ where
             TokenType::EqualTwo |
             TokenType::NotEqual |
             TokenType::Rchevr |
-            TokenType::Lchevr => {
+            TokenType::RchevrEq |
+            TokenType::Lchevr |
+            TokenType::LchevrEq => {
                 let op = match token.token_type {
                     TokenType::EqualTwo => Operator::Equal,
                     TokenType::NotEqual => Operator::NotEqual,

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -423,7 +423,6 @@ fn parse_if(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
             return None;
         }
         tokens.next(); // Consume '{'
-
         else_block = Some(Box::new(parse_block(tokens)?));
         break;
     }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -395,7 +395,11 @@ fn parse_if(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
 
     let body = parse_block(tokens)?;
 
-    let mut else_if_blocks = Vec::new();
+    for (i, node) in body.iter().enumerate() {
+        println!("👀 BODY NODE [{}]: {:#?}", i, node);
+    }
+
+    let mut else_if_blocks: Vec<ASTNode> = Vec::new();
     let mut else_block = None;
 
     while let Some(token) = tokens.peek() {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -418,8 +418,13 @@ fn parse_if(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
                     println!("❗ else-if is not statementNode::If: {:#?}", other);
                     return None;
                 }
-                continue;
+                None => {
+                    println!("❌ else-if Failed to parse!");
+                    return None;
+                }
             }
+
+            continue;
         }
 
         // Handle 'else' case

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -404,13 +404,18 @@ fn parse_if(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         }
         tokens.next(); // Consume 'else'
 
-        // Check for 'else if'
-        if let Some(next_token) = tokens.peek() {
-            if next_token.token_type == TokenType::If {
-                skip_whitespace(tokens);
-                if let Some(else_if_node) = parse_if(tokens) {
-                    else_if_blocks.push(else_if_node);
-                } else {
+        // Check if it comes right after else
+        if let Some(Token { token_type: TokenType::If, .. }) = tokens.peek() {
+            println!("🔍 else if Detected!");
+            let parsed = parse_if(tokens);
+
+            match parsed {
+                Some(ASTNode::Statement(stmt @ StatementNode::If { .. })) => {
+                    println!("✅ Create else-if AST successful");
+                    else_if_blocks.push(ASTNode::Statement(stmt));
+                }
+                Some(other) => {
+                    println!("❗ else-if is not statementNode::If: {:#?}", other);
                     return None;
                 }
                 continue;

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -14,8 +14,8 @@ pub fn function(function_name: String, parameters: Vec<ParameterNode>, body: Vec
     println!("🚨 function() called with {} body items", body.len());
     ASTNode::Function(FunctionNode {
         name: function_name,
-        parameters, // No parameters
-        body,       // Empty body
+        parameters,
+        body,
     })
 }
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -492,11 +492,10 @@ fn parse_block(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> {
     if let Some(Token { token_type: TokenType::Lbrace, .. }) = tokens.next() {
         let mut body = vec![];
 
-        while let Some(token) = tokens.peek() {
-            if token.token_type == TokenType::Rbrace {
-                tokens.next(); // Consume '}'
-                break;
-            }
+    while let Some(token) = tokens.next() {
+        if token.token_type == TokenType::Rbrace {
+            break;
+        }
 
         let node = match token.token_type {
             TokenType::Var => parse_var(tokens),

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -432,7 +432,11 @@ fn parse_if(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
     Some(ASTNode::Statement(StatementNode::If {
         condition,
         body,
-        else_if_blocks: if else_if_blocks.is_empty() { None } else { Some(Box::new(else_if_blocks)) },
+        else_if_blocks: if else_if_blocks.is_empty() {
+            None
+        } else {
+            Some(Box::new(else_if_blocks))
+        },
         else_block,
     });
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -498,13 +498,29 @@ fn parse_block(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> {
                 break;
             }
 
-            body.extend(extract_body(tokens));
-        }
+        let node = match token.token_type {
+            TokenType::Var => parse_var(tokens),
+            TokenType::Println => parse_println(tokens),
+            TokenType::Print => parse_print(tokens),
+            TokenType::If => {
+                println!("🔥 Entering TokenType:::If branch from pas_block!");
+                parse_if(tokens)
+            },
+            TokenType::For => parse_for(tokens),
+            TokenType::While => parse_while(tokens),
+            _ => {
+                println!("⚠️ Unrecognized token in block: {:?}", token.token_type);
+                None
+            }
+        };
 
-        Some(body)
-    } else {
-        None
+        if let Some(ast_node) = node {
+            println!("📦 parse_block() -> ASTNode Insertion: {:#?}", ast_node);
+            body.push(ast_node);
+        }
     }
+
+    Some(body)
 }
 
 pub fn parse_type(type_str: &str) -> Option<TokenType> {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -378,7 +378,17 @@ fn parse_if(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
 
     println!("🧪 parse_if() Start");
 
-    // Expect ')' after condition
+    let condition = match parse_expression(tokens) {
+        Some(expr) => {
+            println!("🎯 condition parsing successful: {:#?}", expr);
+            expr
+        }
+        None => {
+            println!("❌ condition parsing failed!");
+            return None;
+        }
+    };
+
     if tokens.peek()?.token_type != TokenType::Rparen {
         println!("Error: Expected ')' after 'if' condition");
         return None;

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -11,6 +11,7 @@ pub fn parse(tokens: &[Token]) -> Option<ASTNode> {
 }
 
 pub fn function(function_name: String, parameters: Vec<ParameterNode>, body: Vec<ASTNode>) -> ASTNode {
+    println!("🚨 function() called with {} body items", body.len());
     ASTNode::Function(FunctionNode {
         name: function_name,
         parameters, // No parameters

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -434,7 +434,11 @@ fn parse_if(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         body,
         else_if_blocks: if else_if_blocks.is_empty() { None } else { Some(Box::new(else_if_blocks)) },
         else_block,
-    }))
+    });
+
+    println!("✅ AST IF NODE: {:#?}", result);
+    println!("✅ parse_if() -> ASTNode Return: {:#?}", result);
+    Some(result)
 }
 
 // FOR parsing

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -428,8 +428,7 @@ fn parse_if(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         break;
     }
 
-    // Confirm 'if' block exit
-    Some(ASTNode::Statement(StatementNode::If {
+    let result = ASTNode::Statement(StatementNode::If {
         condition,
         body,
         else_if_blocks: if else_if_blocks.is_empty() {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -367,9 +367,6 @@ fn skip_whitespace(tokens: &mut Peekable<Iter<Token>>) {
 
 // IF parsing
 fn parse_if(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
-    skip_whitespace(tokens);
-
-    // Expect '(' after 'if'
     if tokens.peek()?.token_type != TokenType::Lparen {
         println!("Error: Expected '(' after 'if'");
         return None;

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -489,8 +489,8 @@ fn parse_while(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
 
 // block parsing
 fn parse_block(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> {
-    if let Some(Token { token_type: TokenType::Lbrace, .. }) = tokens.next() {
-        let mut body = vec![];
+    println!("🌲 Entering parse_block()");
+    let mut body = vec![];
 
     while let Some(token) = tokens.next() {
         if token.token_type == TokenType::Rbrace {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -376,8 +376,7 @@ fn parse_if(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
     }
     tokens.next(); // Consume '('
 
-    // Parse condition
-    let condition = parse_expression(tokens)?;
+    println!("🧪 parse_if() Start");
 
     // Expect ')' after condition
     if tokens.peek()?.token_type != TokenType::Rparen {

--- a/test/test7.wave
+++ b/test/test7.wave
@@ -1,10 +1,19 @@
 fun main() {
     var a :i32 = 32;
-    println("{}", a);
+    var b :i32 = 20;
 
     if (a > 30) {
-        println("a is greater than 30");
+        println("a({}) is greater than 30", a);
     } else {
-        println("a is less than or equal to 30");
+        println("a({}) is less than or equal to 30", a);
     }
+
+    if (b < a) {
+        println("b({}) is less than a({})", b, a);
+    } else if (b == a) {
+        println("b({}) is equal to a({})", b, a);
+    } else {
+        println("b({}) is greater than a({})", b, a);
+    }
+
 }


### PR DESCRIPTION
This PR introduces conditional branching functionality and improves comparison operator handling in the IR generation phase using `build_int_compare()`.

### Changes
- ✅ Added support for comparison operators: `==`, `!=`, `<`, `>`, `<=`, `>=`
- 🧠 Changed comparison result type to `i1` to align with LLVM expectations
- 🔧 Refactored `value` to `bool` in relevant logic
- 🧱 Implemented conditional branch generation:
  - Created `then`, `else`, and merge blocks
  - Managed builder position transitions for proper control flow
- 🧩 Extended condition parsing function to support complex/nested conditions
- 🧹 Removed `skip_whitespace()` where redundant
- 🧪 Added test case: `test7.wave`
- 🧪 Added new function: `run_wave_file()`
- 🐛 Multiple debugging improvements for better traceability
- 🔄 Minor refactors and structural adjustments to parcel blocks

### Notes
This is a foundational step toward full `if-else` support in the Wave compiler. The logic now correctly generates conditional IR and sets the groundwork for upcoming loop support.