### PR TITLE
feat(compiler): enforce Vex integration check for std/external imports

### DIFF
--- a/front/parser/src/parser/stdlib.rs
+++ b/front/parser/src/parser/stdlib.rs
@@ -95,6 +95,29 @@ impl StdlibManager {
         println!("Note: Linking info for '{}' will be provided by Vex", module_name);
         None
     }
+
+    pub fn ensure_enabled(&self) -> Result<(), WaveError> {
+        if !self.vex_integration_enabled {
+            return Err(WaveError::new(
+                WaveErrorKind::SyntaxError("Standard library not available".to_string()),
+                "Use --with-vex to enable std/external imports.",
+                "<manifest>",
+                0,
+                0,
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn ensure_declared_in_manifest(&self, module: &str) -> Result<(), WaveError> {
+        println!("Checking if '{}' is declared in vex.ws", module);
+        Ok(())
+    }
+
+    pub fn ensure_resolved(&self, module: &str) -> Result<(), WaveError> {
+        println!("Checking if '{}' is resolved by Vex", module);
+        Ok(())
+    }
 }
 
 /// Interface for communication with Vex package manager


### PR DESCRIPTION
## Changes

- **Enforced strict Vex integration checks** when importing standard library modules (`std::`) or external libraries.
- In **standalone mode** (`--with-vex` not used), attempting to import import(`"std::<Name>"`); or any external library now immediately triggers a compilation error.
- Even when `--with-vex` is used, the compiler currently raises an error because Vex is not yet implemented; once Vex integration is complete, this path will allow successful imports.
- Added the following methods to `StdlibManager`:
  - `ensure_enabled()` – Checks if Vex integration is enabled.
  - `ensure_declared_in_manifest()` – Checks if the module is declared in `vex.ws` (currently TODO).
  - `ensure_resolved()` – Checks if the module exists via Vex (currently TODO).
- Updated `handle_std_import` and `external_import` in `import.rs` to call these validation methods.

---

## Behavior Changes

| Mode           | Previous Behavior                                       | New Behavior                                                                 |
| -------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------- |
| Standalone     | Ignored std/external imports and continued build         | Immediate compilation error                                                   |
| Vex Integration| (No implementation) Ignored imports and continued build  | Checks via Vex, errors if missing, passes if found (future)                   |


---

## Example

### Standalone Mode

```kotlin
import("std::iosys");

fun main() {
    println("test");
}
```

```css
error: standard library module 'std::iosys' requires Vex package manager
  --> std::iosys:0:0
   = help: Wave compiler in standalone mode only supports low-level system programming
```

### Vex Integration Mode (`--with-vex`)

```css
Note: Standard library definitions will be loaded from Vex package manager
error: standard library module 'std::iosys' requires Vex package manager
  --> std::iosys:0:0
```

(Currently fails because Vex is not yet implemented)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced stricter validation for standard library and external imports, ensuring proper checks before importing modules.
  * Added new error messages for missing or disabled standard library integrations.

* **Refactor**
  * Updated internal logic to enforce the use of a manager for import validation, replacing previous placeholder handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->