### PR TITLE
bug: struct pasing

### DIFF
--- a/front/parser/src/parser/parser.rs
+++ b/front/parser/src/parser/parser.rs
@@ -1077,12 +1077,24 @@ fn parse_proto(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
                             tokens.next(); // consume ':'
 
                             let type_token = tokens.next();
-                            let wave_type = parse_type_from_token(type_token)?;
+                            let wave_type = parse_type_from_token(type_token.as_ref())?;
                             params.push((name, wave_type));
 
                             // ',' or ')'
-                            if tokens.peek()?.token_type == TokenType::Comma {
-                                tokens.next(); // consume ','
+                            match tokens.peek()?.token_type {
+                                TokenType::Comma => {
+                                    tokens.next(); // consume ','
+                                }
+                                TokenType::Rparen => {
+                                    // 그냥 루프에서 ')' 처리되도록 냅둠
+                                }
+                                _ => {
+                                    println!(
+                                        "Error: Expected ',' or ')' after param in proto method '{}'",
+                                        method_name
+                                    );
+                                    return None;
+                                }
                             }
                         }
 
@@ -1100,7 +1112,7 @@ fn parse_proto(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
                 tokens.next(); // consume '->'
 
                 let return_token = tokens.next();
-                let return_type = parse_type_from_token(return_token)?;
+                let return_type = parse_type_from_token(return_token.as_ref())?;
 
                 if tokens.peek()?.token_type != TokenType::SemiColon {
                     println!("Error: Expected ';' after proto method signature '{}'", method_name);
@@ -1185,7 +1197,7 @@ fn parse_struct(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
                     tokens.next();
 
                     let type_token = tokens.next();
-                    let wave_type = parse_type_from_token(type_token).or_else(|| {
+                    let wave_type = parse_type_from_token(type_token.as_ref()).or_else(|| {
                         if let Some(Token { token_type: TokenType::Identifier(id), .. }) = type_token {
                             Some(WaveType::Struct(id.clone()))
                         } else {

--- a/front/parser/src/parser/type_system.rs
+++ b/front/parser/src/parser/type_system.rs
@@ -112,7 +112,7 @@ pub fn validate_type(expected: &TokenType, actual: &TokenType) -> bool {
     }
 }
 
-pub fn parse_type_from_token(token_opt: Option<&Token>) -> Option<WaveType> {
+pub fn parse_type_from_token(token_opt: Option<&&Token>) -> Option<WaveType> {
     let token = token_opt?;
 
     match &token.token_type {

--- a/test/test52.wave
+++ b/test/test52.wave
@@ -6,5 +6,32 @@ proto Updatable {
     fun update(dt: f32) -> void;
 }
 
+struct Text {
+    content: str;
+
+    fun draw() {
+        println("Draw text {}", content);
+    }
+
+    fun update(dt: f32) {
+        println("Update text {} with dt={}", content, dt);
+    }
+}
+
+fun process_draw(items: array<Drawable, 1>) {
+    items[0].draw();
+}
+
+fun process_update(items: array<Updatable, 1>) {
+    items[0].update(0.016);
+}
+
 fun main() {
+    var t: Text = Text { content: "Hello Proto!" };
+
+    var drawable_list: array<Drawable, 1> = [t];
+    var updatable_list: array<Updatable, 1> = [t];
+
+    process_draw(drawable_list);
+    process_update(updatable_list);
 }

--- a/test/test52.wave
+++ b/test/test52.wave
@@ -6,32 +6,5 @@ proto Updatable {
     fun update(dt: f32) -> void;
 }
 
-struct Text {
-    content: str;
-
-    fun draw() {
-        println("Draw text {}", content);
-    }
-
-    fun update(dt: f32) {
-        println("Update text {} with dt={}", content, dt);
-    }
-}
-
-fun process_draw(items: array<Drawable, 1>) {
-    items[0].draw();
-}
-
-fun process_update(items: array<Updatable, 1>) {
-    items[0].update(0.016);
-}
-
 fun main() {
-    var t: Text = Text { content: "Hello Proto!" };
-
-    var drawable_list: array<Drawable, 1> = [t];
-    var updatable_list: array<Updatable, 1> = [t];
-
-    process_draw(drawable_list);
-    process_update(updatable_list);
 }

--- a/test/test63.wave
+++ b/test/test63.wave
@@ -1,0 +1,96 @@
+fun set_insert(visited: ptr<array<i32, 5>>, x: i32) {
+    deref visited[x] = 1;
+}
+
+fun set_contains(visited: ptr<array<i32, 5>>, x: i32) -> bool {
+    if (deref visited[x] == 1) {
+        return true;
+    }
+    return false;
+}
+
+struct Queue {
+    data: array<i32, 10>;
+    front: i32;
+    rear: i32;
+}
+
+fun queue_new() -> Queue {
+    var q: Queue;
+    q.front = 0;
+    q.rear = 0;
+    return q;
+}
+
+fun queue_push(q: ptr<Queue>, x: i32) {
+    deref q.data[deref q.rear] = x;
+    deref q.rear += 1;
+}
+
+fun queue_pop(q: ptr<Queue>) -> i32 {
+    var x: i32 = deref q.data[deref q.front];
+    deref q.front += 1;
+    return x;
+}
+
+fun queue_empty(q: ptr<Queue>) -> bool {
+    if (deref q.front >= deref q.rear) {
+        return true;
+    }
+    return false;
+}
+
+// DFS
+fun dfs(v: i32, graph: array<array<i32, 5>, 5>, visited: ptr<array<i32, 5>>) {
+    set_insert(visited, v);
+    println("DFS visit {}", v);
+
+    var i: i32 = 0;
+    while (i < 5) {
+        if (graph[v][i] == 1 && !set_contains(visited, i)) {
+            dfs(i, graph, visited);
+        }
+        i += 1;
+    }
+}
+
+// BFS
+fun bfs(start: i32, graph: array<array<i32, 5>, 5>) {
+    var visited: array<i32, 5> = [0,0,0,0,0];
+    var q: Queue = queue_new();
+
+    set_insert(&visited, start);
+    queue_push(&q, start);
+
+    while (!queue_empty(&q)) {
+        var v: i32 = queue_pop(&q);
+        println("BFS visit {}", v);
+
+        var i: i32 = 0;
+        while (i < 5) {
+            if (graph[v][i] == 1 && !set_contains(&visited, i)) {
+                set_insert(&visited, i);
+                queue_push(&q, i);
+            }
+            i += 1;
+        }
+    }
+}
+
+fun main() {
+    var graph: array<array<i32, 5>, 5> = [
+        [0,1,1,0,0],
+        [1,0,0,1,0],
+        [1,0,0,0,1],
+        [0,1,0,0,0],
+        [0,0,1,0,0]
+    ];
+
+    var visited: array<i32, 5> = [0,0,0,0,0];
+
+    println("=== DFS ===");
+    dfs(0, graph, &visited);
+
+    println("=== BFS ===");
+    bfs(0, graph);
+}


### PR DESCRIPTION
- proto Drawable { fun draw() -> void; }: Well parsed.

- proto Updatable { fun update(dt: f32) -> void; }: Failed to parse.

- The reason is that parameter list parsing in fun partial logic does not handle dt:f32 case properly.

- Fix path_type_from_token signature

- It should be in form, but should be passed to token.next(.).as_ref() when calling.