### PR TITLE
Troubleshooting if statement bugs in paser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavec"
-version = "0.1.3-pre-beta-nightly-2025-07-06"
+version = "0.1.3-pre-beta-nightly-2025-07-11"
 edition = "2021"
 
 # [target.x86_64-apple-darwin]

--- a/front/lexer/src/lexer/token.rs
+++ b/front/lexer/src/lexer/token.rs
@@ -163,4 +163,5 @@ pub enum TokenType {
     Break,
     Arrow,                  // ->
     Array,
+    Newline,
 }

--- a/front/parser/src/parser/ast.rs
+++ b/front/parser/src/parser/ast.rs
@@ -138,7 +138,7 @@ pub enum StatementNode {
     If {
         condition: Expression,
         body: Vec<ASTNode>,
-        else_if_blocks: Option<Box<Vec<ASTNode>>>,
+        else_if_blocks: Option<Box<Vec<(Expression, Vec<ASTNode>)>>>,
         else_block: Option<Box<Vec<ASTNode>>>,
     },
     For {

--- a/front/parser/src/parser/format.rs
+++ b/front/parser/src/parser/format.rs
@@ -449,6 +449,8 @@ where
                 TokenType::Continue | TokenType::Break | TokenType::Return | TokenType::SemiColon => None,
                 _ => {
                     println!("Error: Expected primary expression, found {:?}", token.token_type);
+                    println!("Error: Expected primary expression, found {:?}", token.lexeme);
+                    println!("Error: Expected primary expression, found {:?}", token.line);
                     None
                 }
             }


### PR DESCRIPTION
I made a new if door parser and block parser, and I moved the existing block parser to statements and repackaged it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing newline tokens in the lexer.
  * Improved parser handling for if-else statements, now supporting explicit else-if branches with associated conditions and bodies.

* **Bug Fixes**
  * Enforced semicolon requirements after variable declarations and print statements, providing clearer error messages when missing.
  * Enhanced error diagnostics for unexpected tokens during parsing.

* **Refactor**
  * Modularized statement and block parsing for better maintainability and error handling.
  * Reworked internal control flow for if-else and else-if statements to ensure correct execution order.

* **Chores**
  * Updated version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->