### PR TITLE
Fix: Skip host LLVM detection during cross-compilation

### DIFF
--- a/llvm_temporary/build.rs
+++ b/llvm_temporary/build.rs
@@ -5,6 +5,12 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     let target = env::var("TARGET").unwrap();
+    let host = env::var("HOST").unwrap();
+
+    if target != host {
+        println!("cargo:warning=Cross compilation detected; skipping LLVM detection");
+        return;
+    }
 
     if target.contains("apple-darwin") {
         try_macos_paths();


### PR DESCRIPTION
This PR resolves build failures encountered during cross-compilation (e.g., building Windows binaries on a Linux host) by preventing the build script from linking against the host's system libraries.

### Problem
The `build.rs` script executes on the **host** machine during the build process. Previously, it would detect the host's system LLVM libraries (e.g., `/usr/lib/llvm-14` on Linux) and instruct Cargo to link them into the **target** binary (e.g., a Windows `.exe`). This resulted in linker errors due to mismatched binary formats and architectures.

### Solution
- Added a check in `llvm_temporary/build.rs` to compare the `TARGET` and `HOST` environment variables.
- If `TARGET != HOST` (indicating cross-compilation), the script now prints a warning and skips the automatic system LLVM detection logic.
- This ensures that the cross-linker does not attempt to link against incompatible host libraries.