### PR TITLE
feat: implement recursive import expansion and type checking

### DIFF
--- a/front/parser/src/parser/import.rs
+++ b/front/parser/src/parser/import.rs
@@ -25,7 +25,6 @@ pub fn local_import_unit(
         ));
     }
 
-    // ✅ std::* : 지금은 조용히 스킵 (wavec는 std 구현 전)
     if path.starts_with("std::") {
         already_imported.insert(path.to_string());
         return Ok(ImportedUnit {
@@ -34,7 +33,6 @@ pub fn local_import_unit(
         });
     }
 
-    // ✅ foo::bar : wavec 단독모드에서 외부 import 금지 (Vex 언급 없음)
     if path.contains("::") {
         return Err(WaveError::new(
             WaveErrorKind::SyntaxError("External import is not supported".to_string()),

--- a/front/parser/src/parser/import.rs
+++ b/front/parser/src/parser/import.rs
@@ -1,17 +1,20 @@
 use crate::ast::ASTNode;
 use crate::parse;
-use crate::parser::stdlib::StdlibManager;
 use error::error::{WaveError, WaveErrorKind};
 use lexer::Lexer;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-pub fn local_import(
+pub struct ImportedUnit {
+    pub abs_path: PathBuf,
+    pub ast: Vec<ASTNode>,
+}
+
+pub fn local_import_unit(
     path: &str,
     already_imported: &mut HashSet<String>,
     base_dir: &Path,
-    stdlib_manager: Option<&StdlibManager>,
-) -> Result<Vec<ASTNode>, WaveError> {
+) -> Result<ImportedUnit, WaveError> {
     if path.trim().is_empty() {
         return Err(WaveError::new(
             WaveErrorKind::SyntaxError("Empty import path".to_string()),
@@ -22,14 +25,24 @@ pub fn local_import(
         ));
     }
 
-    // Handle standard library imports (std::*)
+    // ✅ std::* : 지금은 조용히 스킵 (wavec는 std 구현 전)
     if path.starts_with("std::") {
-        return handle_std_import(path, already_imported, stdlib_manager);
+        already_imported.insert(path.to_string());
+        return Ok(ImportedUnit {
+            abs_path: base_dir.to_path_buf(),
+            ast: vec![],
+        });
     }
 
-    // Handle external library imports (contain :: but not std::)
-    if path.contains("::") && !path.starts_with("std::") {
-        return external_import(path, already_imported, None);
+    // ✅ foo::bar : wavec 단독모드에서 외부 import 금지 (Vex 언급 없음)
+    if path.contains("::") {
+        return Err(WaveError::new(
+            WaveErrorKind::SyntaxError("External import is not supported".to_string()),
+            "External imports are not supported by the Wave compiler (standalone).",
+            path,
+            0,
+            0,
+        ));
     }
 
     let target_file_name = if path.ends_with(".wave") {
@@ -58,6 +71,7 @@ pub fn local_import(
             0,
         )
     })?;
+
     let abs_path_str = abs_path
         .to_str()
         .ok_or_else(|| {
@@ -72,7 +86,7 @@ pub fn local_import(
         .to_string();
 
     if already_imported.contains(&abs_path_str) {
-        return Ok(vec![]);
+        return Ok(ImportedUnit { abs_path, ast: vec![] });
     }
     already_imported.insert(abs_path_str);
 
@@ -101,68 +115,13 @@ pub fn local_import(
             .with_label("here".to_string())
     })?;
 
-    Ok(ast)
+    Ok(ImportedUnit { abs_path, ast })
 }
 
-fn handle_std_import(
+pub fn local_import(
     path: &str,
     already_imported: &mut HashSet<String>,
-    stdlib_manager: Option<&StdlibManager>,
+    base_dir: &Path,
 ) -> Result<Vec<ASTNode>, WaveError> {
-    let module_name = path.strip_prefix("std::").unwrap_or(path);
-
-    let mgr =
-        stdlib_manager.ok_or_else(|| WaveError::stdlib_requires_vex(module_name, path, 0, 0))?;
-
-    mgr.ensure_enabled()?;
-    mgr.ensure_declared_in_manifest(module_name)?;
-    mgr.validate_stdlib_import(module_name)?;
-
-    already_imported.insert(path.to_string());
-    Ok(vec![])
-}
-
-pub fn external_import(
-    path: &str,
-    already: &mut HashSet<String>,
-    stdlib_manager: Option<&StdlibManager>,
-) -> Result<Vec<ASTNode>, WaveError> {
-    if already.contains(path) {
-        return Ok(vec![]);
-    }
-
-    let mgr = stdlib_manager.ok_or_else(|| {
-        WaveError::new(
-            WaveErrorKind::SyntaxError("External library not available".to_string()),
-            "External imports require Vex (--with-vex) and vex.ws dependencies.",
-            path,
-            0,
-            0,
-        )
-    })?;
-
-    mgr.ensure_enabled()?;
-    mgr.ensure_declared_in_manifest(path)?;
-    mgr.ensure_resolved(path)?;
-
-    already.insert(path.to_string());
-    Ok(vec![])
-}
-
-fn find_wave_file_recursive(dir: &Path, target_file_name: &str) -> Option<PathBuf> {
-    for entry in std::fs::read_dir(dir).ok()? {
-        let entry = entry.ok()?;
-        let path = entry.path();
-
-        if path.is_dir() {
-            if let Some(found) = find_wave_file_recursive(&path, target_file_name) {
-                return Some(found);
-            }
-        } else if path.is_file() {
-            if path.file_name()?.to_str()? == target_file_name {
-                return Some(path);
-            }
-        }
-    }
-    None
+    Ok(local_import_unit(path, already_imported, base_dir)?.ast)
 }

--- a/front/parser/src/parser/stdlib.rs
+++ b/front/parser/src/parser/stdlib.rs
@@ -1,8 +1,6 @@
 use crate::ast::{FunctionSignature, WaveType};
-use error::error::{WaveError, WaveErrorKind};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-/// Struct for managing symbol information of standard library modules
 #[derive(Debug, Clone)]
 pub struct StdlibModule {
     pub name: String,
@@ -11,169 +9,46 @@ pub struct StdlibModule {
     pub constants: HashMap<String, (WaveType, String)>,
 }
 
-/// Wave compiler's standard library manager
-/// Responsible for integration with Vex package manager
-#[derive(Debug)]
-pub struct StdlibManager {
-    pub modules: HashMap<String, StdlibModule>,
-    pub vex_integration_enabled: bool,
-    pub stdlib_definitions_path: Option<String>,
+#[derive(Debug, Default)]
+pub struct StdlibRegistry {
+    modules: HashMap<String, StdlibModule>,
+    used: HashSet<String>,
+    strict: bool,
 }
 
-impl StdlibManager {
+impl StdlibRegistry {
     pub fn new() -> Self {
-        Self {
-            modules: HashMap::new(),
-            vex_integration_enabled: false,
-            stdlib_definitions_path: None,
+        Self::default()
+    }
+
+    pub fn mark_used(&mut self, module: &str) {
+        self.used.insert(module.to_string());
+    }
+
+    pub fn used_modules(&self) -> impl Iterator<Item = &String> {
+        self.used.iter()
+    }
+
+    pub fn set_strict(&mut self, strict: bool) {
+        self.strict = strict;
+    }
+
+    pub fn register_module(&mut self, m: StdlibModule) {
+        self.modules.insert(m.name.clone(), m);
+    }
+
+    pub fn has_module(&self, name: &str) -> bool {
+        self.modules.contains_key(name)
+    }
+
+    pub fn module(&self, name: &str) -> Option<&StdlibModule> {
+        self.modules.get(name)
+    }
+
+    pub fn validate_import(&self, name: &str) -> bool {
+        if !self.strict {
+            return true;
         }
-    }
-
-    /// Enable Vex package manager integration
-    pub fn enable_vex_integration(&mut self, definitions_path: Option<String>) {
-        self.vex_integration_enabled = true;
-        self.stdlib_definitions_path = definitions_path;
-        self.load_stdlib_definitions();
-    }
-
-    /// Load standard library metadata from Vex package manager
-    /// Wave compiler does not define functions, only processes metadata provided by Vex
-    fn load_stdlib_definitions(&mut self) {
-        // TODO: Implement actual metadata loading from Vex package manager
-        // Wave compiler has no builtin functions
-        // All standard library definitions must be provided by Vex package manager
-
-        // Currently only creates empty modules - actual definitions will be loaded from Vex
-        println!("Note: Standard library definitions will be loaded from Vex package manager");
-    }
-
-    /// Only check if standard library module exists (actual validation by Vex)
-    pub fn validate_stdlib_import(&self, module_name: &str) -> Result<(), WaveError> {
-        if !self.vex_integration_enabled {
-            return Err(WaveError::new(
-                WaveErrorKind::SyntaxError("Standard library not available".to_string()),
-                "Standard library imports require Vex package manager. Use Wave compiler with Vex to access std:: modules.",
-                module_name,
-                0,
-                0,
-            ));
-        }
-
-        // TODO: Implement actual module validation with Vex communication
-        // Wave compiler does not validate actual module contents
-        // Only checks if Vex provides the module
-        // Actual function and type validation is Vex's responsibility
-        Ok(())
-    }
-
-    /// Function call validation is handled by Vex - Wave only checks syntax
-    pub fn validate_function_call(
-        &self,
-        module_name: &str,
-        function_name: &str,
-        _arg_types: &[WaveType],
-    ) -> Result<(), WaveError> {
-        self.validate_stdlib_import(module_name)?;
-
-        // TODO: Implement actual function signature validation with Vex
-        // Wave compiler does not know function signatures
-        // Type validation and function existence is Vex package manager's responsibility
-        println!(
-            "Note: Function '{}::{}' will be validated by Vex package manager",
-            module_name, function_name
-        );
-
-        Ok(())
-    }
-
-    /// Load standard library metadata from Vex package manager
-    pub fn load_from_vex_manifest(&mut self, manifest_path: &str) -> Result<(), WaveError> {
-        // TODO: Implement actual manifest file parsing and metadata loading
-        // Load information from standard library manifest file provided by Vex
-        // Wave compiler only acts as an interface
-        println!(
-            "Loading stdlib metadata from Vex manifest: {}",
-            manifest_path
-        );
-        Ok(())
-    }
-
-    /// Linking information is also provided by Vex - Wave does not know it
-    pub fn get_linking_info(&self, module_name: &str) -> Option<Vec<String>> {
-        // TODO: Implement actual linking information retrieval from Vex
-        // Wave compiler does not have linking information
-        // All linking information is provided by Vex package manager
-        println!(
-            "Note: Linking info for '{}' will be provided by Vex",
-            module_name
-        );
-        None
-    }
-
-    pub fn ensure_enabled(&self) -> Result<(), WaveError> {
-        if !self.vex_integration_enabled {
-            return Err(WaveError::new(
-                WaveErrorKind::SyntaxError("Standard library not available".to_string()),
-                "Use --with-vex to enable std/external imports.",
-                "<manifest>",
-                0,
-                0,
-            ));
-        }
-        Ok(())
-    }
-
-    pub fn ensure_declared_in_manifest(&self, module: &str) -> Result<(), WaveError> {
-        println!("Checking if '{}' is declared in vex.ws", module);
-        Ok(())
-    }
-
-    pub fn ensure_resolved(&self, module: &str) -> Result<(), WaveError> {
-        println!("Checking if '{}' is resolved by Vex", module);
-        Ok(())
-    }
-}
-
-/// Interface for communication with Vex package manager
-#[derive(Debug)]
-pub struct VexInterface {
-    pub vex_binary_path: String,
-    pub project_root: String,
-}
-
-impl VexInterface {
-    pub fn new(vex_path: String, project_root: String) -> Self {
-        Self {
-            vex_binary_path: vex_path,
-            project_root,
-        }
-    }
-
-    /// Query standard library information from Vex
-    pub fn query_stdlib_info(&self, module_name: &str) -> Result<String, WaveError> {
-        // TODO: Implement actual Vex binary execution to get standard library information
-        // Example: vex stdlib-info std::iosys
-        println!("Querying Vex for stdlib info: {}", module_name);
-
-        // Wave compiler does not know module contents
-        // Only forwards information provided by Vex
-        Ok(format!(
-            "Module '{}' metadata will be provided by Vex",
-            module_name
-        ))
-    }
-
-    /// Check if project has standard library dependencies
-    pub fn check_stdlib_dependencies(&self) -> Result<Vec<String>, WaveError> {
-        // TODO: Implement actual dependency checking from Vex.toml or similar config file
-        // Check dependencies from Vex.toml or similar configuration file
-        println!(
-            "Checking stdlib dependencies in project: {}",
-            self.project_root
-        );
-
-        // Wave compiler does not analyze dependencies directly
-        // Forwards information provided by Vex as-is
-        Ok(vec![])
+        self.modules.contains_key(name)
     }
 }

--- a/llvm_temporary/Cargo.toml
+++ b/llvm_temporary/Cargo.toml
@@ -7,5 +7,6 @@ build = "build.rs"
 [dependencies]
 parser = { path = "../front/parser" }
 lexer = { path = "../front/lexer" }
+error = { path = "../front/error" }
 inkwell = { version = "0.5.0", features = ["llvm14-0"] }
 llvm-sys = { version = "140.1.3", features = ["no-llvm-linking"] }

--- a/llvm_temporary/src/llvm_temporary/importgen.rs
+++ b/llvm_temporary/src/llvm_temporary/importgen.rs
@@ -1,0 +1,44 @@
+use std::collections::HashSet;
+use std::path::Path;
+
+use error::error::WaveError;
+use parser::ast::{ASTNode, StatementNode};
+use parser::parser::import::local_import_unit;
+
+fn expand_imports_recursive(
+    ast: Vec<ASTNode>,
+    current_file_dir: &Path,
+    already: &mut HashSet<String>,
+) -> Result<Vec<ASTNode>, WaveError> {
+    let mut out = Vec::new();
+
+    for node in ast {
+        match node {
+            ASTNode::Statement(StatementNode::Import(path)) => {
+                let imported = local_import_unit(&path, already, current_file_dir)?;
+
+                let next_dir = imported.abs_path.parent().unwrap_or(current_file_dir);
+
+                let expanded = expand_imports_recursive(imported.ast, next_dir, already)?;
+                out.extend(expanded);
+
+            }
+            other => out.push(other),
+        }
+    }
+
+    Ok(out)
+}
+
+pub fn build_codegen_ast(entry_path: &Path, entry_ast: Vec<ASTNode>) -> Result<Vec<ASTNode>, WaveError> {
+    let mut already = HashSet::new();
+
+    if let Ok(abs) = entry_path.canonicalize() {
+        if let Some(s) = abs.to_str() {
+            already.insert(s.to_string());
+        }
+    }
+
+    let entry_dir = entry_path.parent().unwrap_or(Path::new("."));
+    expand_imports_recursive(entry_ast, entry_dir, &mut already)
+}

--- a/llvm_temporary/src/llvm_temporary/mod.rs
+++ b/llvm_temporary/src/llvm_temporary/mod.rs
@@ -21,3 +21,4 @@ mod expression;
 pub mod llvm_backend;
 pub mod llvm_codegen;
 mod statement;
+mod importgen;

--- a/llvm_temporary/src/llvm_temporary/statement.rs
+++ b/llvm_temporary/src/llvm_temporary/statement.rs
@@ -275,6 +275,15 @@ pub fn generate_statement_ir<'ctx>(
                             &struct_types,
                             struct_field_indices,
                         );
+
+                        if val.get_type() != llvm_type {
+                            panic!(
+                                "Initializer type mismatch: expected {:?}, got {:?}",
+                                llvm_type,
+                                val.get_type()
+                            );
+                        }
+
                         builder.build_store(alloca, val).unwrap();
                     }
                     (Expression::BinaryExpression { .. }, _) => {


### PR DESCRIPTION
This PR significantly upgrades the Wave compiler's ability to handle multi-file projects by implementing a recursive import expansion system. It also strengthens the LLVM backend with stricter type validation for functions and variables, ensuring that code generation is both robust and type-safe.

### Key Changes

#### 1. Recursive Import System
*   **Dependency Resolution**: Refactored `local_import` into `local_import_unit`, which now tracks absolute paths to perform deep dependency tree flattening via `expand_imports_recursive`.
*   **Transitive Support**: The compiler now correctly identifies and includes nested imports across multiple files, enabling modular project structures.
*   **Standalone Mode Restrictions**: 
    *   Disabled external crate imports (e.g., `foo::bar`) when running in standalone `wavec` mode.
    *   Implemented graceful skipping for `std::*` imports to serve as placeholders for the upcoming standard library.

#### 2. Enhanced LLVM Codegen & Type Safety
*   **Strict Argument Validation**: Added checks to ensure function call arguments exactly match the parameter types defined in the function signature.
*   **Type-Safe Initializers**: Variable initializers are now validated against their declared types to prevent implicit or unsafe casts during code generation.
*   **Refined Conditional Logic**: 
    *   Improved truthiness evaluation in `if` statements by explicitly comparing integers and floats against zero to produce valid LLVM `i1` types.
    *   Enhanced pointer null-checking logic.
    *   Fixed Basic Block termination bugs that previously led to LLVM verification failures in complex branching scenarios.

#### 3. Runner & Infrastructure
*   **Multi-file Integration**: Integrated the expansion logic into `run_wave_file`, allowing the runner to compile projects spanning multiple `.wave` files.
*   **Configuration**: Cleaned up repository metadata by removing the custom GitHub funding link.

### Technical Details
*   **Import Expansion**: The expansion process uses a `HashSet` to prevent circular dependencies and redundant file processing.
*   **Codegen Coercion**: Instead of raw bit-casting, the backend now uses proper comparison instructions (`icmp` / `fcmp`) for conditional expressions to maintain IR integrity.