### PR TITLE
Fix inline asm rax handling and array pointer type mismatch

### DIFF
--- a/front/parser/src/parser/parser.rs
+++ b/front/parser/src/parser/parser.rs
@@ -1287,6 +1287,19 @@ fn parse_asm_block(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
                             }
                         }
                     }
+                    Some(Token { token_type: TokenType::AddressOf, .. }) => {
+                        match tokens.next() {
+                            Some(Token { token_type: TokenType::Identifier(s), .. }) => format!("&{}", s),
+                            Some(other) => {
+                                println!("Expected identifier after '&', got {:?}", other.token_type);
+                                return None;
+                            }
+                            None => {
+                                println!("Expected identifier after '&'");
+                                return None;
+                            }
+                        }
+                    },
                     Some(Token { token_type: TokenType::Identifier(s), .. }) => s.clone(),
                     Some(Token { token_type: TokenType::Number(n), .. }) => n.to_string(),
                     Some(Token { token_type: TokenType::String(n), .. }) => n.to_string(),

--- a/llvm_temporary/src/llvm_temporary/statement.rs
+++ b/llvm_temporary/src/llvm_temporary/statement.rs
@@ -605,7 +605,9 @@ pub fn generate_statement_ir<'ctx>(
 
             for (reg, var) in inputs {
                 if !seen_regs.insert(reg.to_string()) {
-                    panic!("Register '{}' duplicated in inputs", reg);
+                    if reg != "rax" {
+                        panic!("Register '{}' duplicated in inputs", reg);
+                    }
                 }
 
                 let clean_var = if var.starts_with('&') {

--- a/llvm_temporary/src/llvm_temporary/statement.rs
+++ b/llvm_temporary/src/llvm_temporary/statement.rs
@@ -594,7 +594,7 @@ pub fn generate_statement_ir<'ctx>(
             let mut seen_regs: HashSet<String> = HashSet::new();
 
             for (reg, var) in outputs {
-                if input_regs.contains(reg) {
+                if input_regs.contains(reg) && reg != "rax" {
                     panic!("Register '{}' used in both input and output", reg);
                 }
                 if !seen_regs.insert(reg.to_string()) {
@@ -608,16 +608,38 @@ pub fn generate_statement_ir<'ctx>(
                     panic!("Register '{}' duplicated in inputs", reg);
                 }
 
-                let val: BasicMetadataValueEnum = if let Ok(value) = var.parse::<i64>() {
-                    context.i64_type().const_int(value as u64, value < 0).into()
+                let clean_var = if var.starts_with('&') {
+                    &var[1..]
                 } else {
-                    let info = variables.get(var)
-                        .unwrap_or_else(|| panic!("Input variable '{}' not found", var));
-                    builder.build_load(info.ptr, var).unwrap().into()
+                    var.as_str()
                 };
 
+                let val: BasicMetadataValueEnum =
+                    if let Ok(value) = var.parse::<i64>() {
+                        context.i64_type().const_int(value as u64, value < 0).into()
+                    } else if let Some(const_val) = global_consts.get(var) {
+                        (*const_val).into()
+                    } else {
+                        let info = variables.get(clean_var)
+                            .unwrap_or_else(|| panic!("Input variable '{}' not found", clean_var));
+
+                        if var.starts_with('&') {
+                            let ptr_val = builder
+                                .build_bit_cast(
+                                    info.ptr,
+                                    context.i8_type().ptr_type(AddressSpace::from(0)),
+                                    "addr_ptr",
+                                )
+                                .unwrap()
+                                .into();
+                            ptr_val
+                        } else {
+                            builder.build_load(info.ptr, var).unwrap().into()
+                        }
+                    };
+
                 operand_vals.push(val);
-                constraint_parts.push(format!("{{{}}}", reg)); // {rdi}
+                constraint_parts.push(format!("{{{}}}", reg));
             }
 
             let constraints_str = constraint_parts.join(",");

--- a/test/test61.wave
+++ b/test/test61.wave
@@ -30,7 +30,6 @@ fun main() {
     }
     println("bind ret = {}", ret);
 
-    // 3. recvfrom 준비
     var buf: array<i8, 128>;
     var src: array<i8, 16>;
     var srclen: i64 = 16;
@@ -43,8 +42,9 @@ fun main() {
         in("rdi") sockfd
         in("rsi") &buf
         in("rdx") 128
-        in("r10") &src
-        in("r8")  &srclen
+        in("rcx") 0        // flags = 0 (blocking mod)
+        in("r8")  &src
+        in("r9")  &srclen
     }
 
     println("recvfrom got {} bytes", n);

--- a/test/test62.wave
+++ b/test/test62.wave
@@ -5,7 +5,7 @@ const SYS_BIND: i64 = 49;
 const SYS_RECVFROM: i64 = 45;
 const SYS_WRITE: i64 = 1;
 
-fun do_recv(sockfd: i64, buf: ptr<i8>, src: ptr<i8>, srclen: ptr<i64>) -> i64 {
+fun do_recv(sockfd: i64, buf: ptr<array<i8, 128>>, src: ptr<array<i8, 16>>, srclen: ptr<i64>) -> i64 {
     var n: i64;
     asm {
         "syscall"

--- a/test/test62.wave
+++ b/test/test62.wave
@@ -5,12 +5,27 @@ const SYS_BIND: i64 = 49;
 const SYS_RECVFROM: i64 = 45;
 const SYS_WRITE: i64 = 1;
 
+fun do_recv(sockfd: i64, buf: ptr<i8>, src: ptr<i8>, srclen: ptr<i64>) -> i64 {
+    var n: i64;
+    asm {
+        "syscall"
+        out("rax") n
+        in("rax") SYS_RECVFROM
+        in("rdi") sockfd
+        in("rsi") buf
+        in("rdx") 128
+        in("r10") src
+        in("r8")  srclen
+    }
+    return n;
+}
+
 fun main() {
     var sockfd: i64;
     asm {
-        "mov rax, 41"      // SYS_SOCKET
         "syscall"
         out("rax") sockfd
+        in("rax") SYS_SOCKET
         in("rdi") AF_INET
         in("rsi") SOCK_DGRAM
         in("rdx") 0
@@ -21,39 +36,36 @@ fun main() {
 
     var ret: i64;
     asm {
-        "mov rax, 49"      // SYS_BIND
         "syscall"
         out("rax") ret
+        in("rax") SYS_BIND
         in("rdi") sockfd
         in("rsi") &addr
         in("rdx") 16
     }
     println("bind ret = {}", ret);
 
-    // 3. recvfrom 준비
     var buf: array<i8, 128>;
     var src: array<i8, 16>;
     var srclen: i64 = 16;
 
-    var n: i64;
-    asm {
-        "mov rax, 45"      // SYS_RECVFROM
-        "syscall"
-        out("rax") n
-        in("rdi") sockfd
-        in("rsi") &buf
-        in("rdx") 128
-        in("r10") &src
-        in("r8")  &srclen
+    var n: i64 = 0;
+
+    while (n == 0) {
+        n = do_recv(sockfd, &buf, &src, &srclen);
+
+        if (n < 0) {
+            println("recvfrom error {}", n);
+        }
     }
 
     println("recvfrom got {} bytes", n);
 
     var ret2: i64;
     asm {
-        "mov rax, 1"       // SYS_WRITE
         "syscall"
         out("rax") ret2
+        in("rax") SYS_WRITE
         in("rdi") 1
         in("rsi") &buf
         in("rdx") n


### PR DESCRIPTION
This PR addresses two issues in the Wave compiler:

1. Inline asm `rax` handling
- Previously, using `rax` as both input (syscall number) and output (return value) caused a duplicate register error.
- Now `rax` can safely be used in both roles, matching the Linux syscall convention.

2. Array pointer type mismatch
- Passing array references like `[128 x i8]*` to functions expecting `i8*` caused type errors.
- Added pointer decay/casting so arrays can be passed as raw pointers (`i8*`) automatically.

## Result

- Syscall examples using `rax` now compile and run correctly.
- Functions such as `do_recv` can accept array references without type errors.