### PR TITLE
feat: Add Global `const` Support and CLI Verbose Output Control

### DIFF
--- a/front/parser/src/parser/ast.rs
+++ b/front/parser/src/parser/ast.rs
@@ -196,7 +196,7 @@ pub enum StatementNode {
     Expression(Expression),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Mutability {
     Var,
     Let,

--- a/src/compiler_config.rs
+++ b/src/compiler_config.rs
@@ -27,6 +27,8 @@ pub struct CompilerConfig {
     
     /// Project root directory
     pub project_root: PathBuf,
+
+    pub show_info: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -49,7 +51,13 @@ impl CompilerConfig {
             optimization_level: OptimizationLevel::None,
             vex_binary_path: None,
             project_root: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            show_info: cfg!(debug_assertions),
         }
+    }
+
+    pub fn with_info(mut self, show: bool) -> Self {
+        self.show_info = show;
+        self
     }
 
     /// Configure for Vex integration mode
@@ -137,6 +145,10 @@ impl CompilerConfig {
 
     /// Print compilation information
     pub fn print_info(&self) {
+        if !self.show_info {
+            return;
+        }
+
         println!("Wave Compiler Configuration:");
         println!("  Mode: {}", if self.vex_integration { "Vex Integration" } else { "Standalone (Low-level)" });
         println!("  Source files: {}", self.source_files.len());

--- a/test/test59.wave
+++ b/test/test59.wave
@@ -1,0 +1,5 @@
+const MAX :i32 = 10;
+
+fun main() {
+    println("{}", MAX);
+}


### PR DESCRIPTION
This PR introduces two major improvements to the Wave compiler:

1. **Global `const` Support**: You can now define compile-time constants in the global scope. This improves code readability, removes magic numbers, and allows the compiler to inline constant values directly into the code for better optimization.

2. **CLI Verbose Output Control**: A new `--verbose` / `-v` flag has been added to control compiler configuration output messages. This ensures that release builds produce clean, minimal output by default, while allowing detailed logs to be enabled for debugging, improving the overall user experience.

### Key Changes

1. Codegen: Implemented `const` Support
* Added Global Constant Handling (`llvm_codegen.rs`):
   * Before generating function code, the AST is scanned for variables declared with Mutability::Const.
  * These constants are stored in a `global_consts: HashMap<String, BasicValueEnum>` with their names and LLVM constant values.
* Modified Constant Reference Logic (`expression.rs`):
  * When processing `Expression::Variable`, the compiler now checks the `global_consts` map before looking up local variables in the variables map.
  * If a match is found, the LLVM constant value is returned directly instead of performing a memory `load`, enabling true compile-time inlining.
* Updated Function Signatures:
  * The `generate_statement_ir` and `generate_expression_ir` functions now take a `&HashMap` reference to share the `global_consts` map.

2. CLI: Verbose Output Control
* Added Configuration Flag (`compiler_config.rs`):
  * Added a `show_info: bool` field to the `CompilerConfig` struct to control informational output.
  * Defaults are set using `cfg!(debug_assertions)`: `true` in debug builds, `false` in release builds.
  * Added a `with_info(bool)` method to allow external control of this setting.
* Improved Command-Line Argument Parsing (main.rs):
  * Detects `--verbose` or `-v` at runtime and updates `show_info` accordingly.
  * Changed parsing logic to collect `env::args()` into a `Vec<String>` before processing, ensuring flags are parsed reliably regardless of their position.

### Testing

Testing `const` Support

1. Create a test file (`test.wave`):

```kotlin
const MAX: i32 = 10;
const PI: f64 = 3.14;

fun main() {
    println("MAX is: {}", MAX);
    println("PI is: {}", PI);
}
```

Compile and run:

```
cargo run -- run test.wave
```

Expected output:

```
MAX is: 10
PI is: 3.14
```

Testing CLI Verbose Output

1. Release Mode (quiet by default)

```
# Should print only program output, no extra info
cargo run --release -- run test.wave

# With --verbose, should print detailed info messages
cargo run --release -- run test.wave --verbose
```

2. Debug Mode (verbose by default)

```
 # Should print detailed info messages by default
cargo run -- run test.wave
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for global constant variables, allowing constants to be declared and referenced throughout the code.
  * Introduced a verbose mode (`-v`/`--verbose` flag) for the compiler, enabling optional display of compilation information.
* **Improvements**
  * Updated help message to document the new verbose flag.
* **Tests**
  * Added a new test demonstrating the use of global constants in code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->