### PR TITLE
style: apply rustfmt, add clippy lint suppressions, and code cleanup

### DIFF
--- a/front/error/src/error.rs
+++ b/front/error/src/error.rs
@@ -8,35 +8,35 @@ pub enum WaveErrorKind {
     InvalidString(String),
     UnterminatedString,
     UnterminatedComment,
-    
+
     // Parser errors
     SyntaxError(String),
     UnexpectedEndOfFile,
     InvalidExpression(String),
     InvalidStatement(String),
     InvalidType(String),
-    
+
     // Import/Module errors
     ModuleNotFound(String),
     ImportError(String),
     CircularImport(String),
-    
+
     // Type checking errors
     TypeMismatch { expected: String, found: String },
     UndefinedVariable(String),
     UndefinedFunction(String),
     InvalidFunctionCall(String),
     InvalidAssignment(String),
-    
+
     // Standard library errors
     StandardLibraryNotAvailable,
     UnknownStandardLibraryModule(String),
     VexIntegrationRequired(String),
-    
+
     // Compilation errors
     CompilationFailed(String),
     LinkingFailed(String),
-    
+
     // I/O errors
     FileNotFound(String),
     FileReadError(String),
@@ -67,7 +67,13 @@ pub enum ErrorSeverity {
 }
 
 impl WaveError {
-    pub fn new(kind: WaveErrorKind, message: impl Into<String>, file: impl Into<String>, line: usize, column: usize) -> Self {
+    pub fn new(
+        kind: WaveErrorKind,
+        message: impl Into<String>,
+        file: impl Into<String>,
+        line: usize,
+        column: usize,
+    ) -> Self {
         Self {
             kind,
             message: message.into(),
@@ -117,24 +123,39 @@ impl WaveError {
     pub fn stdlib_requires_vex(module: &str, file: &str, line: usize, column: usize) -> Self {
         Self::new(
             WaveErrorKind::VexIntegrationRequired(module.to_string()),
-            format!("standard library module 'std::{}' requires Vex package manager", module),
+            format!(
+                "standard library module 'std::{}' requires Vex package manager",
+                module
+            ),
             file,
             line,
             column,
         )
         .with_help("Wave compiler in standalone mode only supports low-level system programming")
         .with_suggestion("Use 'vex build' or 'vex run' to access standard library modules")
-        .with_suggestion(format!("Remove the import for 'std::{}' to use Wave in low-level mode", module))
+        .with_suggestion(format!(
+            "Remove the import for 'std::{}' to use Wave in low-level mode",
+            module
+        ))
     }
 
     /// Create a type mismatch error with detailed information
-    pub fn type_mismatch(expected: &str, found: &str, file: &str, line: usize, column: usize) -> Self {
+    pub fn type_mismatch(
+        expected: &str,
+        found: &str,
+        file: &str,
+        line: usize,
+        column: usize,
+    ) -> Self {
         Self::new(
-            WaveErrorKind::TypeMismatch { 
-                expected: expected.to_string(), 
-                found: found.to_string() 
+            WaveErrorKind::TypeMismatch {
+                expected: expected.to_string(),
+                found: found.to_string(),
             },
-            format!("mismatched types: expected `{}`, found `{}`", expected, found),
+            format!(
+                "mismatched types: expected `{}`, found `{}`",
+                expected, found
+            ),
             file,
             line,
             column,
@@ -168,15 +189,26 @@ impl WaveError {
 
         // Main error message
         eprintln!("{}: {}", severity_str, self.message.bold());
-        
+
         // Location
-        eprintln!("  {} {}:{}:{}", "-->".blue().bold(), self.file, self.line, self.column);
+        eprintln!(
+            "  {} {}:{}:{}",
+            "-->".blue().bold(),
+            self.file,
+            self.line,
+            self.column
+        );
         eprintln!("   {}", "|".blue().bold());
 
         // Source code with highlighting
         if let Some(source_line) = &self.source {
-            eprintln!("{:>3} {} {}", self.line.to_string().blue().bold(), "|".blue().bold(), source_line);
-            
+            eprintln!(
+                "{:>3} {} {}",
+                self.line.to_string().blue().bold(),
+                "|".blue().bold(),
+                source_line
+            );
+
             // Arrow pointing to the error
             let spaces = " ".repeat(self.column.saturating_sub(1));
             let arrow = match self.severity {
@@ -185,9 +217,15 @@ impl WaveError {
                 ErrorSeverity::Note => "^".cyan().bold(),
                 ErrorSeverity::Help => "^".green().bold(),
             };
-            
+
             if let Some(label) = &self.label {
-                eprintln!("   {} {}{} {}", "|".blue().bold(), spaces, arrow, label.dimmed());
+                eprintln!(
+                    "   {} {}{} {}",
+                    "|".blue().bold(),
+                    spaces,
+                    arrow,
+                    label.dimmed()
+                );
             } else {
                 eprintln!("   {} {}{}", "|".blue().bold(), spaces, arrow);
             }
@@ -197,16 +235,31 @@ impl WaveError {
 
         // Additional information
         if let Some(note) = &self.note {
-            eprintln!("   {} {}: {}", "=".blue().bold(), "note".cyan().bold(), note);
+            eprintln!(
+                "   {} {}: {}",
+                "=".blue().bold(),
+                "note".cyan().bold(),
+                note
+            );
         }
 
         if let Some(help) = &self.help {
-            eprintln!("   {} {}: {}", "=".blue().bold(), "help".green().bold(), help);
+            eprintln!(
+                "   {} {}: {}",
+                "=".blue().bold(),
+                "help".green().bold(),
+                help
+            );
         }
 
         // Suggestions
         for suggestion in &self.suggestions {
-            eprintln!("   {} {}: {}", "=".blue().bold(), "suggestion".green().bold(), suggestion);
+            eprintln!(
+                "   {} {}: {}",
+                "=".blue().bold(),
+                "suggestion".green().bold(),
+                suggestion
+            );
         }
     }
 
@@ -218,20 +271,28 @@ impl WaveError {
             }
             error.display();
         }
-        
+
         if errors.len() > 1 {
-            let error_count = errors.iter().filter(|e| matches!(e.severity, ErrorSeverity::Error)).count();
-            let warning_count = errors.iter().filter(|e| matches!(e.severity, ErrorSeverity::Warning)).count();
-            
+            let error_count = errors
+                .iter()
+                .filter(|e| matches!(e.severity, ErrorSeverity::Error))
+                .count();
+            let warning_count = errors
+                .iter()
+                .filter(|e| matches!(e.severity, ErrorSeverity::Warning))
+                .count();
+
             eprintln!();
             if error_count > 0 {
-                eprintln!("error: aborting due to {} previous error{}", 
-                    error_count, 
+                eprintln!(
+                    "error: aborting due to {} previous error{}",
+                    error_count,
                     if error_count == 1 { "" } else { "s" }
                 );
             }
             if warning_count > 0 {
-                eprintln!("warning: {} warning{} emitted", 
+                eprintln!(
+                    "warning: {} warning{} emitted",
                     warning_count,
                     if warning_count == 1 { "" } else { "s" }
                 );

--- a/front/lexer/src/lexer/lexer.rs
+++ b/front/lexer/src/lexer/lexer.rs
@@ -1,5 +1,5 @@
-use std::str::FromStr;
 use crate::*;
+use std::str::FromStr;
 
 #[derive(Debug, Clone)]
 pub struct Token {
@@ -211,7 +211,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 }
-            },
+            }
             '-' => {
                 if self.match_next('-') {
                     Token {
@@ -238,7 +238,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 }
-            },
+            }
             '*' => {
                 if self.match_next('=') {
                     Token {
@@ -253,13 +253,11 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 }
-            } ,
-            '.' => {
-                Token {
-                    token_type: TokenType::Dot,
-                    lexeme: ".".to_string(),
-                    line: self.line,
-                }
+            }
+            '.' => Token {
+                token_type: TokenType::Dot,
+                lexeme: ".".to_string(),
+                line: self.line,
             },
             '/' => {
                 if self.match_next('/') {
@@ -281,7 +279,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 }
-            },
+            }
             '%' => {
                 if self.match_next('=') {
                     Token {
@@ -297,19 +295,15 @@ impl<'a> Lexer<'a> {
                     }
                 }
             }
-            ';' => {
-                Token {
-                    token_type: TokenType::SemiColon,
-                    lexeme: ";".to_string(),
-                    line: self.line,
-                }
+            ';' => Token {
+                token_type: TokenType::SemiColon,
+                lexeme: ";".to_string(),
+                line: self.line,
             },
-            ':' => {
-                Token {
-                    token_type: TokenType::Colon,
-                    lexeme: ":".to_string(),
-                    line: self.line,
-                }
+            ':' => Token {
+                token_type: TokenType::Colon,
+                lexeme: ":".to_string(),
+                line: self.line,
             },
             '<' => {
                 if self.match_next('=') {
@@ -325,8 +319,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 }
-
-            },
+            }
             '>' => {
                 if self.match_next('=') {
                     Token {
@@ -341,49 +334,36 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 }
-
+            }
+            '(' => Token {
+                token_type: TokenType::Lparen,
+                lexeme: "(".to_string(),
+                line: self.line,
             },
-            '(' => {
-                Token {
-                    token_type: TokenType::Lparen,
-                    lexeme: "(".to_string(),
-                    line: self.line,
-                }
+            ')' => Token {
+                token_type: TokenType::Rparen,
+                lexeme: ")".to_string(),
+                line: self.line,
             },
-            ')' => {
-                Token {
-                    token_type: TokenType::Rparen,
-                    lexeme: ")".to_string(),
-                    line: self.line,
-                }
+            '{' => Token {
+                token_type: TokenType::Lbrace,
+                lexeme: "{".to_string(),
+                line: self.line,
             },
-            '{' => {
-                Token {
-                    token_type: TokenType::Lbrace,
-                    lexeme: "{".to_string(),
-                    line: self.line,
-                }
+            '}' => Token {
+                token_type: TokenType::Rbrace,
+                lexeme: "}".to_string(),
+                line: self.line,
             },
-            '}' => {
-                Token {
-                    token_type: TokenType::Rbrace,
-                    lexeme: "}".to_string(),
-                    line: self.line,
-                }
+            '[' => Token {
+                token_type: TokenType::Lbrack,
+                lexeme: "[".to_string(),
+                line: self.line,
             },
-            '[' => {
-                Token {
-                    token_type: TokenType::Lbrack,
-                    lexeme: "[".to_string(),
-                    line: self.line,
-                }
-            },
-            ']' => {
-                Token {
-                    token_type: TokenType::Rbrack,
-                    lexeme: "]".to_string(),
-                    line: self.line,
-                }
+            ']' => Token {
+                token_type: TokenType::Rbrack,
+                lexeme: "]".to_string(),
+                line: self.line,
             },
             '=' => {
                 if self.match_next('=') {
@@ -399,7 +379,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 }
-            },
+            }
             '&' => {
                 if self.match_next('&') {
                     Token {
@@ -414,7 +394,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 }
-            },
+            }
             '|' => {
                 if self.match_next('|') {
                     Token {
@@ -429,7 +409,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 }
-            },
+            }
             '!' => {
                 if self.match_next('=') {
                     Token {
@@ -456,13 +436,11 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 }
-            },
-            '^' => {
-                Token {
-                    token_type: TokenType::Xor,
-                    lexeme: "^".to_string(),
-                    line: self.line,
-                }
+            }
+            '^' => Token {
+                token_type: TokenType::Xor,
+                lexeme: "^".to_string(),
+                line: self.line,
             },
             '~' => {
                 if self.match_next('^') {
@@ -478,7 +456,7 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 }
-            },
+            }
             '?' => {
                 if self.match_next('?') {
                     Token {
@@ -487,19 +465,17 @@ impl<'a> Lexer<'a> {
                         line: self.line,
                     }
                 } else {
-                     Token {
+                    Token {
                         token_type: TokenType::Condition,
                         lexeme: "?".to_string(),
                         line: self.line,
                     }
                 }
-            },
-            ',' => {
-                Token {
-                    token_type: TokenType::Comma,
-                    lexeme: ",".to_string(),
-                    line: self.line,
-                }
+            }
+            ',' => Token {
+                token_type: TokenType::Comma,
+                lexeme: ",".to_string(),
+                line: self.line,
             },
             '"' => {
                 let string_value = self.string();
@@ -508,296 +484,214 @@ impl<'a> Lexer<'a> {
                     lexeme: format!("\"{}\"", string_value),
                     line: self.line,
                 }
-            },
+            }
             'a'..='z' | 'A'..='Z' | '_' => {
                 let identifier = self.identifier();
                 match identifier.as_str() {
-                    "fun" => {
-                        Token {
-                            token_type: TokenType::Fun,
-                            lexeme: "fun".to_string(),
-                            line: self.line,
-                        }
+                    "fun" => Token {
+                        token_type: TokenType::Fun,
+                        lexeme: "fun".to_string(),
+                        line: self.line,
                     },
-                    "var" => {
-                        Token {
-                            token_type: TokenType::Var,
-                            lexeme: "var".to_string(),
-                            line: self.line,
-                        }
+                    "var" => Token {
+                        token_type: TokenType::Var,
+                        lexeme: "var".to_string(),
+                        line: self.line,
                     },
-                    "deref" => {
-                        Token {
-                            token_type: TokenType::Deref,
-                            lexeme: "deref".to_string(),
-                            line: self.line,
-                        }
+                    "deref" => Token {
+                        token_type: TokenType::Deref,
+                        lexeme: "deref".to_string(),
+                        line: self.line,
                     },
-                    "let" => {
-                        Token {
-                            token_type: TokenType::Let,
-                            lexeme: "let".to_string(),
-                            line: self.line,
-                        }
-                    }
-                    "mut" => {
-                        Token {
-                            token_type: TokenType::Mut,
-                            lexeme: "mut".to_string(),
-                            line: self.line,
-                        }
-                    }
-                    "const" => {
-                        Token {
-                            token_type: TokenType::Const,
-                            lexeme: "const".to_string(),
-                            line: self.line,
-                        }
+                    "let" => Token {
+                        token_type: TokenType::Let,
+                        lexeme: "let".to_string(),
+                        line: self.line,
                     },
-                    "if" => {
-                        Token {
-                            token_type: TokenType::If,
-                            lexeme: "if".to_string(),
-                            line: self.line,
-                        }
+                    "mut" => Token {
+                        token_type: TokenType::Mut,
+                        lexeme: "mut".to_string(),
+                        line: self.line,
                     },
-                    "else" => {
-                        Token {
-                            token_type: TokenType::Else,
-                            lexeme: "else".to_string(),
-                            line: self.line,
-                        }
+                    "const" => Token {
+                        token_type: TokenType::Const,
+                        lexeme: "const".to_string(),
+                        line: self.line,
                     },
-                    "proto" => {
-                        Token {
-                            token_type: TokenType::Proto,
-                            lexeme: "proto".to_string(),
-                            line: self.line,
-                        }
+                    "if" => Token {
+                        token_type: TokenType::If,
+                        lexeme: "if".to_string(),
+                        line: self.line,
                     },
-                    "struct" => {
-                        Token {
-                            token_type: TokenType::Struct,
-                            lexeme: "struct".to_string(),
-                            line: self.line,
-                        }
+                    "else" => Token {
+                        token_type: TokenType::Else,
+                        lexeme: "else".to_string(),
+                        line: self.line,
                     },
-                    "while" => {
-                        Token {
-                            token_type: TokenType::While,
-                            lexeme: "while".to_string(),
-                            line: self.line,
-                        }
+                    "proto" => Token {
+                        token_type: TokenType::Proto,
+                        lexeme: "proto".to_string(),
+                        line: self.line,
                     },
-                    "for" => {
-                        Token {
-                            token_type: TokenType::For,
-                            lexeme: "for".to_string(),
-                            line: self.line,
-                        }
+                    "struct" => Token {
+                        token_type: TokenType::Struct,
+                        lexeme: "struct".to_string(),
+                        line: self.line,
                     },
-                    "module" => {
-                        Token {
-                            token_type: TokenType::Module,
-                            lexeme: "module".to_string(),
-                            line: self.line,
-                        }
+                    "while" => Token {
+                        token_type: TokenType::While,
+                        lexeme: "while".to_string(),
+                        line: self.line,
                     },
-                    "class" => {
-                        Token {
-                            token_type: TokenType::Class,
-                            lexeme: "class".to_string(),
-                            line: self.line,
-                        }
+                    "for" => Token {
+                        token_type: TokenType::For,
+                        lexeme: "for".to_string(),
+                        line: self.line,
                     },
-                    "in" => {
-                        Token {
-                            token_type: TokenType::In,
-                            lexeme: "in".to_string(),
-                            line: self.line,
-                        }
+                    "module" => Token {
+                        token_type: TokenType::Module,
+                        lexeme: "module".to_string(),
+                        line: self.line,
                     },
-                    "out" => {
-                        Token {
-                            token_type: TokenType::Out,
-                            lexeme: "out".to_string(),
-                            line: self.line,
-                        }
+                    "class" => Token {
+                        token_type: TokenType::Class,
+                        lexeme: "class".to_string(),
+                        line: self.line,
                     },
-                    "is" => {
-                        Token {
-                            token_type: TokenType::Is,
-                            lexeme: "is".to_string(),
-                            line: self.line,
-                        }
+                    "in" => Token {
+                        token_type: TokenType::In,
+                        lexeme: "in".to_string(),
+                        line: self.line,
                     },
-                    "asm" => {
-                        Token {
-                            token_type: TokenType::Asm,
-                            lexeme: "asm".to_string(),
-                            line: self.line,
-                        }
+                    "out" => Token {
+                        token_type: TokenType::Out,
+                        lexeme: "out".to_string(),
+                        line: self.line,
                     },
-                    "<<" => {
-                        Token {
-                            token_type: TokenType::Rol,
-                            lexeme: "<<".to_string(),
-                            line: self.line,
-                        }
+                    "is" => Token {
+                        token_type: TokenType::Is,
+                        lexeme: "is".to_string(),
+                        line: self.line,
                     },
-                    ">>" => {
-                        Token {
-                            token_type: TokenType::Ror,
-                            lexeme: ">>".to_string(),
-                            line: self.line,
-                        }
+                    "asm" => Token {
+                        token_type: TokenType::Asm,
+                        lexeme: "asm".to_string(),
+                        line: self.line,
                     },
-                    "xnand" => {
-                        Token {
-                            token_type: TokenType::Xnand,
-                            lexeme: "xnand".to_string(),
-                            line: self.line,
-                        }
+                    "<<" => Token {
+                        token_type: TokenType::Rol,
+                        lexeme: "<<".to_string(),
+                        line: self.line,
                     },
-                    "import" => {
-                        Token {
-                            token_type: TokenType::Import,
-                            lexeme: "import".to_string(),
-                            line: self.line,
-                        }
+                    ">>" => Token {
+                        token_type: TokenType::Ror,
+                        lexeme: ">>".to_string(),
+                        line: self.line,
                     },
-                    "return" => {
-                        Token {
-                            token_type: TokenType::Return,
-                            lexeme: "return".to_string(),
-                            line: self.line,
-                        }
+                    "xnand" => Token {
+                        token_type: TokenType::Xnand,
+                        lexeme: "xnand".to_string(),
+                        line: self.line,
                     },
-                    "continue" => {
-                        Token {
-                            token_type: TokenType::Continue,
-                            lexeme: "continue".to_string(),
-                            line: self.line,
-                        }
+                    "import" => Token {
+                        token_type: TokenType::Import,
+                        lexeme: "import".to_string(),
+                        line: self.line,
                     },
-                    "print" => {
-                        Token {
-                            token_type: TokenType::Print,
-                            lexeme: "print".to_string(),
-                            line: self.line,
-                        }
+                    "return" => Token {
+                        token_type: TokenType::Return,
+                        lexeme: "return".to_string(),
+                        line: self.line,
                     },
-                    "input" => {
-                        Token {
-                            token_type: TokenType::Input,
-                            lexeme: "input".to_string(),
-                            line: self.line,
-                        }
+                    "continue" => Token {
+                        token_type: TokenType::Continue,
+                        lexeme: "continue".to_string(),
+                        line: self.line,
                     },
-                    "println" => {
-                        Token {
-                            token_type: TokenType::Println,
-                            lexeme: "println".to_string(),
-                            line: self.line,
-                        }
+                    "print" => Token {
+                        token_type: TokenType::Print,
+                        lexeme: "print".to_string(),
+                        line: self.line,
                     },
-                    "match" => {
-                        Token {
-                            token_type: TokenType::Match,
-                            lexeme: "match".to_string(),
-                            line: self.line,
-                        }
+                    "input" => Token {
+                        token_type: TokenType::Input,
+                        lexeme: "input".to_string(),
+                        line: self.line,
                     },
-                    "char" => {
-                        Token {
-                            token_type: TokenType::TypeChar,
-                            lexeme: "char".to_string(),
-                            line: self.line,
-                        }
+                    "println" => Token {
+                        token_type: TokenType::Println,
+                        lexeme: "println".to_string(),
+                        line: self.line,
                     },
-                    "byte" => {
-                        Token {
-                            token_type: TokenType::TypeByte,
-                            lexeme: "byte".to_string(),
-                            line: self.line,
-                        }
+                    "match" => Token {
+                        token_type: TokenType::Match,
+                        lexeme: "match".to_string(),
+                        line: self.line,
                     },
-                    "ptr" => {
-                        Token {
-                            token_type: TokenType::Identifier("ptr".to_string()),
-                            lexeme: "ptr".to_string(),
-                            line: self.line,
-                        }
+                    "char" => Token {
+                        token_type: TokenType::TypeChar,
+                        lexeme: "char".to_string(),
+                        line: self.line,
                     },
-                    "array" => {
-                        Token {
-                            token_type: TokenType::Identifier("array".to_string()),
-                            lexeme: "array".to_string(),
-                            line: self.line,
-                        }
+                    "byte" => Token {
+                        token_type: TokenType::TypeByte,
+                        lexeme: "byte".to_string(),
+                        line: self.line,
                     },
-                    "isz" => {
-                        Token {
-                            token_type: TokenType::TokenTypeInt(IntegerType::ISZ),
-                            lexeme: "isz".to_string(),
-                            line: self.line,
-                        }
+                    "ptr" => Token {
+                        token_type: TokenType::Identifier("ptr".to_string()),
+                        lexeme: "ptr".to_string(),
+                        line: self.line,
                     },
-                    "i8" => {
-                        Token {
-                            token_type: TokenType::TokenTypeInt(IntegerType::I8),
-                            lexeme: "i8".to_string(),
-                            line: self.line,
-                        }
+                    "array" => Token {
+                        token_type: TokenType::Identifier("array".to_string()),
+                        lexeme: "array".to_string(),
+                        line: self.line,
                     },
-                    "i16" => {
-                        Token {
-                            token_type: TokenType::TokenTypeInt(IntegerType::I16),
-                            lexeme: "i16".to_string(),
-                            line: self.line,
-                        }
+                    "isz" => Token {
+                        token_type: TokenType::TokenTypeInt(IntegerType::ISZ),
+                        lexeme: "isz".to_string(),
+                        line: self.line,
                     },
-                    "i32" => {
-                        Token {
-                            token_type: TokenType::TokenTypeInt(IntegerType::I32),
-                            lexeme: "i32".to_string(),
-                            line: self.line,
-                        }
+                    "i8" => Token {
+                        token_type: TokenType::TokenTypeInt(IntegerType::I8),
+                        lexeme: "i8".to_string(),
+                        line: self.line,
                     },
-                    "i64" => {
-                        Token {
-                            token_type: TokenType::TokenTypeInt(IntegerType::I64),
-                            lexeme: "i64".to_string(),
-                            line: self.line,
-                        }
+                    "i16" => Token {
+                        token_type: TokenType::TokenTypeInt(IntegerType::I16),
+                        lexeme: "i16".to_string(),
+                        line: self.line,
                     },
-                    "i128" => {
-                        Token {
-                            token_type: TokenType::TokenTypeInt(IntegerType::I128),
-                            lexeme: "i128".to_string(),
-                            line: self.line,
-                        }
+                    "i32" => Token {
+                        token_type: TokenType::TokenTypeInt(IntegerType::I32),
+                        lexeme: "i32".to_string(),
+                        line: self.line,
                     },
-                    "i256" => {
-                        Token {
-                            token_type: TokenType::TokenTypeInt(IntegerType::I256),
-                            lexeme: "i256".to_string(),
-                            line: self.line,
-                        }
+                    "i64" => Token {
+                        token_type: TokenType::TokenTypeInt(IntegerType::I64),
+                        lexeme: "i64".to_string(),
+                        line: self.line,
                     },
-                    "i512" => {
-                       Token {
-                            token_type: TokenType::TokenTypeInt(IntegerType::I512),
-                            lexeme: "i512".to_string(),
-                            line: self.line,
-                        }
+                    "i128" => Token {
+                        token_type: TokenType::TokenTypeInt(IntegerType::I128),
+                        lexeme: "i128".to_string(),
+                        line: self.line,
                     },
-                    "i1024" => {
-                        Token {
-                            token_type: TokenType::TokenTypeInt(IntegerType::I1024),
-                            lexeme: "i1024".to_string(),
-                            line: self.line,
-                        }
+                    "i256" => Token {
+                        token_type: TokenType::TokenTypeInt(IntegerType::I256),
+                        lexeme: "i256".to_string(),
+                        line: self.line,
+                    },
+                    "i512" => Token {
+                        token_type: TokenType::TokenTypeInt(IntegerType::I512),
+                        lexeme: "i512".to_string(),
+                        line: self.line,
+                    },
+                    "i1024" => Token {
+                        token_type: TokenType::TokenTypeInt(IntegerType::I1024),
+                        lexeme: "i1024".to_string(),
+                        line: self.line,
                     },
                     "usz" => Token {
                         token_type: TokenType::TokenTypeUint(UnsignedIntegerType::USZ),
@@ -854,29 +748,23 @@ impl<'a> Lexer<'a> {
                         lexeme: "f64".to_string(),
                         line: self.line,
                     },
-                    "str" => {
-                        Token {
-                            token_type: TokenType::TypeString,
-                            lexeme: "str".to_string(),
-                            line: self.line,
-                        }
+                    "str" => Token {
+                        token_type: TokenType::TypeString,
+                        lexeme: "str".to_string(),
+                        line: self.line,
                     },
-                    "break" => {
-                        Token {
-                            token_type: TokenType::Break,
-                            lexeme: "break".to_string(),
-                            line: self.line,
-                        }
+                    "break" => Token {
+                        token_type: TokenType::Break,
+                        lexeme: "break".to_string(),
+                        line: self.line,
                     },
-                    _ => {
-                        Token {
-                            token_type: TokenType::Identifier(identifier.clone()),
-                            lexeme: identifier,
-                            line: self.line,
-                        }
-                    }
+                    _ => Token {
+                        token_type: TokenType::Identifier(identifier.clone()),
+                        lexeme: identifier,
+                        line: self.line,
+                    },
                 }
-            },
+            }
             '0'..='9' => {
                 let mut num_str = self.number().to_string(); // 첫 숫자만 읽음
 
@@ -884,7 +772,7 @@ impl<'a> Lexer<'a> {
                 if num_str == "0" && (self.peek() == 'x' || self.peek() == 'X') {
                     num_str.push(self.advance()); // 'x' 붙이기
 
-                    while self.peek().is_digit(16) {
+                    while self.peek().is_ascii_hexdigit() {
                         num_str.push(self.advance());
                     }
 
@@ -901,7 +789,7 @@ impl<'a> Lexer<'a> {
                     num_str.push('.');
                     self.advance();
 
-                    while self.peek().is_digit(10) {
+                    while self.peek().is_ascii_digit() {
                         num_str.push(self.advance()); // 소수점 뒤 숫자
                     }
                     true
@@ -911,9 +799,15 @@ impl<'a> Lexer<'a> {
 
                 // 일반 숫자/실수 토큰 결정
                 let token_type = if is_float {
-                    num_str.parse::<f64>().map(TokenType::Float).unwrap_or(TokenType::Float(0.0))
+                    num_str
+                        .parse::<f64>()
+                        .map(TokenType::Float)
+                        .unwrap_or(TokenType::Float(0.0))
                 } else {
-                    num_str.parse::<i64>().map(TokenType::Number).unwrap_or(TokenType::Number(0))
+                    num_str
+                        .parse::<i64>()
+                        .map(TokenType::Number)
+                        .unwrap_or(TokenType::Number(0))
                 };
 
                 Token {
@@ -930,38 +824,16 @@ impl<'a> Lexer<'a> {
                     eprintln!("[eprintln] Unexpected backslash outside of string");
                     panic!("[panic] Unexpected character: '\\' outside of string");
                 } else {
-                    eprintln!("[eprintln] Unexpected character: {:?} (code: {})", c, c as u32);
+                    eprintln!(
+                        "[eprintln] Unexpected character: {:?} (code: {})",
+                        c, c as u32
+                    );
                     panic!("[panic] Unexpected character: {:?}", c);
                 }
             }
         }
     }
 
-    // Helper methods to create tokens
-    fn create_int_token(&self, int_type: IntegerType, lexeme: String) -> Token {
-        Token {
-            token_type: TokenType::TokenTypeInt(int_type),
-            lexeme,
-            line: self.line,
-        }
-    }
-
-    fn create_float_token(&self, float_type: FloatType, lexeme: String) -> Token {
-        Token {
-            token_type: TokenType::TokenTypeFloat(float_type),
-            lexeme,
-            line: self.line,
-        }
-    }
-
-    fn create_identifier_token(&self, identifier: String) -> Token {
-        Token {
-            token_type: TokenType::Identifier(identifier.clone()),
-            lexeme: identifier,
-            line: self.line,
-        }
-    }
-    
     // Add string literal processing function
     fn string(&mut self) -> String {
         if self.peek() == '"' {
@@ -1026,6 +898,6 @@ impl<'a> Lexer<'a> {
         }
 
         let number_str = &self.source[start..self.current];
-        i64::from_str(number_str).unwrap_or_else(|_| 0)
+        i64::from_str(number_str).unwrap_or(0)
     }
 }

--- a/front/lexer/src/lexer/mod.rs
+++ b/front/lexer/src/lexer/mod.rs
@@ -1,4 +1,23 @@
-mod lexer;
+#![allow(
+    dead_code,
+    unused_variables,
+    clippy::module_inception,
+    clippy::type_complexity,
+    clippy::unnecessary_map_or,
+    clippy::question_mark,
+    clippy::result_large_err,
+    clippy::ptr_arg,
+    clippy::while_let_on_iterator,
+    clippy::needless_borrow,
+    clippy::useless_format,
+    clippy::manual_strip,
+    clippy::explicit_auto_deref,
+    clippy::collapsible_if,
+    clippy::collapsible_else_if,
+    clippy::new_without_default
+)]
+
+pub mod lexer;
 pub mod token;
 
 pub use lexer::*;

--- a/front/lexer/src/lexer/token.rs
+++ b/front/lexer/src/lexer/token.rs
@@ -87,23 +87,23 @@ pub enum TokenType {
     Module,
     Class,
     Match,
-    LogicalAnd,            // &&
-    AddressOf,            // &
-    LogicalOr,             // ||
-    BitwiseOr,             // |
-    NotEqual,              // !=
-    Xor,                    // ^
-    Xnor,                   // ~^
-    BitwiseNot,            // ~
-    Nand,                   // !&
-    Nor,                    // !|
-    Not,                    // !
-    Condition,              // ?
-    NullCoalesce,          // ??
-    Conditional,            // ?:
-    In,                     // in
-    Out,                    // out
-    Is,                     // is
+    LogicalAnd,   // &&
+    AddressOf,    // &
+    LogicalOr,    // ||
+    BitwiseOr,    // |
+    NotEqual,     // !=
+    Xor,          // ^
+    Xnor,         // ~^
+    BitwiseNot,   // ~
+    Nand,         // !&
+    Nor,          // !|
+    Not,          // !
+    Condition,    // ?
+    NullCoalesce, // ??
+    Conditional,  // ?:
+    In,           // in
+    Out,          // out
+    Is,           // is
     Asm,
     Rol,
     Ror,
@@ -126,39 +126,39 @@ pub enum TokenType {
     String(String),
     Number(i64),
     Float(f64),
-    Plus,                   // +
-    Increment,              // ++
-    PlusEq,                 // +=
-    Minus,                  // -
-    Decrement,              // --
-    MinusEq,                // -=
-    Star,                   // *
-    StarEq,                 // *=
-    Div,                    // /
-    DivEq,                  // /=
-    Remainder,              // %
-    RemainderEq,            // %=
-    Equal,                  // =
-    EqualTwo,              // ==
-    Comma,                  // ,
-    Dot,                    // .
-    SemiColon,              // ;
-    Colon,                  // :
-    Lchevr,                 // <
-    LchevrEq,              // <=
-    Rchevr,                 // >
-    RchevrEq,              // >=
-    Lparen,                 // (
-    Rparen,                 // )
-    Lbrace,                 // {
-    Rbrace,                 // }
-    Lbrack,                 // [
-    Rbrack,                 // ]
-    Eof,                    // End of file
+    Plus,        // +
+    Increment,   // ++
+    PlusEq,      // +=
+    Minus,       // -
+    Decrement,   // --
+    MinusEq,     // -=
+    Star,        // *
+    StarEq,      // *=
+    Div,         // /
+    DivEq,       // /=
+    Remainder,   // %
+    RemainderEq, // %=
+    Equal,       // =
+    EqualTwo,    // ==
+    Comma,       // ,
+    Dot,         // .
+    SemiColon,   // ;
+    Colon,       // :
+    Lchevr,      // <
+    LchevrEq,    // <=
+    Rchevr,      // >
+    RchevrEq,    // >=
+    Lparen,      // (
+    Rparen,      // )
+    Lbrace,      // {
+    Rbrace,      // }
+    Lbrack,      // [
+    Rbrack,      // ]
+    Eof,         // End of file
     Error,
     Whitespace,
     Break,
-    Arrow,                  // ->
+    Arrow, // ->
     Array,
     Newline,
     Proto,

--- a/front/lexer/src/lib.rs
+++ b/front/lexer/src/lib.rs
@@ -1,4 +1,3 @@
 pub mod lexer;
 
 pub use lexer::*;
-pub use lexer::token::*;

--- a/front/parser/src/parser/ast.rs
+++ b/front/parser/src/parser/ast.rs
@@ -153,8 +153,8 @@ pub enum Operator {
     LogicalOr,
     BitwiseOr,
     Assign,
-    ShiftLeft,              // <<
-    ShiftRight,             // >>
+    ShiftLeft,  // <<
+    ShiftRight, // >>
     BitwiseXor,
     LogicalNot,
     BitwiseNot,
@@ -162,12 +162,12 @@ pub enum Operator {
 
 #[derive(Debug, Clone)]
 pub enum AssignOperator {
-    Assign,      // =
-    AddAssign,   // +=
-    SubAssign,   // -=
-    MulAssign,  // *=
-    DivAssign,  // /=
-    RemAssign,  // %=
+    Assign,    // =
+    AddAssign, // +=
+    SubAssign, // -=
+    MulAssign, // *=
+    DivAssign, // /=
+    RemAssign, // %=
 }
 
 #[derive(Debug, Clone)]
@@ -255,15 +255,17 @@ impl Expression {
 
     pub fn get_wave_type(&self, variables: &HashMap<String, VariableInfo>) -> WaveType {
         match self {
-            Expression::Variable(name) => {
-                variables.get(name)
-                    .unwrap_or_else(|| panic!("Variable '{}' not found", name))
-                    .ty.clone()
-            }
+            Expression::Variable(name) => variables
+                .get(name)
+                .unwrap_or_else(|| panic!("Variable '{}' not found", name))
+                .ty
+                .clone(),
             Expression::Literal(Literal::Number(_)) => WaveType::Int(32), // 기본 int
             Expression::Literal(Literal::Float(_)) => WaveType::Float(32),
             Expression::Literal(Literal::String(_)) => WaveType::String,
-            Expression::MethodCall { .. } => panic!("nested method call type inference not supported yet"),
+            Expression::MethodCall { .. } => {
+                panic!("nested method call type inference not supported yet")
+            }
             _ => panic!("get_wave_type not implemented for {:?}", self),
         }
     }

--- a/front/parser/src/parser/format.rs
+++ b/front/parser/src/parser/format.rs
@@ -1,8 +1,8 @@
+use crate::ast::Expression::Variable;
+use crate::ast::{AssignOperator, Expression, FormatPart, Literal, Operator};
+use lexer::{Token, TokenType};
 use std::iter::Peekable;
 use std::slice::Iter;
-use lexer::{Token, TokenType};
-use crate::ast::{Operator, Expression, FormatPart, Literal, AssignOperator};
-use crate::ast::Expression::Variable;
 
 pub fn parse_format_string(s: &str) -> Vec<FormatPart> {
     let mut parts = Vec::new();
@@ -37,7 +37,11 @@ pub fn parse_expression<'a, T>(tokens: &mut Peekable<T>) -> Option<Expression>
 where
     T: Iterator<Item = &'a Token>,
 {
-    if let Some(Token { token_type: TokenType::Not, .. }) = tokens.peek() {
+    if let Some(Token {
+        token_type: TokenType::Not,
+        ..
+    }) = tokens.peek()
+    {
         tokens.next();
         let inner = parse_expression(tokens)?;
         return Some(Expression::Unary {
@@ -45,8 +49,12 @@ where
             expr: Box::new(inner),
         });
     }
-    
-    if let Some(Token { token_type: TokenType::BitwiseNot, .. }) = tokens.peek() {
+
+    if let Some(Token {
+        token_type: TokenType::BitwiseNot,
+        ..
+    }) = tokens.peek()
+    {
         tokens.next();
         let inner = parse_expression(tokens)?;
         return Some(Expression::Unary {
@@ -55,13 +63,21 @@ where
         });
     }
 
-    if let Some(Token { token_type: TokenType::AddressOf, .. }) = tokens.peek() {
+    if let Some(Token {
+        token_type: TokenType::AddressOf,
+        ..
+    }) = tokens.peek()
+    {
         tokens.next(); // consume '&'
         let inner = parse_expression(tokens)?;
         return Some(Expression::AddressOf(Box::new(inner)));
     }
 
-    if let Some(Token { token_type: TokenType::Deref, .. }) = tokens.peek() {
+    if let Some(Token {
+        token_type: TokenType::Deref,
+        ..
+    }) = tokens.peek()
+    {
         tokens.next(); // consume 'deref'
         let inner = parse_expression(tokens)?;
         return Some(Expression::Deref(Box::new(inner)));
@@ -84,7 +100,7 @@ where
             TokenType::StarEq => AssignOperator::MulAssign,
             TokenType::DivEq => AssignOperator::DivAssign,
             TokenType::RemainderEq => AssignOperator::RemAssign,
-            _ => return Some(left)
+            _ => return Some(left),
         };
 
         tokens.next(); // consume +=, -=
@@ -137,12 +153,12 @@ where
 
     while let Some(token) = tokens.peek() {
         match token.token_type {
-            TokenType::EqualTwo |
-            TokenType::NotEqual |
-            TokenType::Rchevr |
-            TokenType::RchevrEq |
-            TokenType::Lchevr |
-            TokenType::LchevrEq => {
+            TokenType::EqualTwo
+            | TokenType::NotEqual
+            | TokenType::Rchevr
+            | TokenType::RchevrEq
+            | TokenType::Lchevr
+            | TokenType::LchevrEq => {
                 let op = match token.token_type {
                     TokenType::EqualTwo => Operator::Equal,
                     TokenType::NotEqual => Operator::NotEqual,
@@ -251,12 +267,19 @@ where
                         tokens.next();
 
                         let mut args = vec![];
-                        if tokens.peek().map_or(false, |t| t.token_type != TokenType::Rparen) {
+                        if tokens
+                            .peek()
+                            .map_or(false, |t| t.token_type != TokenType::Rparen)
+                        {
                             loop {
                                 let arg = parse_expression(tokens)?;
                                 args.push(arg);
 
-                                if let Some(Token { token_type: TokenType::Comma, .. }) = tokens.peek() {
+                                if let Some(Token {
+                                    token_type: TokenType::Comma,
+                                    ..
+                                }) = tokens.peek()
+                                {
                                     tokens.next();
                                 } else {
                                     break;
@@ -264,7 +287,10 @@ where
                             }
                         }
 
-                        if tokens.peek().map_or(true, |t| t.token_type != TokenType::Rparen) {
+                        if tokens
+                            .peek()
+                            .map_or(true, |t| t.token_type != TokenType::Rparen)
+                        {
                             println!("Error: Expected ')' after function call arguments");
                             return None;
                         }
@@ -276,15 +302,25 @@ where
                         tokens.next();
                         let mut fields = vec![];
 
-                        while tokens.peek().map_or(false, |t| t.token_type != TokenType::Rbrace) {
-                            let field_name = if let Some(Token { token_type: TokenType::Identifier(n), .. }) = tokens.next() {
+                        while tokens
+                            .peek()
+                            .map_or(false, |t| t.token_type != TokenType::Rbrace)
+                        {
+                            let field_name = if let Some(Token {
+                                token_type: TokenType::Identifier(n),
+                                ..
+                            }) = tokens.next()
+                            {
                                 n.clone()
                             } else {
                                 println!("Error: Expected field name in struct literal.");
                                 return None;
                             };
 
-                            if tokens.peek().map_or(true, |t| t.token_type != TokenType::Colon) {
+                            if tokens
+                                .peek()
+                                .map_or(true, |t| t.token_type != TokenType::Colon)
+                            {
                                 println!("Error: Expected ':' after field name '{}'", field_name);
                                 return None;
                             }
@@ -293,14 +329,21 @@ where
                             let value = parse_expression(tokens)?;
                             fields.push((field_name, value));
 
-                            if let Some(Token { token_type: TokenType::Comma, .. }) = tokens.peek() {
+                            if let Some(Token {
+                                token_type: TokenType::Comma,
+                                ..
+                            }) = tokens.peek()
+                            {
                                 tokens.next();
                             } else {
                                 break;
                             }
                         }
 
-                        if tokens.peek().map_or(true, |t| t.token_type != TokenType::Rbrace) {
+                        if tokens
+                            .peek()
+                            .map_or(true, |t| t.token_type != TokenType::Rbrace)
+                        {
                             println!("Error: Expected '}}' to close struct literal");
                             return None;
                         }
@@ -319,7 +362,10 @@ where
         TokenType::Lparen => {
             tokens.next();
             let inner_expr = parse_expression(tokens)?;
-            if tokens.peek().map_or(true, |t| t.token_type != TokenType::Rparen) {
+            if tokens
+                .peek()
+                .map_or(true, |t| t.token_type != TokenType::Rparen)
+            {
                 println!("Error: Expected ')' to close grouped expression");
                 return None;
             }
@@ -333,17 +379,27 @@ where
         TokenType::Lbrack => {
             tokens.next();
             let mut elements = vec![];
-            if tokens.peek().map_or(false, |t| t.token_type != TokenType::Rbrack) {
+            if tokens
+                .peek()
+                .map_or(false, |t| t.token_type != TokenType::Rbrack)
+            {
                 loop {
                     elements.push(parse_expression(tokens)?);
-                    if let Some(Token { token_type: TokenType::Comma, .. }) = tokens.peek() {
+                    if let Some(Token {
+                        token_type: TokenType::Comma,
+                        ..
+                    }) = tokens.peek()
+                    {
                         tokens.next();
                     } else {
                         break;
                     }
                 }
             }
-            if tokens.peek().map_or(true, |t| t.token_type != TokenType::Rbrack) {
+            if tokens
+                .peek()
+                .map_or(true, |t| t.token_type != TokenType::Rbrack)
+            {
                 println!("Error: Expected ']' to close array literal");
                 return None;
             }
@@ -381,10 +437,19 @@ where
 
                         let reg_token = tokens.next();
                         let reg = match reg_token {
-                            Some(Token { token_type: TokenType::String(s), .. }) => s.clone(),
-                            Some(Token { token_type: TokenType::Identifier(s), .. }) => s.clone(),
+                            Some(Token {
+                                token_type: TokenType::String(s),
+                                ..
+                            }) => s.clone(),
+                            Some(Token {
+                                token_type: TokenType::Identifier(s),
+                                ..
+                            }) => s.clone(),
                             Some(other) => {
-                                println!("Expected register string or identifier, got {:?}", other.token_type);
+                                println!(
+                                    "Expected register string or identifier, got {:?}",
+                                    other.token_type
+                                );
                                 return None;
                             }
                             None => {
@@ -409,7 +474,6 @@ where
                         }
                     }
 
-
                     TokenType::Identifier(s) if s == "in" || s == "out" => {
                         let is_input = s == "in";
                         tokens.next();
@@ -422,10 +486,19 @@ where
 
                         let reg_token = tokens.next();
                         let reg = match reg_token {
-                            Some(Token { token_type: TokenType::String(s), .. })    => s.clone(),
-                            Some(Token { token_type: TokenType::Identifier(s), .. })=> s.clone(),
+                            Some(Token {
+                                token_type: TokenType::String(s),
+                                ..
+                            }) => s.clone(),
+                            Some(Token {
+                                token_type: TokenType::Identifier(s),
+                                ..
+                            }) => s.clone(),
                             Some(other) => {
-                                println!("Expected register string or identifier, got {:?}", other.token_type);
+                                println!(
+                                    "Expected register string or identifier, got {:?}",
+                                    other.token_type
+                                );
                                 return None;
                             }
                             None => {
@@ -467,17 +540,23 @@ where
                 outputs,
             })
         }
-        _ => {
-            match token.token_type {
-                TokenType::Continue | TokenType::Break | TokenType::Return | TokenType::SemiColon => None,
-                _ => {
-                    println!("Error: Expected primary expression, found {:?}", token.token_type);
-                    println!("Error: Expected primary expression, found {:?}", token.lexeme);
-                    println!("Error: Expected primary expression, found {:?}", token.line);
-                    None
-                }
+        _ => match token.token_type {
+            TokenType::Continue | TokenType::Break | TokenType::Return | TokenType::SemiColon => {
+                None
             }
-        }
+            _ => {
+                println!(
+                    "Error: Expected primary expression, found {:?}",
+                    token.token_type
+                );
+                println!(
+                    "Error: Expected primary expression, found {:?}",
+                    token.lexeme
+                );
+                println!("Error: Expected primary expression, found {:?}", token.line);
+                None
+            }
+        },
     };
 
     if expr.is_none() {
@@ -489,7 +568,11 @@ where
             Some(TokenType::Dot) => {
                 tokens.next(); // consume '.'
 
-                let name = if let Some(Token { token_type: TokenType::Identifier(name), .. }) = tokens.next() {
+                let name = if let Some(Token {
+                    token_type: TokenType::Identifier(name),
+                    ..
+                }) = tokens.next()
+                {
                     name.clone()
                 } else {
                     println!("Error: Expected identifier after '.'");
@@ -506,17 +589,28 @@ where
                 };
 
                 // 다음 토큰이 '(' 이면 메서드 호출, 아니면 필드 접근
-                if let Some(Token { token_type: TokenType::Lparen, .. }) = tokens.peek() {
+                if let Some(Token {
+                    token_type: TokenType::Lparen,
+                    ..
+                }) = tokens.peek()
+                {
                     // ----- MethodCall -----
                     tokens.next(); // consume '('
 
                     let mut args = Vec::new();
-                    if tokens.peek().map_or(false, |t| t.token_type != TokenType::Rparen) {
+                    if tokens
+                        .peek()
+                        .map_or(false, |t| t.token_type != TokenType::Rparen)
+                    {
                         loop {
                             let arg = parse_expression(tokens)?;
                             args.push(arg);
 
-                            if let Some(Token { token_type: TokenType::Comma, .. }) = tokens.peek() {
+                            if let Some(Token {
+                                token_type: TokenType::Comma,
+                                ..
+                            }) = tokens.peek()
+                            {
                                 tokens.next(); // consume ','
                             } else {
                                 break;
@@ -524,7 +618,10 @@ where
                         }
                     }
 
-                    if tokens.peek().map_or(true, |t| t.token_type != TokenType::Rparen) {
+                    if tokens
+                        .peek()
+                        .map_or(true, |t| t.token_type != TokenType::Rparen)
+                    {
                         println!("Error: Expected ')' after method call arguments");
                         return None;
                     }
@@ -548,7 +645,10 @@ where
                 tokens.next(); // consume '['
 
                 let index_expr = parse_expression(tokens)?;
-                if tokens.peek().map_or(true, |t| t.token_type != TokenType::Rbrack) {
+                if tokens
+                    .peek()
+                    .map_or(true, |t| t.token_type != TokenType::Rbrack)
+                {
                     println!("Error: Expected ']' after index");
                     return None;
                 }
@@ -597,14 +697,19 @@ where
     Some(expr)
 }
 
-pub fn parse_expression_from_token(first_token: &Token, tokens: &mut Peekable<Iter<Token>>) -> Option<Expression> {
+pub fn parse_expression_from_token(
+    first_token: &Token,
+    tokens: &mut Peekable<Iter<Token>>,
+) -> Option<Expression> {
     match &first_token.token_type {
         TokenType::Identifier(name) => Some(Expression::Variable(name.clone())),
 
         TokenType::Deref => {
             if let Some(next_token) = tokens.next() {
                 if let TokenType::Identifier(name) = &next_token.token_type {
-                    return Some(Expression::Deref(Box::new(Expression::Variable(name.clone()))));
+                    return Some(Expression::Deref(Box::new(Expression::Variable(
+                        name.clone(),
+                    ))));
                 }
             }
             None
@@ -624,7 +729,11 @@ where
         TokenType::Number(n) => Some(n.to_string()),
         TokenType::String(s) => Some(s.clone()),
         TokenType::AddressOf => {
-            if let Some(Token { token_type: TokenType::Identifier(s), .. }) = tokens.next() {
+            if let Some(Token {
+                token_type: TokenType::Identifier(s),
+                ..
+            }) = tokens.next()
+            {
                 Some(format!("&{}", s))
             } else {
                 println!("Expected identifier after '&' in in/out(...)");
@@ -632,7 +741,10 @@ where
             }
         }
         other => {
-            println!("Expected identifier or number after in/out(...), got {:?}", other);
+            println!(
+                "Expected identifier or number after in/out(...), got {:?}",
+                other
+            );
             None
         }
     }

--- a/front/parser/src/parser/mod.rs
+++ b/front/parser/src/parser/mod.rs
@@ -1,7 +1,26 @@
-pub mod parser;
+#![allow(
+    dead_code,
+    unused_variables,
+    clippy::module_inception,
+    clippy::type_complexity,
+    clippy::unnecessary_map_or,
+    clippy::question_mark,
+    clippy::result_large_err,
+    clippy::ptr_arg,
+    clippy::while_let_on_iterator,
+    clippy::needless_borrow,
+    clippy::useless_format,
+    clippy::manual_strip,
+    clippy::explicit_auto_deref,
+    clippy::collapsible_if,
+    clippy::collapsible_else_if,
+    clippy::new_without_default
+)]
+
 pub mod ast;
 pub mod format;
 pub mod import;
+pub mod parser;
 pub mod stdlib;
 pub mod type_system;
 

--- a/front/parser/src/parser/parser.rs
+++ b/front/parser/src/parser/parser.rs
@@ -1,12 +1,12 @@
+use crate::parser::format::*;
+use crate::type_system::*;
+use crate::*;
+use ::lexer::*;
+use parser::ast::*;
+use regex::Regex;
 use std::collections::HashSet;
 use std::iter::Peekable;
 use std::slice::Iter;
-use regex::Regex;
-use ::lexer::*;
-use parser::ast::*;
-use crate::*;
-use crate::parser::format::*;
-use crate::type_system::*;
 
 pub fn parse(tokens: &Vec<Token>) -> Option<Vec<ASTNode>> {
     let mut iter = tokens.iter().peekable();
@@ -73,15 +73,25 @@ pub fn parse(tokens: &Vec<Token>) -> Option<Vec<ASTNode>> {
 
 pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode> {
     let mut params = vec![];
-    while tokens.peek().map_or(false, |t| t.token_type != TokenType::Rparen) {
-        let name = if let Some(Token { token_type: TokenType::Identifier(n), .. }) = tokens.next() {
+    while tokens
+        .peek()
+        .map_or(false, |t| t.token_type != TokenType::Rparen)
+    {
+        let name = if let Some(Token {
+            token_type: TokenType::Identifier(n),
+            ..
+        }) = tokens.next()
+        {
             n.clone()
         } else {
             println!("Error: Expected parameter name");
             break;
         };
 
-        if tokens.peek().map_or(true, |t| t.token_type != TokenType::Colon) {
+        if tokens
+            .peek()
+            .map_or(true, |t| t.token_type != TokenType::Colon)
+        {
             println!("Error: Expected ':' after parameter name '{}'", name);
             break;
         }
@@ -95,12 +105,24 @@ pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode
             }
         };
 
-        let initial_value = if tokens.peek().map_or(false, |t| t.token_type == TokenType::Equal) {
+        let initial_value = if tokens
+            .peek()
+            .map_or(false, |t| t.token_type == TokenType::Equal)
+        {
             tokens.next(); // consume '='
             match tokens.next() {
-                Some(Token { token_type: TokenType::Number(n), .. }) => Some(Value::Int(*n)),
-                Some(Token { token_type: TokenType::Float(f), .. }) => Some(Value::Float(*f)),
-                Some(Token { token_type: TokenType::String(s), .. }) => Some(Value::Text(s.clone())),
+                Some(Token {
+                    token_type: TokenType::Number(n),
+                    ..
+                }) => Some(Value::Int(*n)),
+                Some(Token {
+                    token_type: TokenType::Float(f),
+                    ..
+                }) => Some(Value::Float(*f)),
+                Some(Token {
+                    token_type: TokenType::String(s),
+                    ..
+                }) => Some(Value::Text(s.clone())),
                 _ => {
                     println!("Error: Unsupported initializer for parameter '{}'", name);
                     None
@@ -134,7 +156,10 @@ pub fn parse_parameters(tokens: &mut Peekable<Iter<Token>>) -> Vec<ParameterNode
         }
     }
 
-    if tokens.peek().map_or(true, |t| t.token_type != TokenType::Rparen) {
+    if tokens
+        .peek()
+        .map_or(true, |t| t.token_type != TokenType::Rparen)
+    {
         println!("Error: Expected ')' or ',' in parameter list");
     } else {
         tokens.next();
@@ -185,9 +210,7 @@ pub fn token_type_to_wave_type(token_type: &TokenType) -> Option<WaveType> {
         TokenType::TypeArray(inner, size) => {
             token_type_to_wave_type(inner).map(|t| WaveType::Array(Box::new(t), *size))
         }
-        TokenType::TypeCustom(name) => {
-            Some(WaveType::Struct(name.clone()))
-        }
+        TokenType::TypeCustom(name) => Some(WaveType::Struct(name.clone())),
         _ => None,
     }
 }
@@ -230,7 +253,11 @@ pub fn extract_body(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> 
                 tokens.next(); // consume 'println'
                 let node = parse_println(tokens)?;
                 // Added semicolon handling
-                if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+                if let Some(Token {
+                    token_type: TokenType::SemiColon,
+                    ..
+                }) = tokens.peek()
+                {
                     tokens.next();
                 }
                 body.push(node);
@@ -239,7 +266,11 @@ pub fn extract_body(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> 
                 tokens.next(); // consume 'print'
                 let node = parse_print(tokens)?;
                 // Added semicolon handling
-                if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+                if let Some(Token {
+                    token_type: TokenType::SemiColon,
+                    ..
+                }) = tokens.peek()
+                {
                     tokens.next();
                 }
                 body.push(node);
@@ -258,7 +289,11 @@ pub fn extract_body(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> 
             }
             TokenType::Identifier(_) => {
                 if let Some(expr) = parse_expression(tokens) {
-                    if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+                    if let Some(Token {
+                        token_type: TokenType::SemiColon,
+                        ..
+                    }) = tokens.peek()
+                    {
                         tokens.next(); // consume ';'
                     }
                     body.push(ASTNode::Statement(StatementNode::Expression(expr)));
@@ -269,14 +304,22 @@ pub fn extract_body(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> 
             }
             TokenType::Break => {
                 tokens.next(); // consume 'break'
-                if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+                if let Some(Token {
+                    token_type: TokenType::SemiColon,
+                    ..
+                }) = tokens.peek()
+                {
                     tokens.next(); // consume ;
                 }
                 body.push(ASTNode::Statement(StatementNode::Break));
             }
             TokenType::Continue => {
                 tokens.next(); // consume 'continue'
-                if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+                if let Some(Token {
+                    token_type: TokenType::SemiColon,
+                    ..
+                }) = tokens.peek()
+                {
                     tokens.next(); // consume ;
                 }
                 body.push(ASTNode::Statement(StatementNode::Continue));
@@ -284,7 +327,11 @@ pub fn extract_body(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> 
             TokenType::Return => {
                 tokens.next(); // consume 'return'
 
-                let expr = if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+                let expr = if let Some(Token {
+                    token_type: TokenType::SemiColon,
+                    ..
+                }) = tokens.peek()
+                {
                     tokens.next(); // return;
                     None
                 } else {
@@ -296,7 +343,11 @@ pub fn extract_body(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> 
                         }
                     };
 
-                    if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+                    if let Some(Token {
+                        token_type: TokenType::SemiColon,
+                        ..
+                    }) = tokens.peek()
+                    {
                         tokens.next();
                     } else {
                         println!("Error: Missing semicolon after return expression");
@@ -314,7 +365,11 @@ pub fn extract_body(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> 
             }
             _ => {
                 if let Some(expr) = parse_expression(tokens) {
-                    if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+                    if let Some(Token {
+                        token_type: TokenType::SemiColon,
+                        ..
+                    }) = tokens.peek()
+                    {
                         tokens.next(); // consume ;
                     }
                     body.push(ASTNode::Statement(StatementNode::Expression(expr)));
@@ -328,7 +383,10 @@ pub fn extract_body(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> 
     Some(body)
 }
 
-pub fn parse_function_call(name: Option<String>, tokens: &mut Peekable<Iter<Token>>) -> Option<Expression> {
+pub fn parse_function_call(
+    name: Option<String>,
+    tokens: &mut Peekable<Iter<Token>>,
+) -> Option<Expression> {
     let name = name?;
 
     if tokens.peek()?.token_type != TokenType::Lparen {
@@ -354,16 +412,16 @@ pub fn parse_function_call(name: Option<String>, tokens: &mut Peekable<Iter<Toke
             }
             Some(TokenType::Rparen) => continue,
             _ => {
-                println!("❌ Unexpected token in function arguments: {:?}", tokens.peek());
+                println!(
+                    "❌ Unexpected token in function arguments: {:?}",
+                    tokens.peek()
+                );
                 return None;
             }
         }
     }
 
-    Some(Expression::FunctionCall {
-        name,
-        args,
-    })
+    Some(Expression::FunctionCall { name, args })
 }
 
 fn parse_parentheses(tokens: &mut Peekable<Iter<Token>>) -> Vec<Token> {
@@ -391,7 +449,10 @@ fn parse_function(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
     tokens.next();
 
     let name = match tokens.next() {
-        Some(Token { token_type: TokenType::Identifier(name), .. }) => name.clone(),
+        Some(Token {
+            token_type: TokenType::Identifier(name),
+            ..
+        }) => name.clone(),
         _ => return None,
     };
 
@@ -405,12 +466,19 @@ fn parse_function(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
     let mut param_names = HashSet::new();
     for param in &parameters {
         if !param_names.insert(param.name.clone()) {
-            println!("Error: Parameter '{}' is declared multiple times", param.name);
+            println!(
+                "Error: Parameter '{}' is declared multiple times",
+                param.name
+            );
             return None;
         }
     }
 
-    let return_type = if let Some(Token { token_type: TokenType::Arrow, .. }) = tokens.peek() {
+    let return_type = if let Some(Token {
+        token_type: TokenType::Arrow,
+        ..
+    }) = tokens.peek()
+    {
         tokens.next(); // consume '->'
         parse_type_from_stream(tokens)
     } else {
@@ -426,10 +494,7 @@ fn parse_function(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
     }))
 }
 
-fn parse_variable_decl(
-    tokens: &mut Peekable<Iter<'_, Token>>,
-    is_const: bool
-) -> Option<ASTNode> {
+fn parse_variable_decl(tokens: &mut Peekable<Iter<'_, Token>>, is_const: bool) -> Option<ASTNode> {
     let mut mutability = if is_const {
         Mutability::Const
     } else {
@@ -437,16 +502,26 @@ fn parse_variable_decl(
     };
 
     if !is_const {
-        if let Some(Token { token_type: TokenType::Mut, .. }) = tokens.peek() {
+        if let Some(Token {
+            token_type: TokenType::Mut,
+            ..
+        }) = tokens.peek()
+        {
             tokens.next(); // consume `mut`
             mutability = Mutability::LetMut;
         }
     }
 
     let name = match tokens.next() {
-        Some(Token { token_type: TokenType::Identifier(name), .. }) => name.clone(),
+        Some(Token {
+            token_type: TokenType::Identifier(name),
+            ..
+        }) => name.clone(),
         _ => {
-            println!("Expected identifier after `{}`", if is_const { "const" } else { "let" });
+            println!(
+                "Expected identifier after `{}`",
+                if is_const { "const" } else { "let" }
+            );
             return None;
         }
     };
@@ -465,7 +540,11 @@ fn parse_variable_decl(
     };
 
     let wave_type = if let TokenType::Identifier(ref name) = type_token.token_type {
-        if let Some(Token { token_type: TokenType::Lchevr, .. }) = tokens.peek() {
+        if let Some(Token {
+            token_type: TokenType::Lchevr,
+            ..
+        }) = tokens.peek()
+        {
             tokens.next(); // consume '<'
 
             let mut inner = String::new();
@@ -476,7 +555,7 @@ fn parse_variable_decl(
                     TokenType::Lchevr => {
                         depth += 1;
                         inner.push('<');
-                    },
+                    }
                     TokenType::Rchevr => {
                         depth -= 1;
                         if depth == 0 {
@@ -484,7 +563,7 @@ fn parse_variable_decl(
                         } else {
                             inner.push('>');
                         }
-                    },
+                    }
                     _ => inner.push_str(&t.lexeme),
                 }
             }
@@ -523,7 +602,11 @@ fn parse_variable_decl(
         }
     };
 
-    let initial_value = if let Some(Token { token_type: TokenType::Equal, .. }) = tokens.peek() {
+    let initial_value = if let Some(Token {
+        token_type: TokenType::Equal,
+        ..
+    }) = tokens.peek()
+    {
         tokens.next(); // consume '='
         let expr = parse_expression(tokens)?;
         Some(expr)
@@ -537,7 +620,9 @@ fn parse_variable_decl(
     }
     tokens.next();
 
-    if let (WaveType::Array(_, expected_len), Some(Expression::ArrayLiteral(elements))) = (&wave_type, &initial_value) {
+    if let (WaveType::Array(_, expected_len), Some(Expression::ArrayLiteral(elements))) =
+        (&wave_type, &initial_value)
+    {
         if *expected_len != elements.len() as u32 {
             println!(
                 "❌ Error: Array length mismatch. Expected {}, but got {} elements",
@@ -569,7 +654,10 @@ fn parse_var(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
     let mutability = Mutability::Var;
 
     let name = match tokens.next() {
-        Some(Token { token_type: TokenType::Identifier(name), .. }) => name.clone(),
+        Some(Token {
+            token_type: TokenType::Identifier(name),
+            ..
+        }) => name.clone(),
         _ => {
             println!("Expected identifier");
             return None;
@@ -590,7 +678,11 @@ fn parse_var(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
     };
 
     let wave_type = if let TokenType::Identifier(ref name) = type_token.token_type {
-        if let Some(Token { token_type: TokenType::Lchevr, .. }) = tokens.peek() {
+        if let Some(Token {
+            token_type: TokenType::Lchevr,
+            ..
+        }) = tokens.peek()
+        {
             tokens.next(); // consume '<'
 
             let mut inner = String::new();
@@ -601,7 +693,7 @@ fn parse_var(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
                     TokenType::Lchevr => {
                         depth += 1;
                         inner.push('<');
-                    },
+                    }
                     TokenType::Rchevr => {
                         depth -= 1;
                         if depth == 0 {
@@ -609,7 +701,7 @@ fn parse_var(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
                         } else {
                             inner.push('>');
                         }
-                    },
+                    }
                     _ => inner.push_str(&t.lexeme),
                 }
             }
@@ -648,7 +740,11 @@ fn parse_var(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
         }
     };
 
-    let initial_value = if let Some(Token { token_type: TokenType::Equal, .. }) = tokens.peek() {
+    let initial_value = if let Some(Token {
+        token_type: TokenType::Equal,
+        ..
+    }) = tokens.peek()
+    {
         tokens.next(); // consume '='
         let expr = parse_expression(tokens)?;
         Some(expr)
@@ -662,7 +758,9 @@ fn parse_var(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
     }
     tokens.next();
 
-    if let (WaveType::Array(_, expected_len), Some(Expression::ArrayLiteral(elements))) = (&wave_type, &initial_value) {
+    if let (WaveType::Array(_, expected_len), Some(Expression::ArrayLiteral(elements))) =
+        (&wave_type, &initial_value)
+    {
         if *expected_len != elements.len() as u32 {
             println!(
                 "❌ Error: Array length mismatch. Expected {}, but got {} elements",
@@ -689,7 +787,11 @@ fn parse_println(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
     }
     tokens.next(); // Consume '('
 
-    let content = if let Some(Token { token_type: TokenType::String(content), .. }) = tokens.next() {
+    let content = if let Some(Token {
+        token_type: TokenType::String(content),
+        ..
+    }) = tokens.next()
+    {
         content.clone()
     } else {
         println!("Error: Expected string literal in 'println'");
@@ -714,13 +816,18 @@ fn parse_println(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         }
         tokens.next();
 
-        return Some(ASTNode::Statement(StatementNode::Println(
-            format!("{}\n", content),
-        )));
+        return Some(ASTNode::Statement(StatementNode::Println(format!(
+            "{}\n",
+            content
+        ))));
     }
 
     let mut args = Vec::new();
-    while let Some(Token { token_type: TokenType::Comma, .. }) = tokens.peek() {
+    while let Some(Token {
+        token_type: TokenType::Comma,
+        ..
+    }) = tokens.peek()
+    {
         tokens.next(); // Consume ','
         if let Some(expr) = parse_expression(tokens) {
             args.push(expr);
@@ -765,7 +872,11 @@ fn parse_print(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
     }
     tokens.next(); // Consume '('
 
-    let content = if let Some(Token { token_type: TokenType::String(content), .. }) = tokens.next() {
+    let content = if let Some(Token {
+        token_type: TokenType::String(content),
+        ..
+    }) = tokens.next()
+    {
         content.clone() // Need clone() because it is String
     } else {
         println!("Error: Expected string literal in 'println'");
@@ -791,13 +902,18 @@ fn parse_print(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         }
         tokens.next();
 
-        return Some(ASTNode::Statement(StatementNode::Print(
-            format!("{}", content),
-        )));
+        return Some(ASTNode::Statement(StatementNode::Print(format!(
+            "{}",
+            content
+        ))));
     }
 
     let mut args = Vec::new();
-    while let Some(Token { token_type: TokenType::Comma, .. }) = tokens.peek() {
+    while let Some(Token {
+        token_type: TokenType::Comma,
+        ..
+    }) = tokens.peek()
+    {
         tokens.next(); // Consume ','
         if let Some(expr) = parse_expression(tokens) {
             args.push(expr);
@@ -875,7 +991,11 @@ fn parse_if(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         }
         tokens.next(); // consume 'else'
 
-        if let Some(Token { token_type: TokenType::If, .. }) = tokens.peek() {
+        if let Some(Token {
+            token_type: TokenType::If,
+            ..
+        }) = tokens.peek()
+        {
             tokens.next(); // consume 'if'
 
             if tokens.peek()?.token_type != TokenType::Lparen {
@@ -991,9 +1111,15 @@ fn parse_import(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
     tokens.next();
 
     let import_path = match tokens.next() {
-        Some(Token { token_type: TokenType::String(s), .. }) => s.clone(),
+        Some(Token {
+            token_type: TokenType::String(s),
+            ..
+        }) => s.clone(),
         other => {
-            println!("Error: Expected string literal in import, found {:?}", other);
+            println!(
+                "Error: Expected string literal in import, found {:?}",
+                other
+            );
             return None;
         }
     };
@@ -1015,15 +1141,24 @@ fn parse_import(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
 
 fn parse_proto(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
     let target_struct = match tokens.next() {
-        Some(Token { token_type: TokenType::Identifier(name), .. }) => name.clone(),
+        Some(Token {
+            token_type: TokenType::Identifier(name),
+            ..
+        }) => name.clone(),
         other => {
-            println!("Error: Expected struct name after 'proto', found {:?}", other);
+            println!(
+                "Error: Expected struct name after 'proto', found {:?}",
+                other
+            );
             return None;
         }
     };
 
     if tokens.peek()?.token_type != TokenType::Lbrace {
-        println!("Error: Expected '{{' after proto target '{}'", target_struct);
+        println!(
+            "Error: Expected '{{' after proto target '{}'",
+            target_struct
+        );
         return None;
     }
     tokens.next(); // consume '{'
@@ -1034,7 +1169,10 @@ fn parse_proto(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         let token_type = if let Some(t) = tokens.peek() {
             t.token_type.clone()
         } else {
-            println!("Error: Unexpected end of file inside proto '{}' definition.", target_struct);
+            println!(
+                "Error: Unexpected end of file inside proto '{}' definition.",
+                target_struct
+            );
             return None;
         };
 
@@ -1051,7 +1189,10 @@ fn parse_proto(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
                     }
                     methods.push(func_node);
                 } else {
-                    println!("Error: Failed to parse method inside proto '{}'.", target_struct);
+                    println!(
+                        "Error: Failed to parse method inside proto '{}'.",
+                        target_struct
+                    );
                     return None;
                 }
             }
@@ -1075,14 +1216,20 @@ fn parse_proto(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
 
 fn parse_struct(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
     let name = match tokens.next() {
-        Some(Token { token_type: TokenType::Identifier(name), .. }) => name.clone(),
+        Some(Token {
+            token_type: TokenType::Identifier(name),
+            ..
+        }) => name.clone(),
         _ => {
             println!("Error: Expected struct name after 'struct' keyword.");
             return None;
         }
     };
 
-    if tokens.peek().map_or(true, |t| t.token_type != TokenType::Lbrace) {
+    if tokens
+        .peek()
+        .map_or(true, |t| t.token_type != TokenType::Lbrace)
+    {
         println!("Error: Expected '{{' after struct name '{}'.", name);
         return None;
     }
@@ -1095,7 +1242,10 @@ fn parse_struct(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         let token_type = if let Some(t) = tokens.peek() {
             t.token_type.clone()
         } else {
-            println!("Error: Unexpected end of file inside struct '{}' definition.", name);
+            println!(
+                "Error: Unexpected end of file inside struct '{}' definition.",
+                name
+            );
             return None;
         };
 
@@ -1122,16 +1272,30 @@ fn parse_struct(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
                 let mut lookahead = tokens.clone();
                 lookahead.next();
 
-                if let Some(Token { token_type: TokenType::Colon, .. }) = lookahead.peek() {
-                    let field_name = if let Some(Token { token_type: TokenType::Identifier(n), .. }) = tokens.next() {
+                if let Some(Token {
+                    token_type: TokenType::Colon,
+                    ..
+                }) = lookahead.peek()
+                {
+                    let field_name = if let Some(Token {
+                        token_type: TokenType::Identifier(n),
+                        ..
+                    }) = tokens.next()
+                    {
                         n.clone()
-                    } else { unreachable!() };
+                    } else {
+                        unreachable!()
+                    };
 
                     tokens.next();
 
                     let type_token = tokens.next();
                     let wave_type = parse_type_from_token(type_token.as_ref()).or_else(|| {
-                        if let Some(Token { token_type: TokenType::Identifier(id), .. }) = type_token {
+                        if let Some(Token {
+                            token_type: TokenType::Identifier(id),
+                            ..
+                        }) = type_token
+                        {
                             Some(WaveType::Struct(id.clone()))
                         } else {
                             None
@@ -1139,29 +1303,42 @@ fn parse_struct(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
                     });
 
                     if wave_type.is_none() {
-                        println!("Error: Invalid type for field '{}' in struct '{}'.", field_name, name);
+                        println!(
+                            "Error: Invalid type for field '{}' in struct '{}'.",
+                            field_name, name
+                        );
                         return None;
                     }
 
-                    if tokens.peek().map_or(true, |t| t.token_type != TokenType::SemiColon) {
-                        println!("Error: Expected ';' after field declaration in struct '{}'.", name);
+                    if tokens
+                        .peek()
+                        .map_or(true, |t| t.token_type != TokenType::SemiColon)
+                    {
+                        println!(
+                            "Error: Expected ';' after field declaration in struct '{}'.",
+                            name
+                        );
                         return None;
                     }
                     tokens.next();
 
                     fields.push((field_name, wave_type.unwrap()));
                 } else {
-                    let id_str = if let TokenType::Identifier(id) = &tokens.peek().unwrap().token_type {
-                        id.clone()
-                    } else {
-                        "".to_string()
-                    };
+                    let id_str =
+                        if let TokenType::Identifier(id) = &tokens.peek().unwrap().token_type {
+                            id.clone()
+                        } else {
+                            "".to_string()
+                        };
                     println!("Error: Unexpected identifier '{}' in struct '{}' body. Expected field or method.", id_str, name);
                     return None;
                 }
             }
             other_token => {
-                println!("Error: Unexpected token inside struct body: {:?}", other_token);
+                println!(
+                    "Error: Unexpected token inside struct body: {:?}",
+                    other_token
+                );
                 return None;
             }
         }
@@ -1173,7 +1350,6 @@ fn parse_struct(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         methods,
     }))
 }
-
 
 fn parse_asm_block(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
     if tokens.peek()?.token_type != TokenType::Lbrace {
@@ -1200,10 +1376,19 @@ fn parse_asm_block(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
 
                 let reg_token = tokens.next();
                 let reg = match reg_token {
-                    Some(Token { token_type: TokenType::String(s), .. }) => s.clone(),
-                    Some(Token { token_type: TokenType::Identifier(s), .. }) => s.clone(),
+                    Some(Token {
+                        token_type: TokenType::String(s),
+                        ..
+                    }) => s.clone(),
+                    Some(Token {
+                        token_type: TokenType::Identifier(s),
+                        ..
+                    }) => s.clone(),
                     Some(other) => {
-                        println!("Expected register string or identifier, got {:?}", other.token_type);
+                        println!(
+                            "Expected register string or identifier, got {:?}",
+                            other.token_type
+                        );
                         return None;
                     }
                     None => {
@@ -1219,37 +1404,57 @@ fn parse_asm_block(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
 
                 let value_token = tokens.next();
                 let value = match value_token {
-                    Some(Token { token_type: TokenType::Minus, .. }) => {
-                        match tokens.next() {
-                            Some(Token { token_type: TokenType::Number(n), .. }) => format!("-{}", n),
-                            Some(other) => {
-                                println!("Expected number after '-', got {:?}", other.token_type);
-                                return None;
-                            }
-                            None => {
-                                println!("Expected number after '-'");
-                                return None;
-                            }
+                    Some(Token {
+                        token_type: TokenType::Minus,
+                        ..
+                    }) => match tokens.next() {
+                        Some(Token {
+                            token_type: TokenType::Number(n),
+                            ..
+                        }) => format!("-{}", n),
+                        Some(other) => {
+                            println!("Expected number after '-', got {:?}", other.token_type);
+                            return None;
                         }
-                    }
-                    Some(Token { token_type: TokenType::AddressOf, .. }) => {
-                        match tokens.next() {
-                            Some(Token { token_type: TokenType::Identifier(s), .. }) => format!("&{}", s),
-                            Some(other) => {
-                                println!("Expected identifier after '&', got {:?}", other.token_type);
-                                return None;
-                            }
-                            None => {
-                                println!("Expected identifier after '&'");
-                                return None;
-                            }
+                        None => {
+                            println!("Expected number after '-'");
+                            return None;
                         }
                     },
-                    Some(Token { token_type: TokenType::Identifier(s), .. }) => s.clone(),
-                    Some(Token { token_type: TokenType::Number(n), .. }) => n.to_string(),
-                    Some(Token { token_type: TokenType::String(n), .. }) => n.to_string(),
+                    Some(Token {
+                        token_type: TokenType::AddressOf,
+                        ..
+                    }) => match tokens.next() {
+                        Some(Token {
+                            token_type: TokenType::Identifier(s),
+                            ..
+                        }) => format!("&{}", s),
+                        Some(other) => {
+                            println!("Expected identifier after '&', got {:?}", other.token_type);
+                            return None;
+                        }
+                        None => {
+                            println!("Expected identifier after '&'");
+                            return None;
+                        }
+                    },
+                    Some(Token {
+                        token_type: TokenType::Identifier(s),
+                        ..
+                    }) => s.clone(),
+                    Some(Token {
+                        token_type: TokenType::Number(n),
+                        ..
+                    }) => n.to_string(),
+                    Some(Token {
+                        token_type: TokenType::String(n),
+                        ..
+                    }) => n.to_string(),
                     Some(other) => {
-                        println!("Expected identifier or number after in/out(...), got {:?}", other.token_type);
+                        println!(
+                            "Expected identifier or number after in/out(...), got {:?}",
+                            other.token_type
+                        );
                         return None;
                     }
                     None => {
@@ -1286,7 +1491,10 @@ fn parse_assignment(tokens: &mut Peekable<Iter<Token>>, first_token: &Token) -> 
     let left_expr = match parse_expression_from_token(first_token, tokens) {
         Some(expr) => expr,
         None => {
-            println!("Error: Failed to parse left-hand side of assignment. Token: {:?}", first_token.token_type);
+            println!(
+                "Error: Failed to parse left-hand side of assignment. Token: {:?}",
+                first_token.token_type
+            );
             return None;
         }
     };
@@ -1321,16 +1529,22 @@ fn parse_assignment(tokens: &mut Peekable<Iter<Token>>, first_token: &Token) -> 
 
     let right_expr = parse_expression(tokens)?;
 
-    if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+    if let Some(Token {
+        token_type: TokenType::SemiColon,
+        ..
+    }) = tokens.peek()
+    {
         tokens.next();
     }
 
     match (assign_op, &left_expr) {
-        (Some(op), Expression::Variable(name)) => Some(ASTNode::Expression(Expression::AssignOperation {
-            target: Box::new(Expression::Variable(name.clone())),
-            operator: op,
-            value: Box::new(right_expr),
-        })),
+        (Some(op), Expression::Variable(name)) => {
+            Some(ASTNode::Expression(Expression::AssignOperation {
+                target: Box::new(Expression::Variable(name.clone())),
+                operator: op,
+                value: Box::new(right_expr),
+            }))
+        }
         (None, Expression::Variable(name)) => Some(ASTNode::Statement(StatementNode::Assign {
             variable: name.clone(),
             value: right_expr,
@@ -1344,7 +1558,10 @@ fn parse_assignment(tokens: &mut Peekable<Iter<Token>>, first_token: &Token) -> 
             },
         })),
         (_, _) => {
-            println!("Error: Unsupported assignment left expression: {:?}", left_expr);
+            println!(
+                "Error: Unsupported assignment left expression: {:?}",
+                left_expr
+            );
             None
         }
     }
@@ -1368,7 +1585,10 @@ fn parse_block(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> {
 
     if let Some(token) = tokens.next() {
         if token.token_type != TokenType::Rbrace {
-            println!("Error: Expected '}}' to close the block, but found {:?}", token.token_type);
+            println!(
+                "Error: Expected '}}' to close the block, but found {:?}",
+                token.token_type
+            );
             return None;
         }
     } else {
@@ -1412,28 +1632,44 @@ fn parse_statement(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         }
         TokenType::Continue => {
             tokens.next();
-            if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+            if let Some(Token {
+                token_type: TokenType::SemiColon,
+                ..
+            }) = tokens.peek()
+            {
                 tokens.next();
             }
             Some(ASTNode::Statement(StatementNode::Continue))
         }
         TokenType::Break => {
             tokens.next();
-            if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+            if let Some(Token {
+                token_type: TokenType::SemiColon,
+                ..
+            }) = tokens.peek()
+            {
                 tokens.next();
             }
             Some(ASTNode::Statement(StatementNode::Break))
         }
         TokenType::Return => {
             tokens.next();
-            let expr = if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+            let expr = if let Some(Token {
+                token_type: TokenType::SemiColon,
+                ..
+            }) = tokens.peek()
+            {
                 tokens.next();
                 None
             } else if tokens.peek().is_none() {
                 None
             } else {
                 let value = parse_expression(tokens)?;
-                if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+                if let Some(Token {
+                    token_type: TokenType::SemiColon,
+                    ..
+                }) = tokens.peek()
+                {
                     tokens.next();
                 }
                 Some(value)
@@ -1445,7 +1681,11 @@ fn parse_statement(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         _ => {
             if is_expression_start(&token.token_type) {
                 if let Some(expr) = parse_expression(tokens) {
-                    if let Some(Token { token_type: TokenType::SemiColon, .. }) = tokens.peek() {
+                    if let Some(Token {
+                        token_type: TokenType::SemiColon,
+                        ..
+                    }) = tokens.peek()
+                    {
                         tokens.next();
                     }
                     Some(ASTNode::Statement(StatementNode::Expression(expr)))
@@ -1454,7 +1694,10 @@ fn parse_statement(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
                     None
                 }
             } else {
-                println!("Error: Unexpected token, cannot start a statement with: {:?}", token.token_type);
+                println!(
+                    "Error: Unexpected token, cannot start a statement with: {:?}",
+                    token.token_type
+                );
                 tokens.next();
                 None
             }

--- a/front/parser/src/parser/stdlib.rs
+++ b/front/parser/src/parser/stdlib.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
-use crate::ast::{WaveType, FunctionSignature};
+use crate::ast::{FunctionSignature, WaveType};
 use error::error::{WaveError, WaveErrorKind};
+use std::collections::HashMap;
 
 /// Struct for managing symbol information of standard library modules
 #[derive(Debug, Clone)]
@@ -67,13 +67,21 @@ impl StdlibManager {
     }
 
     /// Function call validation is handled by Vex - Wave only checks syntax
-    pub fn validate_function_call(&self, module_name: &str, function_name: &str, _arg_types: &[WaveType]) -> Result<(), WaveError> {
+    pub fn validate_function_call(
+        &self,
+        module_name: &str,
+        function_name: &str,
+        _arg_types: &[WaveType],
+    ) -> Result<(), WaveError> {
         self.validate_stdlib_import(module_name)?;
 
         // TODO: Implement actual function signature validation with Vex
         // Wave compiler does not know function signatures
         // Type validation and function existence is Vex package manager's responsibility
-        println!("Note: Function '{}::{}' will be validated by Vex package manager", module_name, function_name);
+        println!(
+            "Note: Function '{}::{}' will be validated by Vex package manager",
+            module_name, function_name
+        );
 
         Ok(())
     }
@@ -83,7 +91,10 @@ impl StdlibManager {
         // TODO: Implement actual manifest file parsing and metadata loading
         // Load information from standard library manifest file provided by Vex
         // Wave compiler only acts as an interface
-        println!("Loading stdlib metadata from Vex manifest: {}", manifest_path);
+        println!(
+            "Loading stdlib metadata from Vex manifest: {}",
+            manifest_path
+        );
         Ok(())
     }
 
@@ -92,7 +103,10 @@ impl StdlibManager {
         // TODO: Implement actual linking information retrieval from Vex
         // Wave compiler does not have linking information
         // All linking information is provided by Vex package manager
-        println!("Note: Linking info for '{}' will be provided by Vex", module_name);
+        println!(
+            "Note: Linking info for '{}' will be provided by Vex",
+            module_name
+        );
         None
     }
 
@@ -143,14 +157,20 @@ impl VexInterface {
 
         // Wave compiler does not know module contents
         // Only forwards information provided by Vex
-        Ok(format!("Module '{}' metadata will be provided by Vex", module_name))
+        Ok(format!(
+            "Module '{}' metadata will be provided by Vex",
+            module_name
+        ))
     }
 
     /// Check if project has standard library dependencies
     pub fn check_stdlib_dependencies(&self) -> Result<Vec<String>, WaveError> {
         // TODO: Implement actual dependency checking from Vex.toml or similar config file
         // Check dependencies from Vex.toml or similar configuration file
-        println!("Checking stdlib dependencies in project: {}", self.project_root);
+        println!(
+            "Checking stdlib dependencies in project: {}",
+            self.project_root
+        );
 
         // Wave compiler does not analyze dependencies directly
         // Forwards information provided by Vex as-is

--- a/front/parser/src/parser/type_system.rs
+++ b/front/parser/src/parser/type_system.rs
@@ -1,8 +1,8 @@
-use std::iter::Peekable;
-use std::slice::Iter;
-use lexer::{Token, TokenType};
 use crate::ast::WaveType;
 use crate::*;
+use lexer::{Token, TokenType};
+use std::iter::Peekable;
+use std::slice::Iter;
 
 pub fn is_expression_start(token_type: &TokenType) -> bool {
     matches!(
@@ -85,8 +85,12 @@ pub fn parse_type(type_str: &str) -> Option<TokenType> {
         return Some(TokenType::TypeString);
     }
 
-    if type_str.chars().next().map_or(false, |c| c.is_alphabetic() || c == '_') &&
-        type_str.chars().all(|c| c.is_alphanumeric() || c == '_') {
+    if type_str
+        .chars()
+        .next()
+        .map_or(false, |c| c.is_alphabetic() || c == '_')
+        && type_str.chars().all(|c| c.is_alphanumeric() || c == '_')
+    {
         return Some(TokenType::TypeCustom(type_str.to_string()));
     }
 
@@ -127,45 +131,45 @@ pub fn parse_type_from_token(token_opt: Option<&&Token>) -> Option<WaveType> {
         | ty @ TokenType::TypeArray(_, _)
         | ty @ TokenType::TokenTypeInt(_)
         | ty @ TokenType::TokenTypeUint(_)
-        | ty @ TokenType::TokenTypeFloat(_)
-        => token_type_to_wave_type(ty),
+        | ty @ TokenType::TokenTypeFloat(_) => token_type_to_wave_type(ty),
 
-        TokenType::Identifier(name) => {
-            match name.as_str() {
-                "i8" => Some(WaveType::Int(8)),
-                "i16" => Some(WaveType::Int(16)),
-                "i32" => Some(WaveType::Int(32)),
-                "i64" => Some(WaveType::Int(64)),
-                "u8" => Some(WaveType::Uint(8)),
-                "u16" => Some(WaveType::Uint(16)),
-                "u32" => Some(WaveType::Uint(32)),
-                "u64" => Some(WaveType::Uint(64)),
-                "f32" => Some(WaveType::Float(32)),
-                "f64" => Some(WaveType::Float(64)),
-                "bool" => Some(WaveType::Bool),
-                "char" => Some(WaveType::Char),
-                "byte" => Some(WaveType::Byte),
-                "str" => Some(WaveType::String),
-                _ => {
-                    if let Some(tt) = parse_type(name) {
-                        token_type_to_wave_type(&tt)
-                    } else {
-                        Some(WaveType::Struct(name.clone()))
-                    }
+        TokenType::Identifier(name) => match name.as_str() {
+            "i8" => Some(WaveType::Int(8)),
+            "i16" => Some(WaveType::Int(16)),
+            "i32" => Some(WaveType::Int(32)),
+            "i64" => Some(WaveType::Int(64)),
+            "u8" => Some(WaveType::Uint(8)),
+            "u16" => Some(WaveType::Uint(16)),
+            "u32" => Some(WaveType::Uint(32)),
+            "u64" => Some(WaveType::Uint(64)),
+            "f32" => Some(WaveType::Float(32)),
+            "f64" => Some(WaveType::Float(64)),
+            "bool" => Some(WaveType::Bool),
+            "char" => Some(WaveType::Char),
+            "byte" => Some(WaveType::Byte),
+            "str" => Some(WaveType::String),
+            _ => {
+                if let Some(tt) = parse_type(name) {
+                    token_type_to_wave_type(&tt)
+                } else {
+                    Some(WaveType::Struct(name.clone()))
                 }
             }
-        }
+        },
 
         _ => None,
     }
 }
 
-
 pub fn parse_type_from_stream(tokens: &mut Peekable<Iter<Token>>) -> Option<WaveType> {
     let type_token = tokens.next()?; // consume identifier
 
     if let TokenType::Identifier(name) = &type_token.token_type {
-        if let Some(Token { token_type: TokenType::Lchevr, .. }) = tokens.peek() {
+        if let Some(Token {
+            token_type: TokenType::Lchevr,
+            ..
+        }) = tokens.peek()
+        {
             tokens.next(); // consume '<'
 
             let inner_type = parse_type_from_stream(tokens)?;

--- a/llvm_temporary/build.rs
+++ b/llvm_temporary/build.rs
@@ -39,8 +39,8 @@ fn linux_original() {
 
 fn try_macos_paths() {
     let candidates = [
-        "/opt/homebrew/opt/llvm@14",   // Apple Silicon
-        "/usr/local/opt/llvm@14",      // Intel
+        "/opt/homebrew/opt/llvm@14", // Apple Silicon
+        "/usr/local/opt/llvm@14",    // Intel
     ];
 
     for prefix in candidates {
@@ -69,10 +69,7 @@ fn link_macos(prefix: PathBuf) {
 }
 
 fn try_windows_paths() {
-    let candidates = [
-        r"C:\Program Files\LLVM",
-        r"C:\Program Files (x86)\LLVM",
-    ];
+    let candidates = [r"C:\Program Files\LLVM", r"C:\Program Files (x86)\LLVM"];
 
     for prefix in candidates {
         let path = PathBuf::from(prefix);

--- a/llvm_temporary/src/lib.rs
+++ b/llvm_temporary/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod llvm_temporary;
 
 pub fn backend() -> Option<String> {
-    option_env!("WAVE_LLVM_MAJOR")
-        .map(|v| format!("LLVM {}", v))
+    option_env!("WAVE_LLVM_MAJOR").map(|v| format!("LLVM {}", v))
 }

--- a/llvm_temporary/src/llvm_temporary/llvm_backend.rs
+++ b/llvm_temporary/src/llvm_temporary/llvm_backend.rs
@@ -1,6 +1,6 @@
-use std::process::Command;
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
 pub fn compile_ir_to_object(ir: &str, file_stem: &str, opt_flag: &str) -> String {
     let object_path = format!("target/{}.o", file_stem);
@@ -19,7 +19,12 @@ pub fn compile_ir_to_object(ir: &str, file_stem: &str, opt_flag: &str) -> String
         .expect("Failed to execute clang");
 
     use std::io::Write;
-    child.stdin.as_mut().unwrap().write_all(ir.as_bytes()).unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(ir.as_bytes())
+        .unwrap();
 
     let output = child.wait_with_output().unwrap();
     if !output.status.success() {
@@ -30,12 +35,7 @@ pub fn compile_ir_to_object(ir: &str, file_stem: &str, opt_flag: &str) -> String
     object_path
 }
 
-pub fn link_objects(
-    objects: &[String],
-    output: &str,
-    libs: &[String],
-    lib_paths: &[String],
-) {
+pub fn link_objects(objects: &[String], output: &str, libs: &[String], lib_paths: &[String]) {
     let mut cmd = Command::new("clang");
 
     for obj in objects {
@@ -50,9 +50,7 @@ pub fn link_objects(
         cmd.arg(format!("-l{}", lib));
     }
 
-    cmd.arg("-o").arg(output)
-        .arg("-lc")
-        .arg("-lm");
+    cmd.arg("-o").arg(output).arg("-lc").arg("-lm");
 
     let output = cmd.output().expect("Failed to link");
     if !output.status.success() {

--- a/llvm_temporary/src/llvm_temporary/mod.rs
+++ b/llvm_temporary/src/llvm_temporary/mod.rs
@@ -1,4 +1,23 @@
-pub mod llvm_codegen;
-pub mod llvm_backend;
+#![allow(
+    dead_code,
+    unused_variables,
+    clippy::module_inception,
+    clippy::type_complexity,
+    clippy::unnecessary_map_or,
+    clippy::question_mark,
+    clippy::result_large_err,
+    clippy::ptr_arg,
+    clippy::while_let_on_iterator,
+    clippy::needless_borrow,
+    clippy::useless_format,
+    clippy::manual_strip,
+    clippy::explicit_auto_deref,
+    clippy::collapsible_if,
+    clippy::collapsible_else_if,
+    clippy::new_without_default
+)]
+
 mod expression;
+pub mod llvm_backend;
+pub mod llvm_codegen;
 mod statement;

--- a/llvm_temporary/src/llvm_temporary/statement.rs
+++ b/llvm_temporary/src/llvm_temporary/statement.rs
@@ -1,13 +1,17 @@
-use std::collections::HashMap;
-use inkwell::{AddressSpace, FloatPredicate};
+use crate::llvm_temporary::expression::generate_expression_ir;
+use crate::llvm_temporary::llvm_codegen::{
+    generate_address_ir, wave_format_to_c, wave_type_to_llvm_type, VariableInfo,
+};
 use inkwell::basic_block::BasicBlock;
 use inkwell::context::Context;
 use inkwell::module::Linkage;
 use inkwell::types::{AnyTypeEnum, BasicType, BasicTypeEnum, StructType};
 use inkwell::values::{BasicValue, BasicValueEnum, FunctionValue};
-use parser::ast::{ASTNode, Expression, Literal, Mutability, StatementNode, VariableNode, WaveType};
-use crate::llvm_temporary::expression::{generate_expression_ir};
-use crate::llvm_temporary::llvm_codegen::{generate_address_ir, wave_format_to_c, wave_type_to_llvm_type, VariableInfo};
+use inkwell::{AddressSpace, FloatPredicate};
+use parser::ast::{
+    ASTNode, Expression, Literal, Mutability, StatementNode, VariableNode, WaveType,
+};
+use std::collections::HashMap;
 
 pub fn generate_statement_ir<'ctx>(
     context: &'ctx Context,
@@ -25,15 +29,17 @@ pub fn generate_statement_ir<'ctx>(
 ) {
     match stmt {
         ASTNode::Variable(VariableNode {
-                              name,
-                              type_name,
-                              initial_value,
-                              mutability
-                          }) => unsafe {
+            name,
+            type_name,
+            initial_value,
+            mutability,
+        }) => unsafe {
             let llvm_type = wave_type_to_llvm_type(&context, &type_name, &struct_types);
             let alloca = builder.build_alloca(llvm_type, &name).unwrap();
 
-            if let (WaveType::Array(element_type, size), Some(Expression::ArrayLiteral(values))) = (&type_name, &initial_value) {
+            if let (WaveType::Array(element_type, size), Some(Expression::ArrayLiteral(values))) =
+                (&type_name, &initial_value)
+            {
                 if values.len() != *size as usize {
                     panic!(
                         "❌ Array length mismatch: expected {}, got {}",
@@ -42,19 +48,32 @@ pub fn generate_statement_ir<'ctx>(
                     );
                 }
 
-                let llvm_element_type = wave_type_to_llvm_type(context, element_type, &struct_types);
+                let llvm_element_type =
+                    wave_type_to_llvm_type(context, element_type, &struct_types);
 
                 for (i, value_expr) in values.iter().enumerate() {
-                    let value = generate_expression_ir(context, builder, value_expr, variables, module, Some(llvm_element_type), global_consts, &struct_types, struct_field_indices);
+                    let value = generate_expression_ir(
+                        context,
+                        builder,
+                        value_expr,
+                        variables,
+                        module,
+                        Some(llvm_element_type),
+                        global_consts,
+                        &struct_types,
+                        struct_field_indices,
+                    );
 
-                    let gep = builder.build_in_bounds_gep(
-                        alloca,
-                        &[
-                            context.i32_type().const_zero(),
-                            context.i32_type().const_int(i as u64, false),
-                        ],
-                        &format!("array_idx_{}", i),
-                    ).unwrap();
+                    let gep = builder
+                        .build_in_bounds_gep(
+                            alloca,
+                            &[
+                                context.i32_type().const_zero(),
+                                context.i32_type().const_int(i as u64, false),
+                            ],
+                            &format!("array_idx_{}", i),
+                        )
+                        .unwrap();
 
                     builder.build_store(gep, value).unwrap();
                 }
@@ -82,11 +101,17 @@ pub fn generate_statement_ir<'ctx>(
 
             if let Some(init) = initial_value {
                 match (init, llvm_type) {
-                    (Expression::Literal(Literal::Number(value)), BasicTypeEnum::IntType(int_type)) => {
+                    (
+                        Expression::Literal(Literal::Number(value)),
+                        BasicTypeEnum::IntType(int_type),
+                    ) => {
                         let init_value = int_type.const_int(*value as u64, false);
                         let _ = builder.build_store(alloca, init_value);
                     }
-                    (Expression::Literal(Literal::Float(value)), BasicTypeEnum::FloatType(float_type)) => {
+                    (
+                        Expression::Literal(Literal::Float(value)),
+                        BasicTypeEnum::FloatType(float_type),
+                    ) => {
                         let init_value = float_type.const_float(*value);
                         builder.build_store(alloca, init_value).unwrap();
                     }
@@ -94,16 +119,20 @@ pub fn generate_statement_ir<'ctx>(
                         let float_value = context.f32_type().const_float(*value);
 
                         let casted_value = match llvm_type {
-                            BasicTypeEnum::IntType(int_ty) => {
-                                builder.build_float_to_signed_int(float_value, int_ty, "float_to_int").unwrap().as_basic_value_enum()
-                            }
+                            BasicTypeEnum::IntType(int_ty) => builder
+                                .build_float_to_signed_int(float_value, int_ty, "float_to_int")
+                                .unwrap()
+                                .as_basic_value_enum(),
                             BasicTypeEnum::FloatType(_) => float_value.as_basic_value_enum(),
                             _ => panic!("Unsupported type for float literal initialization"),
                         };
 
                         builder.build_store(alloca, casted_value).unwrap();
                     }
-                    (Expression::Literal(Literal::String(value)), BasicTypeEnum::PointerType(_)) => unsafe {
+                    (
+                        Expression::Literal(Literal::String(value)),
+                        BasicTypeEnum::PointerType(_),
+                    ) => unsafe {
                         let string_name = format!("str_init_{}", name);
                         let mut bytes = value.as_bytes().to_vec();
                         bytes.push(0); // null-terminated
@@ -120,14 +149,17 @@ pub fn generate_statement_ir<'ctx>(
 
                         let zero = context.i32_type().const_zero();
                         let indices = [zero, zero];
-                        let gep = builder.build_gep(global.as_pointer_value(), &indices, "str_gep").unwrap();
+                        let gep = builder
+                            .build_gep(global.as_pointer_value(), &indices, "str_gep")
+                            .unwrap();
 
                         let _ = builder.build_store(alloca, gep);
-                    }
+                    },
                     (Expression::AddressOf(inner_expr), BasicTypeEnum::PointerType(_)) => {
                         match &**inner_expr {
                             Expression::Variable(var_name) => {
-                                let ptr = variables.get(var_name)
+                                let ptr = variables
+                                    .get(var_name)
                                     .unwrap_or_else(|| panic!("Variable {} not found", var_name));
                                 builder.build_store(alloca, ptr.ptr).unwrap();
                             }
@@ -135,7 +167,9 @@ pub fn generate_statement_ir<'ctx>(
                                 let elem_type = match llvm_type {
                                     BasicTypeEnum::PointerType(ptr_ty) => {
                                         match ptr_ty.get_element_type() {
-                                            AnyTypeEnum::ArrayType(arr_ty) => arr_ty.get_element_type(),
+                                            AnyTypeEnum::ArrayType(arr_ty) => {
+                                                arr_ty.get_element_type()
+                                            }
                                             _ => panic!("Expected pointer to array type"),
                                         }
                                     }
@@ -143,7 +177,8 @@ pub fn generate_statement_ir<'ctx>(
                                 };
 
                                 let array_type = elem_type.array_type(elements.len() as u32);
-                                let tmp_alloca = builder.build_alloca(array_type, "tmp_array").unwrap();
+                                let tmp_alloca =
+                                    builder.build_alloca(array_type, "tmp_array").unwrap();
 
                                 for (i, expr) in elements.iter().enumerate() {
                                     let val = generate_expression_ir(
@@ -155,29 +190,36 @@ pub fn generate_statement_ir<'ctx>(
                                         Some(elem_type),
                                         global_consts,
                                         &struct_types,
-                                        struct_field_indices
+                                        struct_field_indices,
                                     );
-                                    let gep = builder.build_in_bounds_gep(
-                                        tmp_alloca,
-                                        &[
-                                            context.i32_type().const_zero(),
-                                            context.i32_type().const_int(i as u64, false),
-                                        ],
-                                        &format!("array_idx_{}", i),
-                                    ).unwrap();
+                                    let gep = builder
+                                        .build_in_bounds_gep(
+                                            tmp_alloca,
+                                            &[
+                                                context.i32_type().const_zero(),
+                                                context.i32_type().const_int(i as u64, false),
+                                            ],
+                                            &format!("array_idx_{}", i),
+                                        )
+                                        .unwrap();
                                     builder.build_store(gep, val).unwrap();
                                 }
 
                                 builder.build_store(alloca, tmp_alloca).unwrap();
                             }
-                            _ => panic!("& operator must be used on variable name or array literal"),
+                            _ => {
+                                panic!("& operator must be used on variable name or array literal")
+                            }
                         }
                     }
                     (Expression::Deref(inner_expr), BasicTypeEnum::IntType(int_type)) => {
                         let target_ptr = match &**inner_expr {
                             Expression::Variable(var_name) => {
                                 let ptr_to_value = variables.get(var_name).unwrap().ptr;
-                                builder.build_load(ptr_to_value, "load_ptr").unwrap().into_pointer_value()
+                                builder
+                                    .build_load(ptr_to_value, "load_ptr")
+                                    .unwrap()
+                                    .into_pointer_value()
                             }
                             _ => panic!("Invalid deref in variable init"),
                         };
@@ -186,30 +228,63 @@ pub fn generate_statement_ir<'ctx>(
                         let _ = builder.build_store(alloca, val);
                     }
                     (Expression::IndexAccess { target, index }, _) => {
-                        let val = generate_expression_ir(context, builder, init, variables, module, Some(llvm_type), global_consts, &struct_types, struct_field_indices);
+                        let val = generate_expression_ir(
+                            context,
+                            builder,
+                            init,
+                            variables,
+                            module,
+                            Some(llvm_type),
+                            global_consts,
+                            &struct_types,
+                            struct_field_indices,
+                        );
                         builder.build_store(alloca, val).unwrap();
                     }
                     (Expression::FunctionCall { .. } | Expression::MethodCall { .. }, _) => {
-                        let val = generate_expression_ir(context, builder, init, variables, module, Some(llvm_type), global_consts, &struct_types, struct_field_indices);
+                        let val = generate_expression_ir(
+                            context,
+                            builder,
+                            init,
+                            variables,
+                            module,
+                            Some(llvm_type),
+                            global_consts,
+                            &struct_types,
+                            struct_field_indices,
+                        );
                         builder.build_store(alloca, val).unwrap();
                     }
                     (Expression::BinaryExpression { .. }, _) => {
-                        let val = generate_expression_ir(context, builder, init, variables, module, Some(llvm_type), global_consts, &struct_types, struct_field_indices);
+                        let val = generate_expression_ir(
+                            context,
+                            builder,
+                            init,
+                            variables,
+                            module,
+                            Some(llvm_type),
+                            global_consts,
+                            &struct_types,
+                            struct_field_indices,
+                        );
 
                         let casted_val = match (val, llvm_type) {
-                            (BasicValueEnum::FloatValue(v), BasicTypeEnum::IntType(t)) => {
-                                builder.build_float_to_signed_int(v, t, "float_to_int").unwrap().as_basic_value_enum()
-                            }
-                            (BasicValueEnum::IntValue(v), BasicTypeEnum::FloatType(t)) => {
-                                builder.build_signed_int_to_float(v, t, "int_to_float").unwrap().as_basic_value_enum()
-                            }
+                            (BasicValueEnum::FloatValue(v), BasicTypeEnum::IntType(t)) => builder
+                                .build_float_to_signed_int(v, t, "float_to_int")
+                                .unwrap()
+                                .as_basic_value_enum(),
+                            (BasicValueEnum::IntValue(v), BasicTypeEnum::FloatType(t)) => builder
+                                .build_signed_int_to_float(v, t, "int_to_float")
+                                .unwrap()
+                                .as_basic_value_enum(),
                             _ => val,
                         };
 
                         builder.build_store(alloca, casted_val).unwrap();
                     }
                     (Expression::Variable(var_name), _) => {
-                        let source_var = variables.get(var_name)
+                        let source_var = variables
+                            .get(var_name)
                             .unwrap_or_else(|| panic!("Variable {} not found", var_name));
 
                         let loaded_value = builder
@@ -220,27 +295,40 @@ pub fn generate_statement_ir<'ctx>(
 
                         let casted_value = match (loaded_type, llvm_type) {
                             (BasicTypeEnum::IntType(_), BasicTypeEnum::FloatType(float_ty)) => {
-                                builder.build_signed_int_to_float(
-                                    loaded_value.into_int_value(),
-                                    float_ty,
-                                    "int_to_float",
-                                ).unwrap().as_basic_value_enum()
+                                builder
+                                    .build_signed_int_to_float(
+                                        loaded_value.into_int_value(),
+                                        float_ty,
+                                        "int_to_float",
+                                    )
+                                    .unwrap()
+                                    .as_basic_value_enum()
                             }
                             (BasicTypeEnum::FloatType(_), BasicTypeEnum::IntType(int_ty)) => {
-                                builder.build_float_to_signed_int(
-                                    loaded_value.into_float_value(),
-                                    int_ty,
-                                    "float_to_int",
-                                ).unwrap().as_basic_value_enum()
+                                builder
+                                    .build_float_to_signed_int(
+                                        loaded_value.into_float_value(),
+                                        int_ty,
+                                        "float_to_int",
+                                    )
+                                    .unwrap()
+                                    .as_basic_value_enum()
                             }
                             _ => loaded_value,
                         };
 
                         builder.build_store(alloca, casted_value).unwrap();
                     }
-                    (Expression::AsmBlock { instructions, inputs, outputs }, BasicTypeEnum::IntType(int_type)) => {
-                        use inkwell::InlineAsmDialect;
+                    (
+                        Expression::AsmBlock {
+                            instructions,
+                            inputs,
+                            outputs,
+                        },
+                        BasicTypeEnum::IntType(int_type),
+                    ) => {
                         use inkwell::values::{BasicMetadataValueEnum, CallableValue};
+                        use inkwell::InlineAsmDialect;
 
                         let asm_code: String = instructions.join("\n");
                         let mut operand_vals: Vec<BasicMetadataValueEnum> = vec![];
@@ -293,7 +381,9 @@ pub fn generate_statement_ir<'ctx>(
                             .unwrap();
 
                         if expects_return {
-                            let result = call.try_as_basic_value().left()
+                            let result = call
+                                .try_as_basic_value()
+                                .left()
                                 .expect("Expected return value from inline asm but got none");
 
                             builder.build_store(alloca, result).unwrap();
@@ -315,13 +405,16 @@ pub fn generate_statement_ir<'ctx>(
                         builder.build_store(alloca, val).unwrap();
                     }
                     _ => {
-                        panic!("Unsupported type/value combination for initialization: {:?}", init);
+                        panic!(
+                            "Unsupported type/value combination for initialization: {:?}",
+                            init
+                        );
                     }
                 }
             }
-        }
-        ASTNode::Statement(StatementNode::Println(message)) |
-        ASTNode::Statement(StatementNode::Print(message)) => {
+        },
+        ASTNode::Statement(StatementNode::Println(message))
+        | ASTNode::Statement(StatementNode::Print(message)) => {
             let global_name = format!("str_{}", *string_counter);
             *string_counter += 1;
 
@@ -350,16 +443,28 @@ pub fn generate_statement_ir<'ctx>(
             let zero = context.i32_type().const_zero();
             let indices = [zero, zero];
             let gep = unsafe {
-                builder.build_gep(global.as_pointer_value(), &indices, "gep").unwrap()
+                builder
+                    .build_gep(global.as_pointer_value(), &indices, "gep")
+                    .unwrap()
             };
 
             let _ = builder.build_call(printf_func, &[gep.into()], "printf_call");
         }
-        ASTNode::Statement(StatementNode::PrintlnFormat { format, args }) |
-        ASTNode::Statement(StatementNode::PrintFormat { format, args }) => {
+        ASTNode::Statement(StatementNode::PrintlnFormat { format, args })
+        | ASTNode::Statement(StatementNode::PrintFormat { format, args }) => {
             let mut arg_types = vec![];
             for arg in args {
-                let val = generate_expression_ir(context, builder, arg, variables, module, None, global_consts, &struct_types, struct_field_indices);
+                let val = generate_expression_ir(
+                    context,
+                    builder,
+                    arg,
+                    variables,
+                    module,
+                    None,
+                    global_consts,
+                    &struct_types,
+                    struct_field_indices,
+                );
                 arg_types.push(val.get_type());
             }
             let c_format_string = wave_format_to_c(&format, &arg_types);
@@ -392,17 +497,31 @@ pub fn generate_statement_ir<'ctx>(
             let zero = context.i32_type().const_zero();
             let indices = [zero, zero];
             let gep = unsafe {
-                builder.build_gep(global.as_pointer_value(), &indices, "gep").unwrap()
+                builder
+                    .build_gep(global.as_pointer_value(), &indices, "gep")
+                    .unwrap()
             };
 
             let mut printf_args = vec![gep.into()];
             for arg in args {
-                let value = generate_expression_ir(context, builder, arg, variables, module, None, global_consts, &struct_types, struct_field_indices);
+                let value = generate_expression_ir(
+                    context,
+                    builder,
+                    arg,
+                    variables,
+                    module,
+                    None,
+                    global_consts,
+                    &struct_types,
+                    struct_field_indices,
+                );
 
                 let casted_value = match value {
                     BasicValueEnum::PointerValue(ptr_val) => {
                         let element_ty = ptr_val.get_type().get_element_type();
-                        if element_ty.is_int_type() && element_ty.into_int_type().get_bit_width() == 8 {
+                        if element_ty.is_int_type()
+                            && element_ty.into_int_type().get_bit_width() == 8
+                        {
                             ptr_val.as_basic_value_enum()
                         } else {
                             builder
@@ -427,20 +546,34 @@ pub fn generate_statement_ir<'ctx>(
             let _ = builder.build_call(printf_func, &printf_args, "printf_call");
         }
         ASTNode::Statement(StatementNode::If {
-                               condition,
-                               body,
-                               else_if_blocks,
-                               else_block,
-                           }) => {
+            condition,
+            body,
+            else_if_blocks,
+            else_block,
+        }) => {
             let current_fn = builder.get_insert_block().unwrap().get_parent().unwrap();
 
-            let cond_value = generate_expression_ir(context, builder, condition, variables, module, None, global_consts, &struct_types, struct_field_indices);
+            let cond_value = generate_expression_ir(
+                context,
+                builder,
+                condition,
+                variables,
+                module,
+                None,
+                global_consts,
+                &struct_types,
+                struct_field_indices,
+            );
 
             let then_block = context.append_basic_block(current_fn, "then");
             let else_block_bb = context.append_basic_block(current_fn, "else");
             let merge_block = context.append_basic_block(current_fn, "merge");
 
-            let _ = builder.build_conditional_branch(cond_value.try_into().unwrap(), then_block, else_block_bb);
+            let _ = builder.build_conditional_branch(
+                cond_value.try_into().unwrap(),
+                then_block,
+                else_block_bb,
+            );
 
             // ---- then block ----
             builder.position_at_end(then_block);
@@ -457,7 +590,7 @@ pub fn generate_statement_ir<'ctx>(
                     current_function,
                     global_consts,
                     struct_types,
-                    struct_field_indices
+                    struct_field_indices,
                 );
             }
             let then_has_terminator = then_block.get_terminator().is_some();
@@ -481,11 +614,11 @@ pub fn generate_statement_ir<'ctx>(
                         None,
                         global_consts,
                         &struct_types,
-                        struct_field_indices
+                        struct_field_indices,
                     );
                     let then_bb = context.append_basic_block(current_fn, "else_if_then");
                     let next_check_bb = context.append_basic_block(current_fn, "next_else_if");
-                    builder.build_conditional_branch(
+                    let _ = builder.build_conditional_branch(
                         cond_value.try_into().unwrap(),
                         then_bb,
                         next_check_bb,
@@ -504,11 +637,11 @@ pub fn generate_statement_ir<'ctx>(
                             current_function,
                             global_consts,
                             struct_types,
-                            struct_field_indices
+                            struct_field_indices,
                         );
                     }
                     if then_bb.get_terminator().is_none() {
-                        builder.build_unconditional_branch(merge_block);
+                        let _ = builder.build_unconditional_branch(merge_block);
                     }
                     builder.position_at_end(next_check_bb);
                     current_bb = next_check_bb;
@@ -529,7 +662,7 @@ pub fn generate_statement_ir<'ctx>(
                             current_function,
                             global_consts,
                             struct_types,
-                            struct_field_indices
+                            struct_field_indices,
                         );
                     }
                     current_bb.get_terminator().is_some()
@@ -550,7 +683,7 @@ pub fn generate_statement_ir<'ctx>(
                         current_function,
                         global_consts,
                         struct_types,
-                        struct_field_indices
+                        struct_field_indices,
                     );
                 }
                 else_block_bb.get_terminator().is_some()
@@ -579,7 +712,17 @@ pub fn generate_statement_ir<'ctx>(
             let _ = builder.build_unconditional_branch(cond_block);
             builder.position_at_end(cond_block);
 
-            let cond_val = generate_expression_ir(context, builder, condition, variables, module, None, global_consts, &struct_types, struct_field_indices);
+            let cond_val = generate_expression_ir(
+                context,
+                builder,
+                condition,
+                variables,
+                module,
+                None,
+                global_consts,
+                &struct_types,
+                struct_field_indices,
+            );
 
             let cond_bool = match cond_val {
                 BasicValueEnum::IntValue(val) => {
@@ -601,7 +744,20 @@ pub fn generate_statement_ir<'ctx>(
 
             builder.position_at_end(body_block);
             for stmt in body.iter() {
-                generate_statement_ir(context, builder, module, string_counter, stmt, variables, loop_exit_stack, loop_continue_stack, current_function, global_consts, struct_types, struct_field_indices);
+                generate_statement_ir(
+                    context,
+                    builder,
+                    module,
+                    string_counter,
+                    stmt,
+                    variables,
+                    loop_exit_stack,
+                    loop_continue_stack,
+                    current_function,
+                    global_consts,
+                    struct_types,
+                    struct_field_indices,
+                );
             }
             let _ = builder.build_unconditional_branch(cond_block);
 
@@ -610,9 +766,13 @@ pub fn generate_statement_ir<'ctx>(
 
             builder.position_at_end(merge_block);
         }
-        ASTNode::Statement(StatementNode::AsmBlock { instructions, inputs, outputs }) => {
-            use inkwell::InlineAsmDialect;
+        ASTNode::Statement(StatementNode::AsmBlock {
+            instructions,
+            inputs,
+            outputs,
+        }) => {
             use inkwell::values::{BasicMetadataValueEnum, CallableValue};
+            use inkwell::InlineAsmDialect;
             use std::collections::HashSet;
 
             let asm_code: String = instructions.join("\n");
@@ -645,29 +805,29 @@ pub fn generate_statement_ir<'ctx>(
                     var.as_str()
                 };
 
-                let val: BasicMetadataValueEnum =
-                    if let Ok(value) = var.parse::<i64>() {
-                        context.i64_type().const_int(value as u64, value < 0).into()
-                    } else if let Some(const_val) = global_consts.get(var) {
-                        (*const_val).into()
-                    } else {
-                        let info = variables.get(clean_var)
-                            .unwrap_or_else(|| panic!("Input variable '{}' not found", clean_var));
+                let val: BasicMetadataValueEnum = if let Ok(value) = var.parse::<i64>() {
+                    context.i64_type().const_int(value as u64, value < 0).into()
+                } else if let Some(const_val) = global_consts.get(var) {
+                    (*const_val).into()
+                } else {
+                    let info = variables
+                        .get(clean_var)
+                        .unwrap_or_else(|| panic!("Input variable '{}' not found", clean_var));
 
-                        if var.starts_with('&') {
-                            let ptr_val = builder
-                                .build_bit_cast(
-                                    info.ptr,
-                                    context.i8_type().ptr_type(AddressSpace::from(0)),
-                                    "addr_ptr",
-                                )
-                                .unwrap()
-                                .into();
-                            ptr_val
-                        } else {
-                            builder.build_load(info.ptr, var).unwrap().into()
-                        }
-                    };
+                    if var.starts_with('&') {
+                        let ptr_val = builder
+                            .build_bit_cast(
+                                info.ptr,
+                                context.i8_type().ptr_type(AddressSpace::from(0)),
+                                "addr_ptr",
+                            )
+                            .unwrap()
+                            .into();
+                        ptr_val
+                    } else {
+                        builder.build_load(info.ptr, var).unwrap().into()
+                    }
+                };
 
                 operand_vals.push(val);
                 constraint_parts.push(format!("{{{}}}", reg));
@@ -691,54 +851,84 @@ pub fn generate_statement_ir<'ctx>(
                 false,
             );
 
-            let inline_asm_fn = CallableValue::try_from(inline_asm_ptr)
-                .expect("Failed to convert inline asm");
+            let inline_asm_fn =
+                CallableValue::try_from(inline_asm_ptr).expect("Failed to convert inline asm");
 
-            let call = builder.build_call(inline_asm_fn, &operand_vals, "inline_asm").unwrap();
+            let call = builder
+                .build_call(inline_asm_fn, &operand_vals, "inline_asm")
+                .unwrap();
 
             if expects_return {
                 let ret_val = call.try_as_basic_value().left().unwrap();
                 let (_, var) = outputs.iter().next().unwrap();
-                let info = variables.get(var)
+                let info = variables
+                    .get(var)
                     .unwrap_or_else(|| panic!("Output variable '{}' not found", var));
 
                 match &info.ty {
                     WaveType::Int(64) => {
                         builder.build_store(info.ptr, ret_val).unwrap();
                     }
-                    WaveType::Pointer(inner) => {
-                        match **inner {
-                            WaveType::Int(8) => {
-                                let casted_ptr = builder.build_int_to_ptr(
+                    WaveType::Pointer(inner) => match **inner {
+                        WaveType::Int(8) => {
+                            let casted_ptr = builder
+                                .build_int_to_ptr(
                                     ret_val.into_int_value(),
                                     context.i8_type().ptr_type(AddressSpace::from(0)),
                                     "casted_ptr",
-                                ).unwrap();
-                                builder.build_store(info.ptr, casted_ptr).unwrap();
-                            }
-                            _ => panic!("Unsupported pointer inner type in inline asm output"),
+                                )
+                                .unwrap();
+                            builder.build_store(info.ptr, casted_ptr).unwrap();
                         }
-                    }
+                        _ => panic!("Unsupported pointer inner type in inline asm output"),
+                    },
                     _ => panic!("Unsupported return type from inline asm: {:?}", info.ty),
                 }
             }
         }
         ASTNode::Statement(StatementNode::Expression(expr)) => {
-            let _ = generate_expression_ir(context, builder, expr, variables, module, None, global_consts, &struct_types, struct_field_indices);
+            let _ = generate_expression_ir(
+                context,
+                builder,
+                expr,
+                variables,
+                module,
+                None,
+                global_consts,
+                &struct_types,
+                struct_field_indices,
+            );
         }
         ASTNode::Statement(StatementNode::Assign { variable, value }) => {
             if variable == "deref" {
-                if let Expression::BinaryExpression { left, operator: _, right } = value {
+                if let Expression::BinaryExpression {
+                    left,
+                    operator: _,
+                    right,
+                } = value
+                {
                     if let Expression::Deref(inner_expr) = &**left {
-                        let target_ptr = generate_address_ir(context, builder, inner_expr, variables, module);
-                        let val = generate_expression_ir(context, builder, right, variables, module, None, global_consts, &struct_types, struct_field_indices);
+                        let target_ptr =
+                            generate_address_ir(context, builder, inner_expr, variables, module);
+                        let val = generate_expression_ir(
+                            context,
+                            builder,
+                            right,
+                            variables,
+                            module,
+                            None,
+                            global_consts,
+                            &struct_types,
+                            struct_field_indices,
+                        );
                         builder.build_store(target_ptr, val).unwrap();
                     }
                 }
                 return;
             }
 
-            let var_info = variables.get(variable)
+            let var_info = variables
+                .get(variable)
                 .unwrap_or_else(|| panic!("Variable {} not declared", variable));
 
             if matches!(var_info.mutability, Mutability::Let) {
@@ -757,7 +947,17 @@ pub fn generate_statement_ir<'ctx>(
                 _ => panic!("Unsupported LLVM type in assignment"),
             };
 
-            let val = generate_expression_ir(context, builder, value, variables, module, Some(expected_type), global_consts, &struct_types, struct_field_indices);
+            let val = generate_expression_ir(
+                context,
+                builder,
+                value,
+                variables,
+                module,
+                Some(expected_type),
+                global_consts,
+                &struct_types,
+                struct_field_indices,
+            );
 
             if let Some(var_info) = variables.get(variable) {
                 if matches!(var_info.mutability, Mutability::Let) {
@@ -775,12 +975,14 @@ pub fn generate_statement_ir<'ctx>(
                 };
 
                 let casted_val = match (val, element_type) {
-                    (BasicValueEnum::FloatValue(v), BasicTypeEnum::IntType(t)) => {
-                        builder.build_float_to_signed_int(v, t, "float_to_int").unwrap().as_basic_value_enum()
-                    }
-                    (BasicValueEnum::IntValue(v), BasicTypeEnum::FloatType(t)) => {
-                        builder.build_signed_int_to_float(v, t, "int_to_float").unwrap().as_basic_value_enum()
-                    }
+                    (BasicValueEnum::FloatValue(v), BasicTypeEnum::IntType(t)) => builder
+                        .build_float_to_signed_int(v, t, "float_to_int")
+                        .unwrap()
+                        .as_basic_value_enum(),
+                    (BasicValueEnum::IntValue(v), BasicTypeEnum::FloatType(t)) => builder
+                        .build_signed_int_to_float(v, t, "int_to_float")
+                        .unwrap()
+                        .as_basic_value_enum(),
                     _ => val,
                 };
                 builder.build_store(var_info.ptr, casted_val).unwrap();
@@ -804,9 +1006,12 @@ pub fn generate_statement_ir<'ctx>(
         }
         ASTNode::Statement(StatementNode::Return(expr_opt)) => {
             if let Some(expr) = expr_opt {
-                let ret_type = current_function.get_type().get_return_type()
+                let ret_type = current_function
+                    .get_type()
+                    .get_return_type()
                     .expect("Function should have a return type");
-                let expected_type = ret_type.try_into()
+                let expected_type = ret_type
+                    .try_into()
                     .expect("Failed to convert return type to BasicTypeEnum");
 
                 let value = generate_expression_ir(
@@ -818,35 +1023,39 @@ pub fn generate_statement_ir<'ctx>(
                     Some(expected_type),
                     global_consts,
                     &struct_types,
-                    struct_field_indices
+                    struct_field_indices,
                 );
 
                 let value = match value {
                     BasicValueEnum::PointerValue(ptr) => {
                         let ty = ptr.get_type().get_element_type();
                         match ty {
-                            AnyTypeEnum::PointerType(_) => {
-                                builder.build_load(ptr, "load_ret").unwrap().as_basic_value_enum()
-                            }
+                            AnyTypeEnum::PointerType(_) => builder
+                                .build_load(ptr, "load_ret")
+                                .unwrap()
+                                .as_basic_value_enum(),
                             _ => ptr.as_basic_value_enum(),
                         }
-                    },
+                    }
                     other => other,
                 };
 
                 let casted_value = match (value, expected_type) {
-                    (BasicValueEnum::PointerValue(ptr), BasicTypeEnum::IntType(_)) => {
-                        builder.build_ptr_to_int(ptr, expected_type.into_int_type(), "ptr_to_int").unwrap().as_basic_value_enum()
-                    }
+                    (BasicValueEnum::PointerValue(ptr), BasicTypeEnum::IntType(_)) => builder
+                        .build_ptr_to_int(ptr, expected_type.into_int_type(), "ptr_to_int")
+                        .unwrap()
+                        .as_basic_value_enum(),
                     (BasicValueEnum::PointerValue(ptr), BasicTypeEnum::PointerType(_)) => {
                         ptr.as_basic_value_enum()
                     }
-                    (BasicValueEnum::FloatValue(v), BasicTypeEnum::IntType(t)) => {
-                        builder.build_float_to_signed_int(v, t, "float_to_int").unwrap().as_basic_value_enum()
-                    }
-                    (BasicValueEnum::IntValue(v), BasicTypeEnum::FloatType(t)) => {
-                        builder.build_signed_int_to_float(v, t, "int_to_float").unwrap().as_basic_value_enum()
-                    }
+                    (BasicValueEnum::FloatValue(v), BasicTypeEnum::IntType(t)) => builder
+                        .build_float_to_signed_int(v, t, "float_to_int")
+                        .unwrap()
+                        .as_basic_value_enum(),
+                    (BasicValueEnum::IntValue(v), BasicTypeEnum::FloatType(t)) => builder
+                        .build_signed_int_to_float(v, t, "int_to_float")
+                        .unwrap()
+                        .as_basic_value_enum(),
                     _ => value,
                 };
 
@@ -856,7 +1065,17 @@ pub fn generate_statement_ir<'ctx>(
             }
         }
         ASTNode::Statement(StatementNode::Expression(expr)) => {
-            generate_expression_ir(context, builder, expr, variables, module, None, global_consts, &struct_types, struct_field_indices);
+            generate_expression_ir(
+                context,
+                builder,
+                expr,
+                variables,
+                module,
+                None,
+                global_consts,
+                &struct_types,
+                struct_field_indices,
+            );
         }
         _ => {}
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,6 +1,6 @@
-use std::path::Path;
-use crate::{compile_and_img, compile_and_run};
 use crate::errors::CliError;
+use crate::{compile_and_img, compile_and_run};
+use std::path::Path;
 
 #[derive(Default)]
 pub struct DebugFlags {
@@ -30,22 +30,14 @@ impl DebugFlags {
     }
 }
 
-pub fn handle_run(
-    file_path: &Path,
-    opt_flag: &str,
-    debug: &DebugFlags,
-) -> Result<(), CliError> {
+pub fn handle_run(file_path: &Path, opt_flag: &str, debug: &DebugFlags) -> Result<(), CliError> {
     unsafe {
         compile_and_run(file_path, opt_flag, debug);
     }
     Ok(())
 }
 
-pub fn handle_build(
-    file_path: &Path,
-    opt_flag: &str,
-    debug: &DebugFlags,
-) -> Result<(), CliError> {
+pub fn handle_build(file_path: &Path, opt_flag: &str, debug: &DebugFlags) -> Result<(), CliError> {
     println!("Building with {}...", opt_flag);
 
     unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
-pub mod runner;
-pub mod version;
 pub mod commands;
 pub mod errors;
+pub mod runner;
+pub mod version;
 
-use std::path::Path;
-use colorex::Colorize;
 use crate::version::get_os_pretty_name;
+use colorex::Colorize;
+use std::path::Path;
 
 use commands::DebugFlags;
 use llvm_temporary::backend;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use std::{env, fmt, process};
 use std::path::Path;
+use std::{env, fmt, process};
 
 use colorex::Colorize;
 use wavec::commands::{handle_build, handle_run, DebugFlags};

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,20 +1,16 @@
-use std::{fs, process, process::Command};
-use std::collections::HashSet;
-use std::path::Path;
+use crate::commands::DebugFlags;
+use ::error::*;
+use ::parser::ast::{ASTNode, StatementNode};
+use ::parser::import::local_import;
+use ::parser::*;
 use lexer::Lexer;
 use llvm_temporary::llvm_temporary::llvm_backend::*;
 use llvm_temporary::llvm_temporary::llvm_codegen::*;
-use ::parser::*;
-use ::parser::ast::{ASTNode, StatementNode};
-use ::parser::import::local_import;
-use ::error::*;
-use crate::commands::DebugFlags;
+use std::collections::HashSet;
+use std::path::Path;
+use std::{fs, process, process::Command};
 
-pub(crate) unsafe fn run_wave_file(
-    file_path: &Path,
-    opt_flag: &str,
-    debug: &DebugFlags,
-) {
+pub(crate) unsafe fn run_wave_file(file_path: &Path, opt_flag: &str, debug: &DebugFlags) {
     let code = match fs::read_to_string(file_path) {
         Ok(c) => c,
         Err(_) => {
@@ -25,8 +21,8 @@ pub(crate) unsafe fn run_wave_file(
                 0,
                 0,
             )
-                .with_help("check if the file exists and you have permission to read it")
-                .display();
+            .with_help("check if the file exists and you have permission to read it")
+            .display();
             process::exit(1);
         }
     };
@@ -44,7 +40,7 @@ pub(crate) unsafe fn run_wave_file(
                 0,
                 0,
             )
-                .display();
+            .display();
             process::exit(1);
         }
     };
@@ -67,8 +63,7 @@ pub(crate) unsafe fn run_wave_file(
     }
 
     let file_stem = file_path.file_stem().unwrap().to_str().unwrap();
-    let object_patch =
-        compile_ir_to_object(&ir, file_stem, opt_flag);
+    let object_patch = compile_ir_to_object(&ir, file_stem, opt_flag);
 
     if debug.mc {
         println!("\n===== MACHINE CODE PATH =====");
@@ -112,7 +107,8 @@ pub(crate) unsafe fn img_wave_file(file_path: &Path) {
     let mut ast = parse(&tokens).expect("Failed to parse Wave code");
 
     let file_path = Path::new(file_path);
-    let base_dir = file_path.canonicalize()
+    let base_dir = file_path
+        .canonicalize()
         .ok()
         .and_then(|p| p.parent().map(|p| p.to_path_buf()))
         .unwrap_or_else(|| Path::new(".").to_path_buf());

--- a/src/version.rs
+++ b/src/version.rs
@@ -33,10 +33,7 @@ pub fn get_os_pretty_name() -> String {
 
     #[cfg(target_os = "windows")]
     {
-        if let Ok(output) = Command::new("cmd")
-            .args(["/C", "ver"])
-            .output()
-        {
+        if let Ok(output) = Command::new("cmd").args(["/C", "ver"]).output() {
             let text = String::from_utf8_lossy(&output.stdout);
             return format!("Windows {}", text.trim());
         }
@@ -46,10 +43,7 @@ pub fn get_os_pretty_name() -> String {
 
     #[cfg(target_os = "macos")]
     {
-        if let Ok(output) = Command::new("sw_vers")
-            .arg("-productVersion")
-            .output()
-        {
+        if let Ok(output) = Command::new("sw_vers").arg("-productVersion").output() {
             let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
             return format!("macOS {}", version);
         }


### PR DESCRIPTION
This PR introduces a comprehensive cleanup of the codebase to improve maintainability and ensure consistent coding standards. It focuses on automated formatting, silencing non-critical lint warnings, and applying idiomatic Rust improvements. No functional logic or behavioral changes are included.

### Key Changes

1.  **Code Formatting**: 
    *   Applied `rustfmt` project-wide to standardize indentation, bracing, and multi-line function signatures.
    *   Fixed several instances of `No newline at end of file`.

2.  **Lint Management**:
    *   Added module-level `#![allow(...)]` attributes to `lexer`, `parser`, and `llvm_temporary` modules. 
    *   This suppresses warnings for `dead_code`, `unused_variables`, and specific Clippy lints (e.g., `type_complexity`, `collapsible_if`) to reduce noise during the current development phase.

3.  **Idiomatic Rust Refactoring**:
    *   **Character Checks**: Replaced `.is_digit(10)` with `.is_ascii_digit()` and `.is_digit(16)` with `.is_ascii_hexdigit()` for better performance and clarity.
    *   **Iterators**: Simplified `.lines().nth(0)` to `.lines().next()`.
    *   **Imports**: Reorganized and grouped `use` statements across all impacted files.
    *   **Error Messages**: Refactored `eprintln!` and `panic!` calls in the lexer and parser to follow a more consistent format.

4.  **Refactoring for Readability**:
    *   Updated complex `match` arms and long `if-let` chains into more readable multi-line blocks.
    *   Standardized the internal helper methods and token creation logic.