### PR TITLE
Add Error Handle Runner File

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 colorex = "0.1.0"
 lexer = { path = "front/lexer" }
 parser = { path = "front/parser" }
+error = { path = "front/error" }
 llvm_temporary = { path = "./llvm_temporary" }
 
 [workspace]

--- a/front/error/src/lib.rs
+++ b/front/error/src/lib.rs
@@ -1,3 +1,3 @@
 pub mod error;
 
-use error::*;
+pub use error::*;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -7,14 +7,42 @@ use llvm_temporary::llvm_temporary::llvm_codegen::*;
 use ::parser::*;
 use ::parser::ast::{ASTNode, StatementNode};
 use ::parser::import::local_import;
+use ::error::*;
 
 pub(crate) unsafe fn run_wave_file(file_path: &Path) {
-    let code = fs::read_to_string(file_path).expect("Failed to read file");
+    let code = match fs::read_to_string(file_path) {
+        Ok(c) => c,
+        Err(_) => {
+            let err = WaveError::new(
+                WaveErrorKind::FileReadError(file_path.display().to_string()),
+                format!("failed to read file `{}`", file_path.display()),
+                file_path.display().to_string(),
+                0,
+                0,
+            )
+                .with_help("check if the file exists and you have permission to read it");
+            err.display();
+            process::exit(1);
+        }
+    };
 
     let mut lexer = Lexer::new(&code);
     let tokens = lexer.tokenize();
 
-    let mut ast = parse(&tokens).expect("Failed to parse Wave code");
+    let mut ast = match parse(&tokens) {
+        Some(ast) => ast,
+        None => {
+            let err = WaveError::new(
+                WaveErrorKind::SyntaxError("failed to parse Wave code".to_string()),
+                "failed to parse Wave code",
+                file_path.display().to_string(),
+                0,
+                0,
+            );
+            err.display();
+            process::exit(1);
+        }
+    };
 
     let file_path = Path::new(file_path);
     let base_dir = file_path.canonicalize()
@@ -43,24 +71,38 @@ pub(crate) unsafe fn run_wave_file(file_path: &Path) {
 
     ast = extended_ast;
 
-    // println!("{}\n", code);
-    // println!("AST:\n{:#?}", ast);
-
     let ir = generate_ir(&ast);
+
     let path = Path::new(file_path);
     let file_stem = path.file_stem().unwrap().to_str().unwrap();
-    let machine_code_path = compile_ir_to_machine_code(&ir, file_stem);
-
+    let machine_code_path = compile_ir_to_machine_code(&ir, file_stem); // 이것도 그냥 String
     if machine_code_path.is_empty() {
-        eprintln!("Failed to generate machine code");
+        let err = WaveError::new(
+            WaveErrorKind::CompilationFailed("empty machine code path".to_string()),
+            "failed to generate machine code",
+            file_path.display().to_string(),
+            0,
+            0,
+        );
+        err.display();
         return;
     }
 
-    let output = Command::new(machine_code_path)
-        .output()
-        .expect("Failed to execute machine code");
+    let output = match Command::new(machine_code_path).output() {
+        Ok(out) => out,
+        Err(_) => {
+            let err = WaveError::new(
+                WaveErrorKind::LinkingFailed(file_path.display().to_string()),
+                "failed to execute generated machine code",
+                file_path.display().to_string(),
+                0,
+                0,
+            );
+            err.display();
+            return;
+        }
+    };
 
-    // println!("Generated LLVM IR:\n{}", ir);
     println!("{}", String::from_utf8_lossy(&output.stdout));
 }
 


### PR DESCRIPTION
Add Error Handle Runner File

```
Wave Compiler Configuration:
  Mode: Standalone (Low-level)
  Source files: 1
    1: test/test63.wave
  Output: <default>
  Debug mode: false
  Optimization: None
  Standard library: Not available (low-level mode)
❌ Failed to parse function
error: failed to parse Wave code
  --> test/test63.wave:0:0
   |
   |
```