### PR TITLE
Change function parameter syntax from semicolon to comma (issue #196)

### DIFF
--- a/front/parser/src/parser/parser.rs
+++ b/front/parser/src/parser/parser.rs
@@ -101,7 +101,7 @@ pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode
                 });
 
                 match tokens.peek().map(|t| &t.token_type) {
-                    Some(TokenType::SemiColon) => {
+                    Some(TokenType::Comma) => {
                         tokens.next(); // consume ';'
                         continue;
                     }
@@ -109,8 +109,8 @@ pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode
                         tokens.next();
                         break;
                     }
-                    Some(TokenType::Comma) => {
-                        println!("Error: use `;` instead of `,` to separate parameters");
+                    Some(TokenType::SemiColon) => {
+                        println!("Error: use `,` instead of `;` to separate parameters");
                         break;
                     }
                     _ => break,

--- a/test/test12.wave
+++ b/test/test12.wave
@@ -1,4 +1,4 @@
-fun main(q :i32 = 0; w :i32 = 10;) {
+fun main(q :i32 = 0, w :i32 = 10) {
     var a :str = "World";
     var b :i32 = 2;
     var c :i32 = 3;

--- a/test/test14.wave
+++ b/test/test14.wave
@@ -1,4 +1,4 @@
-fun hello(name :i32; namea :i32; nameb :str;) {
+fun hello(name :i32, namea :i32, nameb :str) {
     if (name > 10) {
         println("name is greater than 10");
     } else {

--- a/test/test15.wave
+++ b/test/test15.wave
@@ -1,4 +1,4 @@
-fun add(a :i32; b :i32;) -> i32 {
+fun add(a :i32, b :i32) -> i32 {
     return a + b;
 }
 

--- a/test/test17.wave
+++ b/test/test17.wave
@@ -1,8 +1,8 @@
-fun add(a: i32; b: i32) -> i32 {
+fun add(a: i32, b: i32) -> i32 {
     return a + b;
 }
 
-fun complex(x: i32; y: i32; msg: str; sum: i32) {
+fun complex(x: i32, y: i32, msg: str, sum: i32) {
     println("START COMPLEX FUNCTION");
 
     if (x > y) {

--- a/test/test18.wave
+++ b/test/test18.wave
@@ -1,4 +1,4 @@
-fun add(a :i32; b :i32;) -> i32 {
+fun add(a :i32, b :i32) -> i32 {
     return a + b;
 }
 

--- a/test/test19.wave
+++ b/test/test19.wave
@@ -1,4 +1,4 @@
-fun add(a :i32; b :i32;) -> i32 {
+fun add(a :i32, b :i32) -> i32 {
     return a + b;
 }
 

--- a/test/test25.wave
+++ b/test/test25.wave
@@ -1,4 +1,4 @@
-fun make_http_get(host: str; path: str) {
+fun make_http_get(host: str, path: str) {
     println("GET {} HTTP/1.0", path);
     println("Host: {}", host);
     println("User-Agent: WaveLang/0.0.1");

--- a/test/test26.wave
+++ b/test/test26.wave
@@ -1,4 +1,4 @@
-fun main(q :i32 = 0; w :i32 = 10;) {
+fun main(q :i32 = 0, w :i32 = 10,) {
     var a :str = "World";
     let b :i32 = 2;
     let mut c :i32 = 3;

--- a/test/test28/math.wave
+++ b/test/test28/math.wave
@@ -1,15 +1,15 @@
-fun add(a: i32; b: i32) -> i32 {
+fun add(a: i32, b: i32) -> i32 {
     return a + b;
 }
 
-fun sub(a: i32; b: i32) -> i32 {
+fun sub(a: i32, b: i32) -> i32 {
     return a - b;
 }
 
-fun mul(a: i32; b: i32) -> i32 {
+fun mul(a: i32, b: i32) -> i32 {
     return a * b;
 }
 
-fun div(a: i32; b: i32) -> i32 {
+fun div(a: i32, b: i32) -> i32 {
     return a / b;
 }

--- a/test/test38.wave
+++ b/test/test38.wave
@@ -1,4 +1,4 @@
-fun calculate_values(x: i32; y: i32; factor: f32) -> f32 {
+fun calculate_values(x: i32, y: i32, factor: f32) -> f32 {
     println("inside calculate_values");
     var result: f32 = x;
     result += y;

--- a/test/test39.wave
+++ b/test/test39.wave
@@ -1,4 +1,4 @@
-fun transform(x: i32; y: i32; scale: f32) -> f32 {
+fun transform(x: i32, y: i32, scale: f32) -> f32 {
     println("inside transform");
     var base: i32 = x * 2;
     base += y;
@@ -21,7 +21,7 @@ fun display_pattern(levels: i32) -> i32 {
     return 0;
 }
 
-fun process(a: i32; b: i32; note: str) -> i32 {
+fun process(a: i32, b: i32, note: str) -> i32 {
     println("== PROCESS START ==");
 
     var v: i32 = a;


### PR DESCRIPTION
Issues: #196

This pull request updates the function parameter syntax in Wave from using semicolons (`;`) to commas (`,`), making it more intuitive and consistent with common programming language conventions.

---

## Before

```wave
fun hello(name :i32; namea :i32; nameb :str;) {
```

## After

```wave
fun hello(name :i32, namea :i32, nameb :str) {
```

---

## Rationale
- **Improved readability**: Commas are more familiar to developers from languages like C, Rust, Python, and JavaScript.

- **Consistency**: Matches Wave's goal of being an intuitive and approachable language without sacrificing power.

- **Lower learning curve**: Reduces cognitive friction for new users transitioning from other languages.

- **Cleaner syntax**: Semicolons in parameter lists are uncommon and may feel unnecessarily verbose.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected parameter delimiter in function declarations: parameters are now separated by commas (`,`) instead of semicolons (`;`). Using semicolons as separators will now result in an error message instructing to use commas.

- **Tests**
  - Updated all relevant test cases to use commas as parameter separators in function signatures for consistency with the new syntax rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->