### PR TITLE
v0.0.6-pre-beta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,10 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "wave"
-version = "0.0.5-pre-beta"
+version = "0.0.6-pre-beta"
 dependencies = [
  "colorex",
  "inkwell",
  "llvm-sys",
+ "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wave"
-version = "0.0.5-pre-beta"
+version = "0.0.6-pre-beta"
 edition = "2021"
 
 # [target.x86_64-apple-darwin]
@@ -12,3 +12,4 @@ edition = "2021"
 colorex = "0.1.0"
 inkwell = { version = "0.5.0", features = ["llvm14-0"] }
 llvm-sys = { version = "140.1.3", features = ["no-llvm-linking"] }
+regex = "1.11.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,1 +1,60 @@
-// error.rs
+#[derive(Debug)]
+pub enum WaveErrorKind {
+    UnexpectedToken(String),
+    ExpectedToken(String),
+    UnexpectedChar(char),
+    SyntaxError(String),
+}
+
+#[derive(Debug)]
+pub struct WaveError {
+    pub kind: WaveErrorKind,
+    pub message: String,
+    pub file: String,
+    pub line: usize,
+    pub column: usize,
+    pub source: Option<String>,
+    pub label: Option<String>,
+}
+
+impl WaveError {
+    pub fn new(kind: WaveErrorKind, message: impl Into<String>, file: impl Into<String>, line: usize, column: usize) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            file: file.into(),
+            line,
+            column,
+            source: None,
+            label: None,
+        }
+    }
+
+    pub fn with_source(mut self, source: impl Into<String>) -> Self {
+        self.source = Some(source.into());
+        self
+    }
+
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    pub fn display(&self) {
+        eprintln!("error: {}", self.message);
+        eprintln!("  --> {}:{}:{}", self.file, self.line, self.column);
+        eprintln!("   |");
+
+        if let Some(source_line) = &self.source {
+            eprintln!("{:>3} | {}", self.line, source_line);
+            let arrow_line = format!("{:>3} | {:>width$}^", "", "", width = self.column - 1);
+            if let Some(label) = &self.label {
+                eprintln!("   | {} {}", &arrow_line[6..], label);
+            } else {
+                eprintln!("   | {}", &arrow_line[6..]);
+            }
+        } else {
+            eprintln!("   | (source unavailable)");
+        }
+    }
+}

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -103,6 +103,12 @@ impl<'a> Lexer<'a> {
         tokens
     }
 
+    fn skip_comment(&mut self) {
+        while !self.is_at_end() && self.peek() != '\n' {
+            self.advance();
+        }
+    }
+
     /*
     pub fn consume(&mut self) {
         if let Some(current_char) = self.source.chars().nth(self.current) {

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -111,7 +111,7 @@ impl<'a> Lexer<'a> {
 
     fn skip_multiline_comment(&mut self) {
         while !self.is_at_end() {
-            if self.peek() != '*' && self.peek() != '/' {
+            if self.peek() == '*' && self.peek_next() == '/' {
                 self.advance();
                 self.advance();
                 break;

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -192,6 +192,12 @@ impl<'a> Lexer<'a> {
                         lexeme: "--".to_string(),
                         line: self.line,
                     }
+                } else if self.match_next('>') {
+                    Token {
+                        token_type: TokenType::Arrow,
+                        lexeme: "->".to_string(),
+                        line: self.line,
+                    }
                 } else {
                     Token {
                         token_type: TokenType::Minus,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -109,6 +109,26 @@ impl<'a> Lexer<'a> {
         }
     }
 
+    fn skip_multiline_comment(&mut self) {
+        while !self.is_at_end() {
+            if self.peek() != '*' && self.peek() != '/' {
+                self.advance();
+                self.advance();
+                break;
+            }
+
+            if self.peek() == '\n' {
+                self.line += 1;
+            }
+
+            self.advance();
+        }
+
+        if self.is_at_end() {
+            panic!("Unterminated block comment");
+        }
+    }
+
     /*
     pub fn consume(&mut self) {
         if let Some(current_char) = self.source.chars().nth(self.current) {

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -218,6 +218,9 @@ impl<'a> Lexer<'a> {
                 if self.match_next('/') {
                     self.skip_comment();
                     self.next_token()
+                } else if self.match_next('*') {
+                    self.skip_multiline_comment();
+                    self.next_token()
                 } else {
                     Token {
                         token_type: TokenType::Div,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -181,10 +181,15 @@ impl<'a> Lexer<'a> {
                 }
             },
             '/' => {
-                Token {
-                    token_type: TokenType::Div,
-                    lexeme: "/".to_string(),
-                    line: self.line,
+                if self.match_next('/') {
+                    self.skip_comment();
+                    self.next_token()
+                } else {
+                    Token {
+                        token_type: TokenType::Div,
+                        lexeme: "/".to_string(),
+                        line: self.line,
+                    }
                 }
             },
             ';' => {

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -129,6 +129,14 @@ impl<'a> Lexer<'a> {
         }
     }
 
+    fn peek_next(&self) -> char {
+        if self.current + 1 >= self.source.len() {
+            '\0'
+        } else {
+            self.source.chars().nth(self.current + 1).unwrap_or('\0')
+        }
+    }
+
     /*
     pub fn consume(&mut self) {
         if let Some(current_char) = self.source.chars().nth(self.current) {

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -151,4 +151,5 @@ pub enum TokenType {
     Error,
     Whitespace,
     Break,
+    Arrow,                  // ->
 }

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -120,7 +120,7 @@ pub enum TokenType {
     TypeByte,
     TypeString,
     TypePointer(Box<TokenType>),
-    TypeArray(Box<TokenType>, usize),
+    TypeArray(Box<TokenType>, u32),
     Identifier(String),
     String(String),
     Number(i64),

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -120,7 +120,7 @@ pub enum TokenType {
     TypeByte,
     TypeString,
     TypePointer(Box<TokenType>),
-    TypeArray(Box<TokenType>, u32),
+    TypeArray(Box<TokenType>, usize),
     Identifier(String),
     String(String),
     Number(i64),

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -84,7 +84,7 @@ fn generate_expression_ir<'ctx>(
     builder: &'ctx inkwell::builder::Builder<'ctx>,
     expr: &Expression,
     variables: &mut HashMap<String, PointerValue<'ctx>>,
-) -> inkwell::values::IntValue<'ctx> {
+) -> BasicValueEnum<'ctx> {
     match expr {
         Expression::Literal(lit) => match lit {
             Literal::Number(value) => {

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -5,7 +5,7 @@ use inkwell::values::{PointerValue, FunctionValue, BasicValue, BasicValueEnum};
 use inkwell::{AddressSpace, FloatPredicate};
 
 use std::collections::HashMap;
-use inkwell::types::{BasicType, BasicTypeEnum};
+use inkwell::types::{BasicMetadataTypeEnum, BasicType, BasicTypeEnum};
 use crate::lexer::TokenType;
 
 pub unsafe fn generate_ir(ast: &ASTNode) -> String {

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use inkwell::types::{BasicMetadataTypeEnum, BasicType, BasicTypeEnum};
 use crate::lexer::TokenType;
 
-pub unsafe fn generate_ir(ast: &ASTNode) -> String {
+pub unsafe fn generate_ir(ast_nodes: &[ASTNode]) -> String {
     let context = Context::create();
 
     let ir = {

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -1,4 +1,4 @@
-use crate::parser::ast::{ASTNode, FunctionNode, StatementNode, Expression, VariableNode, Literal, Operator, WaveType};
+use crate::parser::ast::{ASTNode, FunctionNode, StatementNode, Expression, VariableNode, Literal, Operator, WaveType, Value};
 use inkwell::context::Context;
 use inkwell::module::Linkage;
 use inkwell::values::{PointerValue, FunctionValue, BasicValue, BasicValueEnum};

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -170,7 +170,7 @@ fn generate_expression_ir<'ctx>(
             // 리턴 타입이 있을 경우만 사용
             match function.get_type().get_return_type() {
                 Some(_) => call_site.try_as_basic_value().left().unwrap(),
-                None => context.i32_type().const_zero().as_basic_value_enum(), // void 처리용
+                None => context.i32_type().const_zero().as_basic_value_enum(),
             }
         }
 

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -17,7 +17,7 @@ pub unsafe fn generate_ir(ast: &ASTNode) -> String {
 
         let mut variables: HashMap<String, PointerValue> = HashMap::new();
 
-        if let ASTNode::Function(FunctionNode { name, parameters: _, body }) = ast {
+        if let ASTNode::Function(FunctionNode { name, parameters, body }) = ast {
             // Create function type (void -> void)
             let fn_type = context.void_type().fn_type(&[], false);
             let function = module.add_function(name, fn_type, None);

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -49,8 +49,8 @@ pub unsafe fn generate_ir(ast_nodes: &[ASTNode]) -> String {
                     let llvm_param = function.get_nth_param(i as u32).unwrap();
                     builder.build_store(alloca, llvm_param).unwrap();
 
-                variables.insert(param.name.clone(), alloca);
-            }
+                    variables.insert(param.name.clone(), alloca);
+                }
 
             for stmt in body {
                 generate_statement_ir(

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -253,14 +253,14 @@ fn generate_statement_ir<'ctx>(
             let else_block_bb = context.append_basic_block(current_fn, "else");
             let merge_block = context.append_basic_block(current_fn, "merge");
 
-            builder.build_conditional_branch(cond_value, then_block, else_block_bb);
+            let _ = builder.build_conditional_branch(cond_value, then_block, else_block_bb);
 
             // then
             builder.position_at_end(then_block);
             for stmt in body {
                 generate_statement_ir(context, builder, module, string_counter, stmt, variables, loop_exit_stack);
             }
-            builder.build_unconditional_branch(merge_block);
+            let _ = builder.build_unconditional_branch(merge_block);
 
             // else
             builder.position_at_end(else_block_bb);
@@ -277,7 +277,7 @@ fn generate_statement_ir<'ctx>(
                 }
             }
 
-            builder.build_unconditional_branch(merge_block);
+            let _ = builder.build_unconditional_branch(merge_block);
             builder.position_at_end(merge_block);
         }
         ASTNode::Statement(StatementNode::While { condition, body }) => {
@@ -287,9 +287,9 @@ fn generate_statement_ir<'ctx>(
             let body_block = context.append_basic_block(current_fn, "while.body");
             let merge_block = context.append_basic_block(current_fn, "while.end");
 
-            loop_exit_stack.push(merge_block); // 👈 루프 끝 블록을 푸시
+            loop_exit_stack.push(merge_block);
 
-            builder.build_unconditional_branch(cond_block);
+            let _ = builder.build_unconditional_branch(cond_block);
             builder.position_at_end(cond_block);
 
             let cond_val = generate_expression_ir(context, builder, condition, variables);
@@ -301,13 +301,13 @@ fn generate_statement_ir<'ctx>(
                 "while_cond",
             ).unwrap();
 
-            builder.build_conditional_branch(cond_bool, body_block, merge_block);
+            let _ = builder.build_conditional_branch(cond_bool, body_block, merge_block);
 
             builder.position_at_end(body_block);
             for stmt in body.iter() {
                 generate_statement_ir(context, builder, module, string_counter, stmt, variables, loop_exit_stack);
             }
-            builder.build_unconditional_branch(cond_block);
+            let _ = builder.build_unconditional_branch(cond_block);
 
             loop_exit_stack.pop();
 
@@ -323,7 +323,7 @@ fn generate_statement_ir<'ctx>(
         }
         ASTNode::Statement(StatementNode::Break) => {
             if let Some(target_block) = loop_exit_stack.last() {
-                builder.build_unconditional_branch(*target_block);
+                let _ = builder.build_unconditional_branch(*target_block);
             } else {
                 panic!("break used outside of loop!");
             }

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -1,4 +1,4 @@
-use crate::parser::ast::{ASTNode, FunctionNode, StatementNode, Expression, VariableNode, Literal, Operator};
+use crate::parser::ast::{ASTNode, FunctionNode, StatementNode, Expression, VariableNode, Literal, Operator, WaveType};
 use inkwell::context::Context;
 use inkwell::module::Linkage;
 use inkwell::values::{PointerValue, FunctionValue, BasicValue, BasicValueEnum};

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -52,17 +52,24 @@ pub unsafe fn generate_ir(ast_nodes: &[ASTNode]) -> String {
                     variables.insert(param.name.clone(), alloca);
                 }
 
-            for stmt in body {
-                generate_statement_ir(
-                    &context,
-                    &builder,
-                    module,
-                    &mut string_counter,
-                    stmt,
-                    &mut variables,
-                    &mut loop_exit_stack,
-                );
-            }
+                let is_void_fn = return_type.is_none();
+
+                let mut did_return = false;
+                for stmt in body {
+                    if let ASTNode::Statement(StatementNode::Return(_)) = stmt {
+                        did_return = true;
+                    }
+
+                    generate_statement_ir(
+                        &context,
+                        &builder,
+                        &module,
+                        &mut string_counter,
+                        stmt,
+                        &mut variables,
+                        &mut loop_exit_stack,
+                    );
+                }
 
             // Add void return
             let _ = builder.build_return(None);

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -16,7 +16,6 @@ pub unsafe fn generate_ir(ast: &ASTNode) -> String {
         let builder = Box::leak(Box::new(context.create_builder()));
 
         let mut variables: HashMap<String, PointerValue> = HashMap::new();
-        let mut string_counter = 0;
 
         if let ASTNode::Function(FunctionNode { name, parameters: _, body }) = ast {
             // Create function type (void -> void)

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -51,7 +51,7 @@ pub unsafe fn generate_ir(ast: &ASTNode) -> String {
     ir
 }
 
-fn wave_format_to_c(format: &str) -> String {
+fn wave_format_to_c(format: &str, arg_types: &[BasicTypeEnum]) -> String {
     let mut result = String::new();
     let mut chars = format.chars().peekable();
 

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -472,6 +472,9 @@ fn generate_statement_ir<'ctx>(
 
             builder.position_at_end(merge_block);
         }
+        ASTNode::Statement(StatementNode::Expression(expr)) => {
+            let _ = generate_expression_ir(context, builder, expr, variables, module);
+        }
         ASTNode::Statement(StatementNode::Assign { variable, value }) => {
             let val = generate_expression_ir(context, builder, value, variables);
             if let Some(ptr) = variables.get(variable) {

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -1,8 +1,8 @@
 use crate::parser::ast::{ASTNode, FunctionNode, StatementNode, Expression, VariableNode, Literal, Operator};
 use inkwell::context::Context;
 use inkwell::module::Linkage;
-use inkwell::values::{PointerValue, FunctionValue};
-use inkwell::AddressSpace;
+use inkwell::values::{PointerValue, FunctionValue, BasicValue, BasicValueEnum};
+use inkwell::{AddressSpace, FloatPredicate};
 
 use std::collections::HashMap;
 use inkwell::types::{BasicType, BasicTypeEnum};

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -32,7 +32,7 @@ pub unsafe fn generate_ir(ast: &ASTNode) -> String {
             for param in parameters {
                 let llvm_type = wave_type_to_llvm_type(&context, &param.param_type);
                 let alloca = builder.build_alloca(llvm_type, &param.name).unwrap();
-                
+
                 if let Some(init) = &param.initial_value {
                     match (init, llvm_type) {
                         (Value::Int(value), BasicTypeEnum::IntType(int_type)) => {

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -214,7 +214,12 @@ fn generate_statement_ir<'ctx>(
         }
         ASTNode::Statement(StatementNode::PrintlnFormat { format, args }) |
         ASTNode::Statement(StatementNode::PrintFormat { format, args }) => {
-            let c_format_string = wave_format_to_c(&format);
+            let mut arg_types = vec![];
+            for arg in args {
+                let val = generate_expression_ir(context, builder, arg, variables);
+                arg_types.push(val.get_type());
+            }
+            let c_format_string = wave_format_to_c(&format, &arg_types);
 
             let global_name = format!("str_{}", *string_counter);
             *string_counter += 1;

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -35,9 +35,8 @@ pub unsafe fn generate_ir(ast_nodes: &[ASTNode]) -> String {
                 };
                 let function = module.add_function(name, fn_type, None);
 
-            // Create entry block
-            let entry_block = context.append_basic_block(function, "entry");
-            builder.position_at_end(entry_block);
+                let entry_block = context.append_basic_block(function, "entry");
+                builder.position_at_end(entry_block);
 
             let mut string_counter = 0;
             let mut loop_exit_stack = vec![];

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -7,7 +7,6 @@ use inkwell::{AddressSpace, FloatPredicate};
 use std::collections::HashMap;
 use inkwell::types::{BasicType, BasicTypeEnum};
 use crate::lexer::TokenType;
-use crate::parser::parse_type;
 
 pub unsafe fn generate_ir(ast: &ASTNode) -> String {
     let context = Context::create();

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -138,15 +138,7 @@ fn generate_expression_ir<'ctx>(
                     }
                 }
 
-                Operator::GreaterEqual => builder
-                    .build_int_compare(inkwell::IntPredicate::SGE, left_val, right_val, "cmptmp")
-                    .unwrap(),
-                Operator::LessEqual => builder
-                    .build_int_compare(inkwell::IntPredicate::SLE, left_val, right_val, "cmptmp")
-                    .unwrap(),
-
-
-                _ => panic!("Unsupported binary operator in generate_expression_ir"),
+                _ => panic!("Type mismatch in binary expression"),
             }
         }
 

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -281,7 +281,7 @@ fn generate_statement_ir<'ctx>(
             let else_block_bb = context.append_basic_block(current_fn, "else");
             let merge_block = context.append_basic_block(current_fn, "merge");
 
-            let _ = builder.build_conditional_branch(cond_value, then_block, else_block_bb);
+            let _ = builder.build_conditional_branch(cond_value.try_into().unwrap(), then_block, else_block_bb);
 
             // then
             builder.position_at_end(then_block);

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -38,8 +38,9 @@ pub unsafe fn generate_ir(ast_nodes: &[ASTNode]) -> String {
                 let entry_block = context.append_basic_block(function, "entry");
                 builder.position_at_end(entry_block);
 
-            let mut string_counter = 0;
-            let mut loop_exit_stack = vec![];
+                let mut variables: HashMap<String, PointerValue> = HashMap::new();
+                let mut string_counter = 0;
+                let mut loop_exit_stack = vec![];
 
                 for (i, param) in parameters.iter().enumerate() {
                     let llvm_type = wave_type_to_llvm_type(&context, &param.param_type);

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -71,9 +71,12 @@ pub unsafe fn generate_ir(ast_nodes: &[ASTNode]) -> String {
                     );
                 }
 
-            // Add void return
-            let _ = builder.build_return(None);
+                if !did_return && is_void_fn {
+                    let _ = builder.build_return(None);
+                }
+            }
         }
+
         module.print_to_string().to_string()
     };
     ir

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -76,9 +76,15 @@ fn generate_expression_ir<'ctx>(
     variables: &mut HashMap<String, PointerValue<'ctx>>,
 ) -> inkwell::values::IntValue<'ctx> {
     match expr {
-        Expression::Literal(Literal::Number(value)) => {
-            context.i32_type().const_int(*value as u64, false)
-        }
+        Expression::Literal(lit) => match lit {
+            Literal::Number(value) => {
+                context.i32_type().const_int(*value as u64, false).as_basic_value_enum().try_into().unwrap()
+            }
+            Literal::Float(value) => {
+                context.f32_type().const_float(*value).as_basic_value_enum().try_into().unwrap()
+            }
+            _ => unimplemented!("Unsupported literal type"),
+        },
         Expression::Variable(var_name) => {
             if let Some(alloca) = variables.get(var_name) {
                 builder.build_load(*alloca, var_name).unwrap().into_int_value()

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -490,6 +490,14 @@ fn generate_statement_ir<'ctx>(
                 panic!("break used outside of loop!");
             }
         }
+        ASTNode::Statement(StatementNode::Return(expr_opt)) => {
+            if let Some(expr) = expr_opt {
+                let value = generate_expression_ir(context, builder, expr, variables, module);
+                let _ = builder.build_return(Some(&value));
+            } else {
+                let _ = builder.build_return(None);
+            }
+        }
         _ => {}
     }
 }

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -54,6 +54,7 @@ pub unsafe fn generate_ir(ast: &ASTNode) -> String {
 fn wave_format_to_c(format: &str, arg_types: &[BasicTypeEnum]) -> String {
     let mut result = String::new();
     let mut chars = format.chars().peekable();
+    let mut arg_index = 0;
 
     while let Some(c) = chars.next() {
         if c == '{' {

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -376,6 +376,7 @@ fn get_llvm_type<'a>(context: &'a Context, ty: &TokenType) -> BasicTypeEnum<'a> 
         TokenType::TypeFloat(bits) => match bits {
             32 => context.f32_type().as_basic_type_enum(),
             64 => context.f64_type().as_basic_type_enum(),
+            128 => context.f128_type().as_basic_type_enum(),
             _ => panic!("Unsupported float size: {}", bits),
         },
         TokenType::TypeBool => context.bool_type().as_basic_type_enum(),

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -29,6 +29,39 @@ pub unsafe fn generate_ir(ast: &ASTNode) -> String {
             let mut string_counter = 0;
             let mut loop_exit_stack = vec![];
 
+            for param in parameters {
+                let llvm_type = wave_type_to_llvm_type(&context, &param.param_type);
+                let alloca = builder.build_alloca(llvm_type, &param.name).unwrap();
+                
+                if let Some(init) = &param.initial_value {
+                    match (init, llvm_type) {
+                        (Value::Int(value), BasicTypeEnum::IntType(int_type)) => {
+                            let val = int_type.const_int(*value as u64, false);
+                            builder.build_store(alloca, val).unwrap();
+                        }
+                        (Value::Float(value), BasicTypeEnum::FloatType(float_type)) => {
+                            let val = float_type.const_float(*value);
+                            builder.build_store(alloca, val).unwrap();
+                        }
+                        (Value::Text(s), BasicTypeEnum::PointerType(_)) => {
+                            let bytes = s.as_bytes().to_vec();
+                            let global = module.add_global(
+                                context.i8_type().array_type((bytes.len() + 1) as u32),
+                                None,
+                                &format!("str_init_{}", param.name)
+                            );
+                            global.set_initializer(&context.const_string(&bytes, true));
+                            global.set_constant(true);
+                            let gep = builder.build_gep(global.as_pointer_value(), &[context.i32_type().const_zero(), context.i32_type().const_zero()], "str_gep").unwrap();
+                            builder.build_store(alloca, gep).unwrap();
+                        }
+                        _ => panic!("Unsupported param init type"),
+                    }
+                }
+
+                variables.insert(param.name.clone(), alloca);
+            }
+
             for stmt in body {
                 generate_statement_ir(
                     &context,

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -59,8 +59,18 @@ fn wave_format_to_c(format: &str) -> String {
         if c == '{' {
             if let Some('}') = chars.peek() {
                 chars.next(); // consume '}'
-                result.push_str("%d"); // Wave placeholder → C format
-                continue;
+
+                if let Some(arg_type) = arg_types.get(arg_index) {
+                    let fmt = match arg_type {
+                        BasicTypeEnum::FloatType(_) => "%f",
+                        BasicTypeEnum::IntType(_) => "%d",
+                        BasicTypeEnum::PointerType(_) => "%s",
+                        _ => "%d", // fallback
+                    };
+                    result.push_str(fmt);
+                    arg_index += 1;
+                    continue;
+                }
             }
         }
         result.push(c);

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -116,6 +116,7 @@ fn generate_expression_ir<'ctx>(
     builder: &'ctx inkwell::builder::Builder<'ctx>,
     expr: &Expression,
     variables: &mut HashMap<String, PointerValue<'ctx>>,
+    module: &'ctx inkwell::module::Module<'ctx>,
 ) -> BasicValueEnum<'ctx> {
     match expr {
         Expression::Literal(lit) => match lit {

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -15,7 +15,11 @@ pub unsafe fn generate_ir(ast_nodes: &[ASTNode]) -> String {
         let module = Box::leak(Box::new(context.create_module("main")));
         let builder = Box::leak(Box::new(context.create_builder()));
 
-        let mut variables: HashMap<String, PointerValue> = HashMap::new();
+        for ast in ast_nodes {
+            if let ASTNode::Function(FunctionNode { name, parameters, return_type, body }) = ast {
+                let param_types: Vec<BasicMetadataTypeEnum> = parameters.iter()
+                    .map(|p| wave_type_to_llvm_type(&context, &p.param_type).into())
+                    .collect();
 
         if let ASTNode::Function(FunctionNode { name, parameters, body }) = ast {
             // Create function type (void -> void)

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -87,16 +87,17 @@ fn generate_expression_ir<'ctx>(
     match expr {
         Expression::Literal(lit) => match lit {
             Literal::Number(value) => {
-                context.i32_type().const_int(*value as u64, false).as_basic_value_enum().try_into().unwrap()
+                context.i32_type().const_int(*value as u64, false).as_basic_value_enum()
             }
             Literal::Float(value) => {
-                context.f32_type().const_float(*value).as_basic_value_enum().try_into().unwrap()
+                context.f32_type().const_float(*value).as_basic_value_enum()
             }
             _ => unimplemented!("Unsupported literal type"),
         },
+
         Expression::Variable(var_name) => {
             if let Some(alloca) = variables.get(var_name) {
-                builder.build_load(*alloca, var_name).unwrap().into_int_value()
+                builder.build_load(*alloca, var_name).unwrap()
             } else {
                 panic!("Variable {} not found", var_name);
             }

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -167,7 +167,6 @@ fn generate_expression_ir<'ctx>(
 
             let call_site = builder.build_call(function, &compiled_args, "calltmp").unwrap();
 
-            // 리턴 타입이 있을 경우만 사용
             match function.get_type().get_return_type() {
                 Some(_) => call_site.try_as_basic_value().left().unwrap(),
                 None => context.i32_type().const_zero().as_basic_value_enum(),

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -250,7 +250,19 @@ fn generate_statement_ir<'ctx>(
             let mut printf_args = vec![gep.into()];
             for arg in args {
                 let value = generate_expression_ir(context, builder, arg, variables);
-                printf_args.push(value.into()); // BasicValueEnum -> BasicMetadataValueEnum
+
+                let casted_value = match value {
+                    BasicValueEnum::FloatValue(fv) => {
+                        let double_ty = context.f64_type();
+                        builder
+                            .build_float_ext(fv, double_ty, "cast_to_double")
+                            .unwrap()
+                            .as_basic_value_enum()
+                    }
+                    _ => value,
+                };
+
+                printf_args.push(casted_value.into());
             }
 
             let _ = builder.build_call(printf_func, &printf_args, "printf_call");

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -41,9 +41,9 @@ pub unsafe fn generate_ir(ast_nodes: &[ASTNode]) -> String {
             let mut string_counter = 0;
             let mut loop_exit_stack = vec![];
 
-            for param in parameters {
-                let llvm_type = wave_type_to_llvm_type(&context, &param.param_type);
-                let alloca = builder.build_alloca(llvm_type, &param.name).unwrap();
+                for (i, param) in parameters.iter().enumerate() {
+                    let llvm_type = wave_type_to_llvm_type(&context, &param.param_type);
+                    let alloca = builder.build_alloca(llvm_type, &param.name).unwrap();
 
                 if let Some(init) = &param.initial_value {
                     match (init, llvm_type) {

--- a/src/llvm_temporary/llvm_codegen.rs
+++ b/src/llvm_temporary/llvm_codegen.rs
@@ -157,10 +157,7 @@ fn generate_statement_ir<'ctx>(
     match stmt {
         ASTNode::Variable(VariableNode { name, type_name, initial_value }) => {
             // Parse the type
-            let llvm_type = match parse_type(type_name) {
-                Some(token_type) => get_llvm_type(&context, &token_type),
-                None => panic!("Unsupported type: {}", type_name),
-            };
+            let llvm_type = wave_type_to_llvm_type(&context, &type_name);
 
             // Create alloca for the variable
             let alloca = builder.build_alloca(llvm_type, &name).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use lexer::{Lexer};
 use crate::lexer::TokenType;
 use crate::llvm_temporary::llvm_backend::compile_ir_to_machine_code;
 use crate::llvm_temporary::llvm_codegen::generate_ir;
-use crate::parser::{extract_body, extract_parameters, function, parse};
+use crate::parser::{extract_body, parse_parameters, function, parse};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,37 +104,3 @@ unsafe fn run_wave_file(file_path: &str) {
     // println!("Generated LLVM IR:\n{}", ir);
     println!("{}", String::from_utf8_lossy(&output.stdout));
 }
-
-
-/*
-fn run_wave_file(file_path: &str) {
-    let code = match fs::read_to_string(file_path) {
-        Ok(content) => content,
-        Err(err) => {
-            eprintln!("Error reading file {}: {}", file_path, err);
-            process::exit(1);
-        }
-    };
-
-    let mut lexer = Lexer::new(code.as_str());
-
-    let tokens = lexer.tokenize();
-    eprintln!("Tokens: \n{:#?}", &tokens);
-
-    let function_name = tokens
-        .iter()
-        .find(|token| matches!(token.token_type, TokenType::Identifier(_)))
-        .map(|token| token.lexeme.clone())
-        .unwrap_or_default();
-
-    let params = extract_parameters(&tokens[..], 0, tokens.len());
-
-    let mut peekable_tokens = tokens.iter().peekable();
-
-    let body = extract_body(&mut peekable_tokens);
-
-    let ast = function(function_name, params, body);
-
-    eprintln!("AST:\n{:#?}", &ast);
-}
- */

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -110,6 +110,6 @@ pub enum StatementNode {
 #[derive(Debug, Clone)]
 pub struct VariableNode {
     pub name: String,
-    pub type_name: String,
+    pub type_name: WaveType,
     pub initial_value: Option<Literal>,
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -24,7 +24,7 @@ pub struct FunctionNode {
 #[derive(Debug, Clone)]
 pub struct ParameterNode {
     pub name: String,
-    pub param_type: String, // For simplicity, assuming type as string.
+    pub param_type: WaveType,
     pub initial_value: Option<Value>,
 }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -50,6 +50,10 @@ pub enum FormatPart {
 
 #[derive(Debug, Clone)]
 pub enum Expression {
+    FunctionCall {
+        name: String,
+        args: Vec<Expression>,
+    },
     Literal(Literal),
     Variable(String),
     BinaryExpression {

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -31,6 +31,7 @@ pub enum ASTNode {
 pub struct FunctionNode {
     pub name: String,
     pub parameters: Vec<ParameterNode>,
+    pub return_type: Option<WaveType>,
     pub body: Vec<ASTNode>,
 }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -123,6 +123,8 @@ pub enum StatementNode {
         value: Expression,
     },
     Break,
+    Return(Option<Expression>),
+    Expression(Expression),
 }
 
 #[derive(Debug, Clone)]

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -123,6 +123,7 @@ pub enum StatementNode {
         value: Expression,
     },
     Break,
+    Continue,
     Return(Option<Expression>),
     Expression(Expression),
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -6,6 +6,19 @@ pub enum Value {
 }
 
 #[derive(Debug, Clone)]
+pub enum WaveType {
+    Int(u16),
+    Uint(u16),
+    Float(u16),
+    Bool,
+    Char,
+    Byte,
+    String,
+    Pointer(Box<WaveType>),
+    Array(Box<WaveType>, u32),
+}
+
+#[derive(Debug, Clone)]
 pub enum ASTNode {
     Function(FunctionNode),
     Program(ParameterNode),

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -20,7 +20,7 @@ pub fn function(function_name: String, parameters: Vec<ParameterNode>, body: Vec
     })
 }
 
-pub fn param(parameter: String, param_type: String, initial_value: Option<Value>) -> ParameterNode {
+pub fn param(parameter: String, param_type: WaveType, initial_value: Option<Value>) -> ParameterNode {
     ParameterNode {
         name: parameter,
         param_type,

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -280,8 +280,8 @@ fn parse_var(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
         return None;
     }
 
-    let type_name = match tokens.next() {
-        Some(Token { lexeme, .. }) => lexeme.clone(),
+    let type_token = match tokens.next() {
+        Some(token) => token.clone(),
         _ => {
             println!("Expected type after ':'");
             return None;

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -288,6 +288,14 @@ fn parse_var(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
         }
     };
 
+    let wave_type = match token_type_to_wave_type(&type_token.token_type) {
+        Some(t) => t,
+        None => {
+            println!("Unknown or unsupported type: {}", type_token.lexeme);
+            return None;
+        }
+    };
+
     let initial_value = if let Some(Token { token_type: TokenType::Equal, .. }) = tokens.peek() {
         tokens.next();
         match tokens.next() {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -275,7 +275,7 @@ fn parse_function(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
     };
 
     let body = extract_body(tokens);
-    Some(function(name, parameters, body))
+    Some(function(name, parameters, body?, return_type))
 }
 
 // VAR parsing

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -28,7 +28,7 @@ pub fn param(parameter: String, param_type: String, initial_value: Option<Value>
     }
 }
 
-pub fn extract_parameters(tokens: &[Token], start: usize, end: usize) -> Vec<ParameterNode> {
+pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode> {
     let mut params = vec![];
     let mut i = start;
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -397,7 +397,10 @@ fn parse_print(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         return None;
     };
 
-    let placeholder_count = content.matches("{}").count();
+    let placeholder_count = Regex::new(r"\{[^}]*\}")
+        .unwrap()
+        .find_iter(&content)
+        .count();
 
     if placeholder_count == 0 {
         // No format → Print just a string

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -51,20 +51,17 @@ pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode
                     }
                 };
 
-        let initial_value = if i < end && matches!(tokens[i].token_type, TokenType::Equal) {
-            i += 1;
-            if i < end {
-                match &tokens[i].token_type {
-                    TokenType::Float(value) => Some(Value::Float(*value)),
-                    TokenType::Number(value) => Some(Value::Int(*value)),
-                    _ => None,
-                }
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+                let initial_value = if matches!(tokens.peek().map(|t| &t.token_type), Some(TokenType::Equal)) {
+                    tokens.next(); // consume '='
+                    match tokens.next() {
+                        Some(Token { token_type: TokenType::Number(n), .. }) => Some(Value::Int(*n)),
+                        Some(Token { token_type: TokenType::Float(f), .. }) => Some(Value::Float(*f)),
+                        Some(Token { token_type: TokenType::String(s), .. }) => Some(Value::Text(s.clone())),
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
 
         while i < end && !matches!(tokens[i].token_type, TokenType::SemiColon) {
             i += 1;

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -51,6 +51,20 @@ pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode
                     }
                 };
 
+                let param_type = match parse_type(&param_type_str) {
+                    Some(token_type) => match token_type_to_wave_type(&token_type) {
+                        Some(wt) => wt,
+                        None => {
+                            println!("Error: Unsupported or unknown type '{}'", param_type_str);
+                            break;
+                        }
+                    },
+                    None => {
+                        println!("Error: Failed to parse type '{}'", param_type_str);
+                        break;
+                    }
+                };
+
                 let initial_value = if matches!(tokens.peek().map(|t| &t.token_type), Some(TokenType::Equal)) {
                     tokens.next(); // consume '='
                     match tokens.next() {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -187,7 +187,7 @@ fn parse_function(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
 
     let mut param_names = HashSet::new();
     for param in &parameters {
-        if param_names.contains(&param.name) {
+        if !param_names.insert(param.name.clone()) {
             println!("Error: Parameter '{}' is declared multiple times", param.name);
             return None;
         }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -28,7 +28,10 @@ pub fn parse(tokens: &Vec<Token>) -> Option<Vec<ASTNode>> {
         }
     }
 
-pub fn function(function_name: String, parameters: Vec<ParameterNode>, body: Vec<ASTNode>) -> ASTNode {
+    Some(nodes)
+}
+
+pub fn function(function_name: String, parameters: Vec<ParameterNode>, body: Vec<ASTNode>, return_type: Option<WaveType>,) -> ASTNode {
     // println!("🚨 function() called with {} body items", body.len());
     ASTNode::Function(FunctionNode {
         name: function_name,

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -341,7 +341,6 @@ fn parse_println(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         .count();
 
     if placeholder_count == 0 {
-        // No format → Println that just outputs string
         if tokens.peek()?.token_type != TokenType::Rparen {
             println!("Error: Expected closing ')'");
             return None;

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -31,11 +31,17 @@ pub fn param(parameter: String, param_type: String, initial_value: Option<Value>
 pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode> {
     let mut params = vec![];
 
-    while i < end {
-        if let TokenType::Var = tokens[i].token_type {
-            // println!("Found 'var', stopping parameter parsing.");
-            break;
-        }
+    while let Some(token) = tokens.peek() {
+        match &token.token_type {
+            TokenType::Identifier(name) => {
+                let name = name.clone();
+                tokens.next(); // consume identifier
+
+                if !matches!(tokens.peek().map(|t| &t.token_type), Some(TokenType::Colon)) {
+                    println!("Error: Expected ':' after parameter name '{}'", name);
+                    break;
+                }
+                tokens.next(); // consume ':'
 
                 let param_type = match tokens.next() {
                     Some(Token { lexeme, .. }) => lexeme.clone(),

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -203,7 +203,45 @@ pub fn extract_body(tokens: &mut Peekable<Iter<Token>>) -> Vec<ASTNode> {
         }
     }
 
-    body
+    Some(body)
+}
+
+pub fn parse_function_call(name: Option<String>, tokens: &mut Peekable<Iter<Token>>) -> Option<Expression> {
+    let name = name?;
+
+    if tokens.peek()?.token_type != TokenType::Lparen {
+        println!("❌ Expected '(' after function name '{}'", name);
+        return None;
+    }
+    tokens.next(); // consume '('
+
+    let mut args = vec![];
+
+    while let Some(token) = tokens.peek() {
+        if token.token_type == TokenType::Rparen {
+            tokens.next(); // consume ')'
+            break;
+        }
+
+        let arg = parse_expression(tokens)?;
+        args.push(arg);
+
+        match tokens.peek().map(|t| &t.token_type) {
+            Some(TokenType::Comma) => {
+                tokens.next(); // consume ','
+            }
+            Some(TokenType::Rparen) => continue,
+            _ => {
+                println!("❌ Unexpected token in function arguments: {:?}", tokens.peek());
+                return None;
+            }
+        }
+    }
+
+    Some(Expression::FunctionCall {
+        name,
+        args,
+    })
 }
 
 fn parse_parentheses(tokens: &mut Peekable<Iter<Token>>) -> Vec<Token> {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -241,11 +241,6 @@ fn parse_function(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
 
     tokens.next(); // consume '('
     let parameters = parse_parameters(tokens);
-    if tokens.peek()?.token_type != TokenType::Rparen {
-        println!("Error: Expected ')' after parameters");
-        return None;
-    }
-    tokens.next(); // consume ')'
 
     let mut param_names = HashSet::new();
     for param in &parameters {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -68,16 +68,9 @@ pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode
                 }
                 tokens.next(); // consume ':'
 
-                let param_type_str = match tokens.next() {
-                    Some(Token { lexeme, .. }) => lexeme.clone(),
-                    _ => {
-                        println!("Expected type after ':' for parameter '{}'", name);
-                        break;
-                    }
-                };
-
-                let param_type = match parse_type(&param_type_str) {
-                    Some(token_type) => match token_type_to_wave_type(&token_type) {
+                let token = tokens.next();
+                let param_type = match &token {
+                    Some(Token { token_type, .. }) => match token_type_to_wave_type(token_type) {
                         Some(wt) => wt,
                         None => {
                             println!("Error: Unsupported or unknown type '{}'", param_type_str);

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -78,7 +78,7 @@ pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode
                         }
                     },
                     None => {
-                        println!("Error: Failed to parse type '{}'", param_type_str);
+                        println!("Expected type after ':' for parameter '{}'", name);
                         break;
                     }
                 };

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -191,6 +191,7 @@ pub fn extract_body(tokens: &mut Peekable<Iter<Token>>) -> Vec<ASTNode> {
                 }
             }
             TokenType::Break => {
+                tokens.next(); // consume 'break'
                 if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
                     tokens.next(); // consume ;
                 }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -178,10 +178,7 @@ fn parse_function(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         return None;
     }
 
-    let param_tokens = parse_parentheses(tokens);
-    let parameters = extract_parameters(&param_tokens, 0, param_tokens.len());
-
-    let param_names: HashSet<String> = parameters.iter().map(|p| p.name.clone()).collect();
+    let mut param_names = HashSet::new();
     for param in &parameters {
         if param_names.contains(&param.name) {
             println!("Error: Parameter '{}' is declared multiple times", param.name);

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -577,7 +577,6 @@ fn parse_block(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> {
         };
 
         if let Some(ast_node) = node {
-            // println!("📦 parse_block() -> ASTNode Insertion: {:#?}", ast_node);
             body.push(ast_node);
         }
     }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -38,25 +38,13 @@ pub fn extract_parameters(tokens: &[Token], start: usize, end: usize) -> Vec<Par
             break;
         }
 
-        let name = match &tokens[i].token_type {
-            TokenType::Identifier(name) => name.clone(),
-            _ => {
-                i += 1;
-                continue;
-            }
-        };
-        i += 1;
-
-        if i >= end || !matches!(tokens[i].token_type, TokenType::Colon) {
-            continue;
-        }
-        i += 1;
-
-        let param_type = match &tokens[i].token_type {
-            TokenType::TypeInt(_) => tokens[i].lexeme.clone(),
-            _ => "unknown".into(),
-        };
-        i += 1;
+                let param_type = match tokens.next() {
+                    Some(Token { lexeme, .. }) => lexeme.clone(),
+                    _ => {
+                        println!("Expected type after ':' for parameter '{}'", name);
+                        break;
+                    }
+                };
 
         let initial_value = if i < end && matches!(tokens[i].token_type, TokenType::Equal) {
             i += 1;

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -250,6 +250,13 @@ pub fn extract_body(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> 
                 }
                 body.push(ASTNode::Statement(StatementNode::Break));
             }
+            TokenType::Continue => {
+                tokens.next(); // consume 'break'
+                if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+                    tokens.next(); // consume ;
+                }
+                body.push(ASTNode::Statement(StatementNode::Continue));
+            }
             TokenType::Return => {
                 tokens.next(); // consume 'return'
 
@@ -764,6 +771,12 @@ fn parse_block(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> {
                     tokens.next();
                 }
                 Some(ASTNode::Statement(StatementNode::Break))
+            }
+            TokenType::Continue => {
+                if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+                    tokens.next();
+                }
+                Some(ASTNode::Statement(StatementNode::Continue))
             }
             TokenType::Return => {
                 let expr = if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -648,6 +648,19 @@ fn parse_block(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> {
                 }
                 Some(ASTNode::Statement(StatementNode::Break))
             }
+            TokenType::Return => {
+                let expr = if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+                    tokens.next(); // consume ;
+                    None
+                } else {
+                    let value = parse_expression(tokens)?;
+                    if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+                        tokens.next(); // consume ;
+                    }
+                    Some(value)
+                };
+                Some(ASTNode::Statement(StatementNode::Return(expr)))
+            }
             _ => {
                 None
             }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -335,7 +335,10 @@ fn parse_println(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         return None;
     };
 
-    let placeholder_count = content.matches("{}").count();
+    let placeholder_count = Regex::new(r"\{[^}]*\}")
+        .unwrap()
+        .find_iter(&content)
+        .count();
 
     if placeholder_count == 0 {
         // No format → Println that just outputs string

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -43,7 +43,7 @@ pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode
                 }
                 tokens.next(); // consume ':'
 
-                let param_type = match tokens.next() {
+                let param_type_str = match tokens.next() {
                     Some(Token { lexeme, .. }) => lexeme.clone(),
                     _ => {
                         println!("Expected type after ':' for parameter '{}'", name);

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -73,7 +73,7 @@ pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode
                     Some(Token { token_type, .. }) => match token_type_to_wave_type(token_type) {
                         Some(wt) => wt,
                         None => {
-                            println!("Error: Unsupported or unknown type '{}'", param_type_str);
+                            println!("Error: Unsupported or unknown type token: {:?}", token_type);
                             break;
                         }
                     },

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -314,7 +314,7 @@ fn parse_var(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
 
     Some(ASTNode::Variable(VariableNode {
         name,
-        type_name,
+        type_name: wave_type,
         initial_value,
     }))
 }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -52,7 +52,11 @@ pub fn param(parameter: String, param_type: WaveType, initial_value: Option<Valu
 pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode> {
     let mut params = vec![];
 
-    while let Some(token) = tokens.peek() {
+    loop {
+        let Some(token) = tokens.peek() else {
+            break;
+        };
+
         match &token.token_type {
             TokenType::Identifier(name) => {
                 let name = name.clone();

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -197,7 +197,8 @@ pub fn extract_body(tokens: &mut Peekable<Iter<Token>>) -> Vec<ASTNode> {
                 body.push(ASTNode::Statement(StatementNode::Break));
             }
             _ => {
-                // Ignore unprocessed tokens
+                // println!("⚠️ Unexpected token inside function body: {:?}", token);
+                tokens.next(); // consume and skip
             }
         }
     }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -85,6 +85,56 @@ pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode
     params
 }
 
+fn token_type_to_wave_type(token_type: &TokenType) -> Option<WaveType> {
+    match token_type {
+        TokenType::TypeInt(bits) => Some(WaveType::Int(*bits)),
+        TokenType::TokenTypeInt(int_type) => match int_type {
+            IntegerType::I8 => Some(WaveType::Int(8)),
+            IntegerType::I16 => Some(WaveType::Int(16)),
+            IntegerType::I32 => Some(WaveType::Int(32)),
+            IntegerType::I64 => Some(WaveType::Int(64)),
+            IntegerType::I128 => Some(WaveType::Int(128)),
+            IntegerType::I256 => Some(WaveType::Int(256)),
+            IntegerType::I512 => Some(WaveType::Int(512)),
+            IntegerType::I1024 => Some(WaveType::Int(1024)),
+            _ => panic!("Unhandled integer type: {:?}", int_type),
+        },
+        TokenType::TypeUint(bits) => Some(WaveType::Uint(*bits)),
+        TokenType::TokenTypeUint(uint_type) => match uint_type {
+            UnsignedIntegerType::U8 => Some(WaveType::Uint(8)),
+            UnsignedIntegerType::U16 => Some(WaveType::Uint(16)),
+            UnsignedIntegerType::U32 => Some(WaveType::Uint(32)),
+            UnsignedIntegerType::U64 => Some(WaveType::Uint(64)),
+            UnsignedIntegerType::U128 => Some(WaveType::Uint(128)),
+            UnsignedIntegerType::U256 => Some(WaveType::Uint(256)),
+            UnsignedIntegerType::U512 => Some(WaveType::Uint(512)),
+            UnsignedIntegerType::U1024 => Some(WaveType::Uint(1024)),
+            _ => panic!("Unhandled uint type: {:?}", uint_type),
+        },
+        TokenType::TokenTypeFloat(float_type) => match float_type {
+            FloatType::F32 => Some(WaveType::Float(32)),
+            FloatType::F64 => Some(WaveType::Float(64)),
+            FloatType::F128 => Some(WaveType::Float(128)),
+            FloatType::F256 => Some(WaveType::Float(256)),
+            FloatType::F512 => Some(WaveType::Float(512)),
+            FloatType::F1024 => Some(WaveType::Float(1024)),
+            _ => panic!("Unhandled float type: {:?}", float_type),
+        },
+        TokenType::TypeFloat(bits) => Some(WaveType::Float(*bits)),
+        TokenType::TypeBool => Some(WaveType::Bool),
+        TokenType::TypeChar => Some(WaveType::Char),
+        TokenType::TypeByte => Some(WaveType::Byte),
+        TokenType::TypeString => Some(WaveType::String),
+        TokenType::TypePointer(inner) => {
+            token_type_to_wave_type(inner).map(|t| WaveType::Pointer(Box::new(t)))
+        }
+        TokenType::TypeArray(inner, size) => {
+            token_type_to_wave_type(inner).map(|t| WaveType::Array(Box::new(t), *size))
+        }
+        _ => None,
+    }
+}
+
 pub fn extract_body(tokens: &mut Peekable<Iter<Token>>) -> Vec<ASTNode> {
     let mut body = vec![];
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -239,9 +239,6 @@ fn parse_function(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         return None;
     }
 
-    if tokens.peek()?.token_type != TokenType::Lparen {
-        return None;
-    }
     tokens.next(); // consume '('
     let parameters = parse_parameters(tokens);
     if tokens.peek()?.token_type != TokenType::Rparen {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -63,19 +63,25 @@ pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode
                     None
                 };
 
-        while i < end && !matches!(tokens[i].token_type, TokenType::SemiColon) {
-            i += 1;
-        }
-        if i < end {
-            i += 1;
-        }
+                params.push(ParameterNode {
+                    name,
+                    param_type,
+                    initial_value,
+                });
 
-        params.push(ParameterNode {
-            name,
-            param_type,
-            initial_value,
-        });
+                match tokens.peek().map(|t| &t.token_type) {
+                    Some(TokenType::SemiColon) => {
+                        tokens.next();
+                        continue;
+                    }
+                    Some(TokenType::Rparen) => break,
+                    _ => break,
+                }
+            }
+            _ => break,
+        }
     }
+
     params
 }
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -170,7 +170,11 @@ fn parse_function(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         _ => return None,
     };
 
-    if !matches!(tokens.next().map(|t| &t.token_type), Some(TokenType::Lparen)) {
+    if tokens.peek()?.token_type != TokenType::Lparen {
+        return None;
+    }
+
+    if tokens.peek()?.token_type != TokenType::Lparen {
         return None;
     }
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -30,7 +30,6 @@ pub fn param(parameter: String, param_type: String, initial_value: Option<Value>
 
 pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode> {
     let mut params = vec![];
-    let mut i = start;
 
     while i < end {
         if let TokenType::Var = tokens[i].token_type {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -548,7 +548,6 @@ fn parse_assignment(tokens: &mut Peekable<Iter<Token>>, first_token: &Token) -> 
 
 // block parsing
 fn parse_block(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> {
-    // println!("🌲 Entering parse_block()");
     let mut body = vec![];
 
     while let Some(token) = tokens.next() {
@@ -561,7 +560,6 @@ fn parse_block(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> {
             TokenType::Println => parse_println(tokens),
             TokenType::Print => parse_print(tokens),
             TokenType::If => {
-                // println!("🔥 Entering TokenType:::If branch from pas_block!");
                 parse_if(tokens)
             },
             TokenType::For => parse_for(tokens),
@@ -574,7 +572,6 @@ fn parse_block(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> {
                 Some(ASTNode::Statement(StatementNode::Break))
             }
             _ => {
-                // println!("⚠️ Unrecognized token in block: {:?}", token.token_type);
                 None
             }
         };

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -37,6 +37,7 @@ pub fn function(function_name: String, parameters: Vec<ParameterNode>, body: Vec
         name: function_name,
         parameters,
         body,
+        return_type,
     })
 }
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -196,6 +196,22 @@ pub fn extract_body(tokens: &mut Peekable<Iter<Token>>) -> Vec<ASTNode> {
                 }
                 body.push(ASTNode::Statement(StatementNode::Break));
             }
+            TokenType::Return => {
+                tokens.next(); // consume 'return'
+
+                let expr = if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+                    tokens.next(); // return;
+                    None
+                } else {
+                    let value = parse_expression(tokens)?;
+                    if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+                        tokens.next();
+                    }
+                    Some(value)
+                };
+
+                body.push(ASTNode::Statement(StatementNode::Return(expr)));
+            }
             _ => {
                 // println!("⚠️ Unexpected token inside function body: {:?}", token);
                 tokens.next(); // consume and skip

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -177,6 +177,13 @@ fn parse_function(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
     if tokens.peek()?.token_type != TokenType::Lparen {
         return None;
     }
+    tokens.next(); // consume '('
+    let parameters = parse_parameters(tokens);
+    if tokens.peek()?.token_type != TokenType::Rparen {
+        println!("Error: Expected ')' after parameters");
+        return None;
+    }
+    tokens.next(); // consume ')'
 
     let mut param_names = HashSet::new();
     for param in &parameters {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -110,6 +110,12 @@ pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode
                     _ => break,
                 }
             }
+
+            TokenType::Rparen => {
+                tokens.next();
+                break;
+            }
+
             _ => break,
         }
     }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -6,10 +6,27 @@ use crate::lexer::*;
 use crate::parser::ast::*;
 use crate::parser::format::*;
 
-pub fn parse(tokens: &[Token]) -> Option<ASTNode> {
-    let mut tokens_iter = tokens.iter().peekable();
-    parse_function(&mut tokens_iter)
-}
+pub fn parse(tokens: &Vec<Token>) -> Option<Vec<ASTNode>> {
+    let mut iter = tokens.iter().peekable();
+    let mut nodes = vec![];
+
+    while let Some(token) = iter.peek() {
+        match token.token_type {
+            TokenType::Fun => {
+                if let Some(func) = parse_function(&mut iter) {
+                    nodes.push(func);
+                } else {
+                    println!("❌ Failed to parse function");
+                    return None;
+                }
+            }
+            TokenType::Eof => break,
+            _ => {
+                println!("❌ Unexpected token at top level: {:?}", token);
+                return None;
+            }
+        }
+    }
 
 pub fn function(function_name: String, parameters: Vec<ParameterNode>, body: Vec<ASTNode>) -> ASTNode {
     // println!("🚨 function() called with {} body items", body.len());

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::iter::Peekable;
 use std::slice::Iter;
+use crate::error::*;
 use crate::lexer::*;
 use crate::parser::ast::*;
 use crate::parser::format::*;
@@ -385,15 +386,11 @@ fn parse_if(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
     }
     tokens.next(); // Consume '('
 
-    // println!("🧪 parse_if() Start");
-
     let condition = match parse_expression(tokens) {
         Some(expr) => {
-            // println!("🎯 condition parsing successful: {:#?}", expr);
             expr
         }
         None => {
-            // println!("❌ condition parsing failed!");
             return None;
         }
     };
@@ -424,21 +421,17 @@ fn parse_if(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
 
         // Check if it comes right after else
         if let Some(Token { token_type: TokenType::If, .. }) = tokens.peek() {
-            // println!("🔍 else if Detected!");
             tokens.next();
             let parsed = parse_if(tokens);
 
             match parsed {
                 Some(ASTNode::Statement(stmt @ StatementNode::If { .. })) => {
-                    // println!("✅ Create else-if AST successful");
                     else_if_blocks.push(ASTNode::Statement(stmt));
                 }
                 Some(other) => {
-                    // println!("❗ else-if is not statementNode::If: {:#?}", other);
                     return None;
                 }
                 None => {
-                    // println!("❌ else-if Failed to parse!");
                     return None;
                 }
             }
@@ -467,8 +460,6 @@ fn parse_if(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         else_block,
     });
 
-    // println!("✅ AST IF NODE: {:#?}", result);
-    // println!("✅ parse_if() -> ASTNode Return: {:#?}", result);
     Some(result)
 }
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -258,9 +258,21 @@ fn parse_function(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         }
     }
 
-    if !matches!(tokens.next().map(|t| &t.token_type), Some(TokenType::Lbrace)) {
-        return None;
-    }
+    let return_type = if let Some(Token { token_type: TokenType::Arrow, .. }) = tokens.peek() {
+        tokens.next(); // consume '->'
+
+        match tokens.next() {
+            Some(Token { token_type, .. }) => {
+                token_type_to_wave_type(token_type)
+            }
+            None => {
+                println!("Error: Expected type after '->'");
+                None
+            }
+        }
+    } else {
+        None
+    };
 
     let body = extract_body(tokens);
     Some(function(name, parameters, body))

--- a/test/test12.wave
+++ b/test/test12.wave
@@ -1,4 +1,6 @@
 fun main(q :i32 = 0; w :i32 = 10;) {
     var a :str = "World";
-    println("Hello {}", a);
+    var b :i32 = 2;
+    var c :i32 = 3;
+    println("Hello {} {} {}", a, q, w);
 }

--- a/test/test12.wave
+++ b/test/test12.wave
@@ -1,0 +1,3 @@
+fun main(q :i32 = 0; w :i32 = 10;) {
+    println("H");
+}

--- a/test/test12.wave
+++ b/test/test12.wave
@@ -1,3 +1,4 @@
 fun main(q :i32 = 0; w :i32 = 10;) {
-    println("H");
+    var a :str = "World";
+    println("Hello {}", a);
 }

--- a/test/test13.wave
+++ b/test/test13.wave
@@ -1,0 +1,4 @@
+fun main() {
+    var numbers: array<i32, 5> = [1, 2, 3, 4, 5];
+    println("First = {}", numbers[0]);
+}

--- a/test/test14.wave
+++ b/test/test14.wave
@@ -1,7 +1,22 @@
-fun hello(name: str;) {
+fun hello(name :i32; namea :i32; nameb :str;) {
+    if (name > 10) {
+        println("name is greater than 10");
+    } else {
+        println("name is 10 or less");
+    }
+
+    var counter: i32 = 0;
+
+    while (counter < name) {
+        println("Current: {}", counter);
+        counter = counter + 1;
+    }
+
     println("Hello {}", name);
+    println("Hello {}", namea);
+    println("Hello {}", nameb);
 }
 
 fun main() {
-    hello("World");
+    hello(5, 2, "World");
 }

--- a/test/test14.wave
+++ b/test/test14.wave
@@ -1,0 +1,7 @@
+fun hello(name: str;) {
+    println("Hello {}", name);
+}
+
+fun main() {
+    hello("World");
+}

--- a/test/test15.wave
+++ b/test/test15.wave
@@ -1,0 +1,7 @@
+fun add(a :i32; b :i32;) -> i32 {
+    return a + b;
+}
+
+fun main() {
+    println("{}", add(4, 5));
+}

--- a/test/test16.wave
+++ b/test/test16.wave
@@ -1,0 +1,11 @@
+fun main() {
+    var i: i32 = 0;
+
+    while (i < 5) {
+        i = i + 1;
+        if (i == 3) {
+            continue;
+        }
+        println("Value: {}", i);
+    }
+}


### PR DESCRIPTION
## ✅ Added Features

### 💬 Comment Support
* Supports single-line comments using `//`
* Supports multi-line comment blocks using `/* */`

### ✅ continue statement Support
* Possible to skip to the next iteration depending on the condition within the 'while' loop
* Syntax supported for 'if (condition) {continue; }'
* In LLVM IR, 'continue' is treated as a condition check block for the corresponding loop

### 🧠 Strong Typing for Variables and Parameters
* Replaced string-based types with structured `WaveType` enums in the AST
* Fully supports types like `i32`, `u64`, `f32` for both variables and parameters
* Enables static type checking and safer LLVM IR generation

### 🔢 Float Type Support (`f32`)
* Supports `f32` literals (e.g., `12.34`)
* Allows declaration, initialization, and reassignment of `f32` variables
* Enables use of `f32` values in arithmetic and comparison operations (e.g., `if`, `while`)
* Promotes `float` to `double` using `fpext` when passing to `printf` to conform to the C ABI

### 🖨️ Formatted Print (`println("...", value)`)
* Automatically maps Wave types to proper C format specifiers (`%d`, `%f`, `%s`)
* Correctly handles printing of `f32`, `i32`, and string types with type inference

### 🌀 Type-Aware LLVM IR Generation
* LLVM `alloca`, `store`, and `load` instructions are generated based on `WaveType`
* Supports both integer and float value initialization
* Uses `BasicTypeEnum` and `BasicValueEnum` to unify value handling
* Ensures correctness in mixed-type binary expressions and conditionals

### 🧩 Function Definition and Calls
* Supports user-defined functions with multiple parameters
* Parameters support explicit typing (e.g., `i32`, `str`)
* Functions can be called with literals or variables as arguments
* LLVM IR correctly handles parameter passing using `%0`, `%1`, ... style
* Parameter values are properly `store`d and `load`ed from the stack
* Enables composable and reusable logic with full IR-level integration

### 🧠 Function Return Type Support
* Functions can now specify return types using `->` syntax (e.g., `-> i32`)
* Supported return types: `i32`, `f32`, `str` (more planned)
* Return statements (`return expr;`) emit the appropriate LLVM `ret` instruction
* If no return is specified in a void function, `ret void` is automatically inserted
* Ensures matching return types between Wave AST and LLVM IR generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Bumped the package version for the new release and removed legacy code.

- **New Features**
  - Enhanced error reporting for clearer, more informative messages.
  - Improved handling of comments and expanded support for diverse data types during code generation.
  - Upgraded parameter parsing with robust type checking for more reliable function definitions.
  - Added support for function calls and improved expression parsing.

- **Tests**
  - Added sample programs showcasing optional parameters, array operations, and control flow structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->