### PR TITLE
Cambiar la estructura de import

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavec"
-version = "0.1.3-pre-beta-nightly-2025-07-11"
+version = "0.1.3-pre-beta"
 edition = "2021"
 
 # [target.x86_64-apple-darwin]

--- a/front/parser/src/parser/import.rs
+++ b/front/parser/src/parser/import.rs
@@ -1,26 +1,91 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use error::error::{WaveError, WaveErrorKind};
 use crate::ast::ASTNode;
 use crate::parse;
 use lexer::Lexer;
 
-pub fn local_import(path: &str, already_imported: &mut HashSet<String>, base_dir: &Path) -> Option<Vec<ASTNode>> {
-    if already_imported.contains(path) {
-        return Some(vec![]);
+pub fn local_import(
+    path: &str,
+    already_imported: &mut HashSet<String>,
+    base_dir: &Path,
+) -> Result<Vec<ASTNode>, WaveError> {
+    if path.trim().is_empty() {
+        return Err(WaveError::new(
+            WaveErrorKind::SyntaxError("Empty import path".to_string()),
+            "import path cannot be empty",
+            "<main>",
+            0,
+            0,
+        ));
     }
 
-    already_imported.insert(path.to_string());
+    let target_file_name = if path.ends_with(".wave") {
+        path.to_string()
+    } else {
+        format!("{}.wave", path)
+    };
 
-    let target_file_name = format!("{}.wave", path);
+    let found_path = base_dir.join(&target_file_name);
+    if !found_path.exists() || !found_path.is_file() {
+        return Err(WaveError::new(
+            WaveErrorKind::SyntaxError("File not found".to_string()),
+            format!("Could not find import target '{}'", target_file_name),
+            target_file_name.clone(),
+            0,
+            0,
+        ));
+    }
 
-    let found_path = find_wave_file_recursive(base_dir, &target_file_name)?;
+    let abs_path = found_path.canonicalize().map_err(|e| {
+        WaveError::new(
+            WaveErrorKind::SyntaxError("Canonicalization failed".to_string()),
+            format!("Failed to canonicalize path: {}", e),
+            target_file_name.clone(),
+            0,
+            0,
+        )
+    })?;
+    let abs_path_str = abs_path.to_str().ok_or_else(|| {
+        WaveError::new(
+            WaveErrorKind::UnexpectedChar('?'),
+            "Invalid path encoding",
+            target_file_name.clone(),
+            0,
+            0,
+        )
+    })?.to_string();
 
-    let content = std::fs::read_to_string(&found_path).ok()?;
+    if already_imported.contains(&abs_path_str) {
+        return Ok(vec![]);
+    }
+    already_imported.insert(abs_path_str);
+
+    let content = std::fs::read_to_string(&found_path).map_err(|e| {
+        WaveError::new(
+            WaveErrorKind::SyntaxError("Read error".to_string()),
+            format!("Failed to read '{}': {}", target_file_name, e),
+            target_file_name.clone(),
+            0,
+            0,
+        )
+    })?;
+
     let mut lexer = Lexer::new(&content);
     let tokens = lexer.tokenize();
-    let ast = parse(&tokens)?;
 
-    Some(ast)
+    let ast = parse(&tokens).ok_or_else(|| {
+        WaveError::new(
+            WaveErrorKind::SyntaxError("Parse failed".to_string()),
+            format!("Failed to parse '{}'", target_file_name),
+            target_file_name.clone(),
+            1,
+            1,
+        ).with_source(content.lines().nth(0).unwrap_or("").to_string())
+            .with_label("here".to_string())
+    })?;
+
+    Ok(ast)
 }
 
 fn find_wave_file_recursive(dir: &Path, target_file_name: &str) -> Option<PathBuf> {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -28,11 +28,14 @@ pub(crate) unsafe fn run_wave_file(file_path: &Path) {
     for node in &ast {
         if let ASTNode::Statement(StatementNode::Import(path)) = node {
             if !path.starts_with("std::") {
-                if let Some(mut imported_nodes) = local_import(&path, &mut already_imported, &base_dir) {
-                    extended_ast.append(&mut imported_nodes);
-                } else {
-                    eprintln!("❌ Failed to import '{}'", path);
-                    process::exit(1);
+                match local_import(&path, &mut already_imported, &base_dir) {
+                    Ok(mut imported_nodes) => {
+                        extended_ast.append(&mut imported_nodes);
+                    }
+                    Err(err) => {
+                        err.display();
+                        process::exit(1);
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
Added directory support from local import, including error message improvement.

* `import("math");` -> `project_root/math.wave`
* `import("math/math")` -> `project_root/math/math.wave`

Error Message Example:

```
error: Could not find import target 'math.wave'
  --> math.wave:0:0
   |
   | (source unavailable)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling for local module imports, providing more detailed diagnostic messages for import failures.

* **Style**
  * Simplified the version tag format in the application metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->