### PR TITLE
Add LLVM backend version reporting and improve help formatting

### DIFF
--- a/llvm_temporary/build.rs
+++ b/llvm_temporary/build.rs
@@ -27,6 +27,8 @@ fn linux_original() {
     println!("cargo:rustc-link-lib=llvm-14");
     println!("cargo:rustc-link-search=native=/usr/lib/llvm-14/lib");
 
+    println!("cargo:rustc-env=WAVE_LLVM_MAJOR=14");
+
     println!("cargo:rustc-link-lib=stdc++");
     println!("cargo:rustc-link-lib=ffi");
     println!("cargo:rustc-link-lib=z");
@@ -53,6 +55,7 @@ fn try_macos_paths() {
 }
 
 fn link_macos(prefix: PathBuf) {
+    println!("cargo:rustc-env=WAVE_LLVM_MAJOR=14");
     let lib = prefix.join("lib");
 
     println!("cargo:rustc-link-search=native={}", lib.display());
@@ -83,6 +86,7 @@ fn try_windows_paths() {
 }
 
 fn link_windows(prefix: PathBuf) {
+    println!("cargo:rustc-env=WAVE_LLVM_MAJOR=14");
     let lib = prefix.join("lib");
 
     println!("cargo:rustc-link-search=native={}", lib.display());

--- a/llvm_temporary/src/lib.rs
+++ b/llvm_temporary/src/lib.rs
@@ -1,1 +1,6 @@
 pub mod llvm_temporary;
+
+pub fn backend() -> Option<String> {
+    option_env!("WAVE_LLVM_MAJOR")
+        .map(|v| format!("LLVM {}", v))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use colorex::Colorize;
 use crate::version::get_os_pretty_name;
 
 use commands::DebugFlags;
+use llvm_temporary::backend;
 
 pub unsafe fn compile_and_run(path: &Path, opt_flag: &str, debug: &DebugFlags) {
     runner::run_wave_file(path, opt_flag, debug);
@@ -26,4 +27,10 @@ pub fn version_wave() {
         version::version().color("2,161,47"),
         os
     );
+
+    if let Some(backend) = backend() {
+        println!("  backend: {}", backend.color("117,117,117"));
+    } else {
+        println!("{}", "  backend: unknown backend".color("117,117,117"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,25 +85,80 @@ fn print_usage() {
 }
 
 fn print_help() {
-    println!("{}", "Wave Compiler — Commands & Options".color("145,161,2"));
+    println!("{}", "Wave Compiler".color("145,161,2"));
+    println!("{}", "Commands & Options");
     print_usage();
 
     println!("\nCommands:");
-    println!("  {}      {}", "run <file>".color("38,139,235"), "Execute Wave file");
-    println!("  {}    {}", "build <file>".color("38,139,235"), "Compile Wave file");
-    println!("  {}           {}", "--help".color("38,139,235"), "Show help");
-    println!("  {}       {}", "--version".color("38,139,235"), "Show version");
+    println!(
+        "  {:<18} {}",
+        "run <file>".color("38,139,235"),
+        "Execute Wave file"
+    );
+    println!(
+        "  {:<18} {}",
+        "build <file>".color("38,139,235"),
+        "Compile Wave file"
+    );
+    println!(
+        "  {:<18} {}",
+        "--help".color("38,139,235"),
+        "Show this help message"
+    );
+    println!(
+        "  {:<18} {}",
+        "--version".color("38,139,235"),
+        "Show compiler version"
+    );
 
     println!("\nOptimization:");
-    println!("  -O0, -O1, -O2, -O3, -Oz, -Ofast");
+    println!(
+        "  {:<18} {}",
+        "-O0 .. -O3".color("38,139,235"),
+        "Set optimization level"
+    );
+    println!(
+        "  {:<18} {}",
+        "-Oz".color("38,139,235"),
+        "Optimize for binary size"
+    );
+    println!(
+        "  {:<18} {}",
+        "-Ofast".color("38,139,235"),
+        "Enable aggressive optimizations"
+    );
 
     println!("\nDebug options:");
-    println!("  --debug-wave=tokens");
-    println!("  --debug-wave=ast");
-    println!("  --debug-wave=ir");
-    println!("  --debug-wave=mc");
-    println!("  --debug-wave=hex");
-    println!("  --debug-wave=all");
+    println!(
+        "  {:<22} {}",
+        "--debug-wave=tokens".color("38,139,235"),
+        "Print lexer tokens"
+    );
+    println!(
+        "  {:<22} {}",
+        "--debug-wave=ast".color("38,139,235"),
+        "Print AST"
+    );
+    println!(
+        "  {:<22} {}",
+        "--debug-wave=ir".color("38,139,235"),
+        "Print LLVM IR"
+    );
+    println!(
+        "  {:<22} {}",
+        "--debug-wave=mc".color("38,139,235"),
+        "Print machine code"
+    );
+    println!(
+        "  {:<22} {}",
+        "--debug-wave=hex".color("38,139,235"),
+        "Print raw hex output"
+    );
+    println!(
+        "  {:<22} {}",
+        "--debug-wave=all".color("38,139,235"),
+        "Enable all debug outputs"
+    );
 
     println!("\nExamples:");
     println!("  wavec run test.wave");


### PR DESCRIPTION
### Summary

This PR adds compile-time LLVM version detection and display in `--version` output, while improving help text readability with aligned column formatting.

### Changes

Backend Version Reporting

- Build-time LLVM version detection
  - Export `WAVE_LLVM_MAJOR=14` via `cargo:rustc-env` in platform-specific linkers:
    - Linux (linux_original)
    - macOS (link_macos)
    - Windows (link_windows)
- New `backend()` function in `llvm_temporary/lib.rs`
  - Retrieves `WAVE_LLVM_MAJOR` from compile-time environment
  - Returns formatted string `"LLVM {version}"` or `None` if unavailable
- Enhanced `--version` output
  - Calls `llvm_temporary::backend()` from `version_wave()`
  - Displays backend version with gray color formatting
  - Falls back to `"backend: unknown backend"` if unavailable

### Help Text Improvements

- Consistent column alignment in `print_help()`
  - Standardized column widths (`{:<18}`, `{:<22}`)
  - Added descriptive text for each command and option
- Better organization
  - Grouped related options (Commands, Optimization, Debug)
  - Expanded optimization flag descriptions (`-O0` through `-O3`, `-Oz`, `-Ofast`)
  - Clarified debug option purposes (tokens, AST, IR, MC, hex)
  - Maintained practical usage examples at bottom

### Example Output

```
wavec 0.1.5-pre-beta (Fedora Linux 43 (Workstation Edition))
  backend: LLVM 14
```