### PR TITLE
primary expression assignment function fix

### DIFF
--- a/front/parser/src/parser/parser.rs
+++ b/front/parser/src/parser/parser.rs
@@ -1033,7 +1033,13 @@ fn parse_asm_block(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
 }
 
 fn parse_assignment(tokens: &mut Peekable<Iter<Token>>, first_token: &Token) -> Option<ASTNode> {
-    let left_expr = parse_expression_from_token(first_token, tokens)?;
+    let left_expr = match parse_expression_from_token(first_token, tokens) {
+        Some(expr) => expr,
+        None => {
+            println!("Error: Failed to parse left-hand side of assignment. Token: {:?}", first_token.token_type);
+            return None;
+        }
+    };
 
     let assign_op = match tokens.peek()?.token_type {
         TokenType::PlusEq => {
@@ -1056,55 +1062,42 @@ fn parse_assignment(tokens: &mut Peekable<Iter<Token>>, first_token: &Token) -> 
             tokens.next();
             Some(AssignOperator::RemAssign)
         }
-        TokenType::Equal => None,
+        TokenType::Equal => {
+            tokens.next();
+            None
+        }
         _ => return None,
     };
 
-    if let Some(op) = assign_op {
-        let right_expr = parse_expression(tokens)?;
+    let right_expr = parse_expression(tokens)?;
 
-        if let Expression::Variable(name) = left_expr {
-            if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
-                tokens.next();
-            }
-            return Some(ASTNode::Expression(Expression::AssignOperation {
-                target: Box::new(Expression::Variable(name)),
-                operator: op,
-                value: Box::new(right_expr),
-            }))
-        }
-        panic!("Unsupported left-hand side for assignment operator: {:?}", left_expr);
+    if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+        tokens.next();
     }
 
-    if let Some(Token { token_type: TokenType::Equal, .. }) = tokens.peek() {
-        tokens.next(); // consume '='
-        let right_expr = parse_expression(tokens)?;
-
-        if let Expression::Deref(_) = left_expr {
-            return Some(ASTNode::Statement(StatementNode::Assign {
-                variable: "deref".to_string(),
-                value: Expression::BinaryExpression {
-                    left: Box::new(left_expr),
-                    operator: Operator::Assign,
-                    right: Box::new(right_expr),
-                },
-            }));
+    match (assign_op, &left_expr) {
+        (Some(op), Expression::Variable(name)) => Some(ASTNode::Expression(Expression::AssignOperation {
+            target: Box::new(Expression::Variable(name.clone())),
+            operator: op,
+            value: Box::new(right_expr),
+        })),
+        (None, Expression::Variable(name)) => Some(ASTNode::Statement(StatementNode::Assign {
+            variable: name.clone(),
+            value: right_expr,
+        })),
+        (None, Expression::Deref(_)) => Some(ASTNode::Statement(StatementNode::Assign {
+            variable: "deref".to_string(),
+            value: Expression::BinaryExpression {
+                left: Box::new(left_expr),
+                operator: Operator::Assign,
+                right: Box::new(right_expr),
+            },
+        })),
+        (_, _) => {
+            println!("Error: Unsupported assignment left expression: {:?}", left_expr);
+            None
         }
-
-        if let Expression::Variable(name) = left_expr {
-            if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
-                tokens.next(); // consume ';'
-            }
-            return Some(ASTNode::Statement(StatementNode::Assign {
-                variable: name,
-                value: right_expr,
-            }));
-        }
-
-        panic!("Unsupported assignment left expression: {:?}", left_expr);
     }
-
-    None
 }
 
 // block parsing


### PR DESCRIPTION
I initially suspected the bug in `test47` was related to assignment parsing and tried to fix the `parse_assignment` function, but it turns out the issue lies elsewhere.
The error message `Error: Expected primary expression, found Equal` indicates that Wave's variable handling may be the actual cause.

In Wave, `var` is used for mutable variables and `let` for constants. However, in `test47`, the following lines:

```wave
a = 12;
b = 5;
```

seem to fail because `a` and `b` are used without prior declaration.

I believe the current variable system does not properly handle implicit declarations or assignments to undeclared identifiers. This might be causing the parser to misinterpret the `=` as a primary expression error.

I'll now investigate the variable tracking or declaration logic instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved and unified the logic for parsing assignment expressions, resulting in clearer control flow and more consistent error reporting.
  - Enhanced error messages for unsupported assignment cases and removed redundant code paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->