### PR TITLE
Feat: Implement Bitwise Operations and Unary Operators

### DIFF
--- a/front/lexer/src/lexer/lexer.rs
+++ b/front/lexer/src/lexer/lexer.rs
@@ -638,17 +638,17 @@ impl<'a> Lexer<'a> {
                             line: self.line,
                         }
                     },
-                    "rol" => {
+                    "<<" => {
                         Token {
                             token_type: TokenType::Rol,
-                            lexeme: "rol".to_string(),
+                            lexeme: "<<".to_string(),
                             line: self.line,
                         }
                     },
-                    "ror" => {
+                    ">>" => {
                         Token {
                             token_type: TokenType::Ror,
-                            lexeme: "ror".to_string(),
+                            lexeme: ">>".to_string(),
                             line: self.line,
                         }
                     },

--- a/front/parser/src/parser/ast.rs
+++ b/front/parser/src/parser/ast.rs
@@ -122,6 +122,10 @@ pub enum Expression {
         object: Box<Expression>,
         field: String,
     },
+    Unary {
+        operator: Operator,
+        expr: Box<Expression>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -149,6 +153,11 @@ pub enum Operator {
     LogicalOr,
     BitwiseOr,
     Assign,
+    ShiftLeft,              // <<
+    ShiftRight,             // >>
+    BitwiseXor,
+    LogicalNot,
+    BitwiseNot,
 }
 
 #[derive(Debug, Clone)]

--- a/test/test70.wave
+++ b/test/test70.wave
@@ -1,0 +1,53 @@
+fun main() {
+    var a: i32 = 10;
+    var b: i32 = 3;
+
+    println("a + b = {}", a + b);
+    println("a - b = {}", a - b);
+    println("a * b = {}", a * b);
+    println("a / b = {}", a / b);
+    println("a % b = {}", a % b);
+
+    var x: i32 = 5;
+    x += 2;
+    println("x += 2 -> {}", x);
+    x -= 1;
+    println("x -= 1 -> {}", x);
+    x *= 3;
+    println("x *= 3 -> {}", x);
+    x /= 2;
+    println("x /= 2 -> {}", x);
+
+    println("a == b -> {}", a == b);
+    println("a != b -> {}", a != b);
+    println("a < b  -> {}", a < b);
+    println("a <= b -> {}", a <= b);
+    println("a > b  -> {}", a > b);
+    println("a >= b -> {}", a >= b);
+
+    var t: bool = true;
+    var f: bool = false;
+
+    println("t && f -> {}", t && f);
+    println("t || f -> {}", t || f);
+    println("!t -> {}", !t);
+
+    var m: i32 = 0b1010; // 10
+    var n: i32 = 0b0110; // 6
+
+    println("m | n  -> {}", m | n);
+    println("m ^ n  -> {}", m ^ n);
+    println("~m     -> {}", ~m);
+
+    println("a << 1 -> {}", a << 1);
+    println("a >> 1 -> {}", a >> 1);
+
+    var y: i32 = a + b * 2;
+    println("a + b * 2 -> {}", y);
+
+    var z: bool = a > b && b < 5;
+    println("a > b && b < 5 -> {}", z);
+
+    var w: i32 = (a + b) << 2;
+    println("(a + b) << 2 -> {}", w);
+}


### PR DESCRIPTION
### Summary
This PR adds support for **bitwise operations** (Shift, XOR, NOT) and **unary operators** (Logical NOT, Bitwise NOT). It also refactors the expression parsing logic to ensure proper operator precedence, completing a robust set of industry-standard operators for Wave.

### Key Changes

#### 1. Lexer & Syntax Update
- **C-style Shift Operators:** Changed the shift keywords from `rol`/`ror` to standard `<<` (Shift Left) and `>>` (Shift Right) syntax. 
- **Internal Mapping:** Maintained `TokenType::Rol` and `TokenType::Ror` internally for consistency.

#### 2. AST Enhancements
- Added new operator variants to `Expression` and `Operator` enums:
  - Binary: `<<`, `>>`, `^`
  - Unary: `!` (Logical NOT), `~` (Bitwise NOT)
- Introduced `Expression::Unary` to represent prefix operations.

#### 3. Parser Refactoring (Precedence Hierarchy)
- Refined the expression parsing tree to handle complex operations with correct precedence:
  - **Hierarchy:** `Logical` > `Bitwise` (`|`, `^`) > `Shift` (`<<`, `>>`) > `Relational` (`<`, `>`, etc.).
- Added `parse_bitwise_expression` and `parse_shift_expression` methods.

#### 4. LLVM Code Generation
- Implemented IR generation for new operations:
  - `build_left_shift` and `build_right_shift` for bitwise shifts.
  - `build_not` for bitwise NOT (`~`).
  - `build_xor` with `const_int(1)` for logical NOT (`!`).

#### 5. Comprehensive Testing (`test70.wave`)
- Added a full-scale operator test suite covering:
  - Arithmetic and Compound assignment.
  - Comparison and Logical operations.
  - Bitwise manipulation and Shift results.
  - Complex grouping and precedence validation.

### Example Usage
```wave
var x: i32 = 10;
var y: i32 = x << 2;     // result: 40
var z: i32 = ~x;         // result: -11
var w: bool = !(x > 5);  // result: false
```