### PR TITLE
Handling Inline Assembly Negative Values (issue #205)

### DIFF
--- a/front/parser/src/parser/parser.rs
+++ b/front/parser/src/parser/parser.rs
@@ -1110,6 +1110,19 @@ fn parse_asm_block(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
 
                 let value_token = tokens.next();
                 let value = match value_token {
+                    Some(Token { token_type: TokenType::Minus, .. }) => {
+                        match tokens.next() {
+                            Some(Token { token_type: TokenType::Number(n), .. }) => format!("-{}", n),
+                            Some(other) => {
+                                println!("Expected number after '-', got {:?}", other.token_type);
+                                return None;
+                            }
+                            None => {
+                                println!("Expected number after '-'");
+                                return None;
+                            }
+                        }
+                    }
                     Some(Token { token_type: TokenType::Identifier(s), .. }) => s.clone(),
                     Some(Token { token_type: TokenType::Number(n), .. }) => n.to_string(),
                     Some(Token { token_type: TokenType::String(n), .. }) => n.to_string(),

--- a/llvm_temporary/src/llvm_temporary/expression.rs
+++ b/llvm_temporary/src/llvm_temporary/expression.rs
@@ -56,6 +56,12 @@ pub fn generate_expression_ir<'ctx>(
         },
 
         Expression::Variable(var_name) => {
+            if var_name == "true" {
+                return context.bool_type().const_int(1, false).as_basic_value_enum();
+            } else if var_name == "false" {
+                return context.bool_type().const_int(0, false).as_basic_value_enum();
+            }
+
             if let Some(var_info) = variables.get(var_name) {
                 let var_type = var_info.ptr.get_type().get_element_type();
 
@@ -440,10 +446,9 @@ pub fn generate_expression_ir<'ctx>(
                 }
 
                 let val: BasicMetadataValueEnum = if let Ok(value) = var.parse::<i64>() {
-                    context.i64_type().const_int(value as u64, false).into()
+                    context.i64_type().const_int(value as u64, value < 0).into()
                 } else {
-                    let info = variables
-                        .get(var)
+                    let info = variables.get(var)
                         .unwrap_or_else(|| panic!("Input variable '{}' not found", var));
                     builder.build_load(info.ptr, var).unwrap().into()
                 };

--- a/llvm_temporary/src/llvm_temporary/llvm_codegen.rs
+++ b/llvm_temporary/src/llvm_temporary/llvm_codegen.rs
@@ -16,6 +16,7 @@ pub unsafe fn generate_ir(ast_nodes: &[ASTNode]) -> String {
         let builder = Box::leak(Box::new(context.create_builder()));
         let mut functions: HashMap<String, FunctionValue> = HashMap::new();
 
+
         for ast in ast_nodes {
             if let ASTNode::Function(FunctionNode { name, parameters, return_type, .. }) = ast {
                 let param_types: Vec<BasicMetadataTypeEnum> = parameters.iter()
@@ -25,12 +26,7 @@ pub unsafe fn generate_ir(ast_nodes: &[ASTNode]) -> String {
                 let fn_type = match return_type {
                     Some(wave_ret_ty) => {
                         let llvm_ret_type = wave_type_to_llvm_type(&context, wave_ret_ty);
-                        match llvm_ret_type {
-                            BasicTypeEnum::IntType(int_ty) => int_ty.fn_type(&param_types, false),
-                            BasicTypeEnum::FloatType(float_ty) => float_ty.fn_type(&param_types, false),
-                            BasicTypeEnum::PointerType(ptr_ty) => ptr_ty.fn_type(&param_types, false),
-                            _ => panic!("Unsupported return type"),
-                        }
+                        llvm_ret_type.fn_type(&param_types, false)
                     }
                     None => context.void_type().fn_type(&param_types, false),
                 };
@@ -94,6 +90,7 @@ pub unsafe fn generate_ir(ast_nodes: &[ASTNode]) -> String {
                         VariableInfo {
                             ptr: alloca,
                             mutability: Mutability::Let,
+                            ty: param.param_type.clone(),
                         },
                     );
                 }
@@ -224,6 +221,7 @@ pub fn generate_address_ir<'ctx>(
 pub struct VariableInfo<'ctx> {
     pub ptr: PointerValue<'ctx>,
     pub mutability: Mutability,
+    pub ty: WaveType,
 }
 
 pub fn get_llvm_type<'a>(context: &'a Context, ty: &TokenType) -> BasicTypeEnum<'a> {

--- a/test/test49.wave
+++ b/test/test49.wave
@@ -1,0 +1,15 @@
+fun main() {
+    var dummy_ptr: ptr<i8> = "dummy";
+    var ret_val: i64;
+
+    asm {
+        "mov rax, 257" // syscall openat
+        "syscall"
+        in("rdi") -100
+        in("rsi") dummy_ptr
+        in("rdx") 0
+        out("rax") ret_val
+    }
+
+    println("syscall result: {}", ret_val);
+}


### PR DESCRIPTION
### Summary

This PR fixes a parsing issue where negative literals (e.g., `-1`) were not accepted as operands in inline assembly `in(...)` expressions.

---

### Problem
Wave currently fails to parse negative numeric literals in `asm` blocks:

```wave
asm {
    ...
    in("r8") -1  // ❌ Fails to parse
}
```

Error Message:

```text
error: Expected identifier or number after in/out(...), got Minus
--> main.wave:9
    in("r8") -1
             ^
```

This prevents valid use cases like `mmap(..., fd=-1, ...)` which are common in system-level programming.

### Solution
- Updated the `parse_asm_operand()` logic to allow unary minus expressions.

- Modified parser to accept both positive and negative literals in `in(...)` and `out(...)` clauses.

---

### Test Case
Added regression test `test/test49.wave`:

```wave
fun main() {
    var dummy_ptr: ptr<i8> = "dummy";
    var ret_val: i64;

    asm {
        "mov rax, 257" // syscall openat
        "syscall"
        in("rdi") -100
        in("rsi") dummy_ptr
        in("rdx") 0
        out("rax") ret_val
    }

    println("syscall result: {}", ret_val);
}
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for negative numeric literals in inline assembly input/output declarations.
  * Introduced explicit handling for boolean literals (`true`, `false`) in expressions.
  * Enhanced type-aware handling for variables, inline assembly outputs, and return values, improving correctness in type casting and storage.
  * Added a new test demonstrating inline assembly for system calls and pointer handling.

* **Bug Fixes**
  * Corrected sign handling for integer constants in inline assembly, ensuring negative values are properly represented.

* **Refactor**
  * Simplified LLVM function type construction and improved variable type tracking for better type management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->