### PR TITLE
Show current operating system in version command

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod version;
 
 use std::path::Path;
 use colorex::Colorize;
+use crate::version::get_os_pretty_name;
 
 pub unsafe fn compile_and_run(path: &Path) {
     runner::run_wave_file(path);
@@ -13,5 +14,10 @@ pub unsafe fn compile_and_img(path: &Path) {
 }
 
 pub fn version_wave() {
-    println!("{} {}", "wavec".color("2,161,47"), version::version().color("2,161,47"));
+    let os = format!("({})", get_os_pretty_name()).color("117,117,117");
+
+    println!("{} {} {}",
+             "wavec".color("2,161,47"),
+             version::version().color("2,161,47"),
+             os);
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,6 +1,64 @@
+use std::fs;
+use std::process::Command;
+
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub(crate) fn version() -> &'static str {
     let version = VERSION;
     version.into()
+}
+
+pub fn get_os_pretty_name() -> String {
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(content) = fs::read_to_string("/etc/os-release") {
+            for line in content.lines() {
+                if line.starts_with("PRETTY_NAME=") {
+                    return line
+                        .trim_start_matches("PRETTY_NAME=")
+                        .trim_matches('"')
+                        .to_string();
+                }
+            }
+        }
+
+        // fallback to uname
+        if let Ok(output) = Command::new("uname").arg("-sr").output() {
+            let text = String::from_utf8_lossy(&output.stdout);
+            return format!("Linux ({})", text.trim());
+        }
+
+        return "Linux (unknown version)".to_string();
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(output) = Command::new("cmd")
+            .args(["/C", "ver"])
+            .output()
+        {
+            let text = String::from_utf8_lossy(&output.stdout);
+            return format!("Windows {}", text.trim());
+        }
+
+        return "Windows (unknown version)".to_string();
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(output) = Command::new("sw_vers")
+            .arg("-productVersion")
+            .output()
+        {
+            let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            return format!("macOS {}", version);
+        }
+
+        return "macOS (unknown version)".to_string();
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+    {
+        return std::env::consts::OS.to_string();
+    }
 }


### PR DESCRIPTION
Displays the current operating system in the version command.

<img width="780" height="47" alt="image" src="https://github.com/user-attachments/assets/fb7a25f7-d35f-403a-927e-734c76485523" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The application now displays the operating system's name and version alongside its own version information, providing clearer context about the environment in which it is running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->