### PR TITLE
Fix expression parser false positives for statement tokens

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavec"
-version = "0.1.2-pre-beta-nightly"
+version = "0.1.2-pre-beta"
 edition = "2021"
 
 # [target.x86_64-apple-darwin]

--- a/front/parser/src/parser/format.rs
+++ b/front/parser/src/parser/format.rs
@@ -445,10 +445,13 @@ where
             })
         }
         _ => {
-            if let TokenType::SemiColon = token.token_type { } else {
-                println!("Error: Expected primary expression, found {:?}", token.token_type);
+            match token.token_type {
+                TokenType::Continue | TokenType::Break | TokenType::Return | TokenType::SemiColon => None,
+                _ => {
+                    println!("Error: Expected primary expression, found {:?}", token.token_type);
+                    None
+                }
             }
-            None
         }
     }
 }

--- a/llvm_temporary/src/llvm_temporary/expression.rs
+++ b/llvm_temporary/src/llvm_temporary/expression.rs
@@ -150,10 +150,15 @@ pub fn generate_expression_ir<'ctx>(
             }
 
             let call_site = builder.build_call(function, &compiled_args, "calltmp").unwrap();
-            if let Some(ret_val) = call_site.try_as_basic_value().left() {
-                ret_val
+
+            if function_type.get_return_type().is_some() {
+                if let Some(ret_val) = call_site.try_as_basic_value().left() {
+                    ret_val
+                } else {
+                    panic!("Function '{}' should return a value but didn't", name);
+                }
             } else {
-                panic!("Function '{}' did not return a value", name);
+                context.i32_type().const_zero().as_basic_value_enum()
             }
         }
 

--- a/llvm_temporary/src/llvm_temporary/statement.rs
+++ b/llvm_temporary/src/llvm_temporary/statement.rs
@@ -640,7 +640,6 @@ pub fn generate_statement_ir<'ctx>(
         ASTNode::Statement(StatementNode::Continue) => {
             if let Some(target_block) = loop_continue_stack.last() {
                 let _ = builder.build_unconditional_branch(*target_block);
-                builder.build_unreachable().unwrap();
             } else {
                 panic!("continue used outside of loop!");
             }


### PR DESCRIPTION
This PR resolves an issue where statement-like tokens such as 'continue', 'break', 'return', and semicolons were incorrectly reported as invalid primary expressions.

- Adjusted the fallback case in `parse_primary_expression` to silently ignore non-expression tokens
- Error logging now only triggers on truly unexpected tokens
- Cleaned up noisy logs that previously confused expression parsing

This makes the parser more robust and aligns error output with actual syntax violations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling and messaging for invalid or unexpected tokens in expressions and return statements.
	- Corrected control flow handling for break and continue statements to ensure proper parsing and execution.
	- Enhanced error recovery during expression parsing within code blocks.

- **Improvements**
	- Added support for optional semicolons after print statements for more flexible syntax.
	- Improved handling of function call return values, providing a default value for functions with no return type.
	- Refined internal error messages and parsing order for better consistency and clarity during code analysis.
	- Updated version string to reflect pre-beta release status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->