### PR TITLE
Refactor: Separate Compilation and Linking Phases

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -67,17 +67,17 @@ pub(crate) unsafe fn run_wave_file(
     }
 
     let file_stem = file_path.file_stem().unwrap().to_str().unwrap();
-    let machine_code_path =
-        compile_ir_to_machine_code(&ir, file_stem, opt_flag);
+    let object_patch =
+        compile_ir_to_object(&ir, file_stem, opt_flag);
 
     if debug.mc {
         println!("\n===== MACHINE CODE PATH =====");
-        println!("{}", machine_code_path);
+        println!("{}", object_patch);
     }
 
     if debug.hex {
         println!("\n===== HEX DUMP =====");
-        let data = fs::read(&machine_code_path).unwrap();
+        let data = fs::read(&object_patch).unwrap();
         for (i, b) in data.iter().enumerate() {
             if i % 16 == 0 {
                 print!("\n{:04x}: ", i);
@@ -87,7 +87,19 @@ pub(crate) unsafe fn run_wave_file(
         println!();
     }
 
-    let output = Command::new(machine_code_path).output();
+    let exe_patch = format!("target/{}", file_stem);
+
+    let link_libs: Vec<String> = Vec::new();
+    let link_lib_paths: Vec<String> = Vec::new();
+
+    link_objects(
+        &[object_patch.clone()],
+        &exe_patch,
+        &link_libs,
+        &link_lib_paths,
+    );
+
+    let output = Command::new(&exe_patch).output();
     println!("{}", String::from_utf8_lossy(&output.unwrap().stdout));
 }
 


### PR DESCRIPTION
### Summary
This PR refactors the build pipeline by splitting the monolithic compilation process into distinct **Compile-to-Object** and **Link-Object** phases. This modular approach aligns with standard compiler toolchains (like GCC/Clang), enabling better build system integration and paving the way for multi-file project support.

### Key Changes

#### 1. Compilation Phase (`compile_ir_to_object`)
- Renamed `compile_ir_to_machine_code` to `compile_ir_to_object`.
- **Object Generation:** Now generates `.o` object files instead of final executables.
- **Improved I/O:** Removed temporary IR file creation; LLVM IR is now streamed directly to Clang via `stdin` using the `-x ir` flag.
- **Compile-Only Mode:** Added the `-c` flag to ensure only compilation occurs.
- **Output:** Object files are saved to `target/{stem}.o`.

#### 2. Linking Phase (`link_objects`)
- Introduced a new `link_objects` function to handle the final binary generation.
- **Flexibility:** Accepts multiple object files as input.
- **Library Support:** Added support for custom library paths (`-L`) and library names (`-l`).
- **Defaults:** Links against `libc` and `libm` by default.

#### 3. Pipeline Update (`runner.rs`)
- Updated the main execution flow to reflect the split phases:
  1. Generate LLVM IR from Wave source.
  2. Compile IR to an object file (`.o`).
  3. Link the object file to produce the final executable.
  4. Execute the resulting binary.

### Benefits
- **Incremental Compilation:** Allows recompiling only changed modules in future multi-file projects.
- **External Linking:** Supports linking with external static/dynamic libraries.
- **Performance:** Reduced filesystem I/O overhead by eliminating intermediate `.ll` files.
- **Standardization:** Matches the workflow of standard C/C++ build systems.

### Example Workflow
```mermaid
graph LR
    A[Wave Source] -->|Frontend| B[LLVM IR]
    B -->|Compile| C[Object File]
    C -->|Link| D[Executable]
    E[Libraries] --> D
```