### PR TITLE
Change to nightly because 0.1.2-pre-beta has not been released

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavec"
-version = "0.1.2-pre-beta"
+version = "0.1.2-pre-beta-nightly"
 edition = "2021"
 
 # [target.x86_64-apple-darwin]


### PR DESCRIPTION
* [Change to nightly because 0.1.2-pre-beta has not been released](https://github.com/LunaStev/Wave/commit/77ed3bf1f573a52591f137c0b372cc8bcc2d3c21)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to "0.1.2-pre-beta-nightly".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->