### PR TITLE
feat: support unary negation, let/const statements, and expand std syscalls

### DIFF
--- a/front/parser/src/ast.rs
+++ b/front/parser/src/ast.rs
@@ -174,6 +174,7 @@ pub enum Operator {
     LogicalNot,
     BitwiseNot,
     Not,
+    Neg,
 }
 
 #[derive(Debug, Clone)]
@@ -286,6 +287,20 @@ impl Expression {
             Expression::Literal(Literal::String(_)) => WaveType::String,
             Expression::MethodCall { .. } => {
                 panic!("nested method call type inference not supported yet")
+            }
+            Expression::Unary { operator, expr } => {
+                let t = expr.get_wave_type(variables);
+                match operator {
+                    Operator::Neg => {
+                        match &t {
+                            WaveType::Int(_) | WaveType::Uint(_) | WaveType::Float(_) => t,
+                            _ => panic!("unary '-' not allowed for type {:?}", t),
+                        }
+                    }
+                    Operator::Not | Operator::LogicalNot => WaveType::Bool,
+                    Operator::BitwiseNot => t,
+                    _ => panic!("unary op type inference not supported: {:?}", operator),
+                }
             }
             _ => panic!("get_wave_type not implemented for {:?}", self),
         }

--- a/front/parser/src/expr/unary.rs
+++ b/front/parser/src/expr/unary.rs
@@ -71,9 +71,12 @@ where
                     Expression::Literal(Literal::Float(f)) => {
                         return Some(Expression::Literal(Literal::Float(-f)));
                     }
-                    _ => {
-                        println!("Error: unary '-' only supports numeric literals (line {})", tok.line);
-                        return None;
+
+                    other => {
+                        return Some(Expression::Unary {
+                            operator: Operator::Neg,
+                            expr: Box::new(other),
+                        })
                     }
                 }
             }

--- a/front/parser/src/parser/stmt.rs
+++ b/front/parser/src/parser/stmt.rs
@@ -5,7 +5,7 @@ use lexer::token::TokenType;
 use crate::ast::{ASTNode, AssignOperator, Expression, Operator, StatementNode};
 use crate::expr::{is_assignable, parse_expression, parse_expression_from_token};
 use crate::parser::control::{parse_for, parse_if, parse_while};
-use crate::parser::decl::parse_var;
+use crate::parser::decl::{parse_const, parse_let, parse_var};
 use crate::parser::io::*;
 use crate::parser::types::is_expression_start;
 
@@ -157,6 +157,14 @@ pub fn parse_statement(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
         TokenType::Var => {
             tokens.next();
             parse_var(tokens)
+        }
+        TokenType::Let => {
+            tokens.next();
+            parse_let(tokens)
+        }
+        TokenType::Const => {
+            tokens.next();
+            parse_const(tokens)
         }
         TokenType::Println => {
             tokens.next();

--- a/llvm_temporary/src/llvm_temporary/expression/rvalue/unary.rs
+++ b/llvm_temporary/src/llvm_temporary/expression/rvalue/unary.rs
@@ -11,6 +11,23 @@ pub(crate) fn gen<'ctx, 'a>(
     let val = env.gen(expr, None);
 
     match (operator, val) {
+        // - (negation)
+        (Operator::Neg, BasicValueEnum::IntValue(iv)) => {
+            let zero = iv.get_type().const_zero();
+            env.builder
+                .build_int_sub(zero, iv, "neg")
+                .unwrap()
+                .as_basic_value_enum()
+        }
+
+        (Operator::Neg, BasicValueEnum::FloatValue(fv)) => {
+            let zero = fv.get_type().const_float(0.0);
+            env.builder
+                .build_float_sub(zero, fv, "fneg")
+                .unwrap()
+                .as_basic_value_enum()
+        }
+
         // ! (logical not)
         (Operator::LogicalNot, BasicValueEnum::IntValue(iv))
         | (Operator::Not, BasicValueEnum::IntValue(iv)) => {

--- a/std/libc/c.wave
+++ b/std/libc/c.wave
@@ -1,0 +1,3 @@
+fun libc() {
+    println("The libc library is designed to take full advantage of the C ABI, and as part of the Wave standard library, FFI is used only here. In other words, to use the C ABI, use here.");
+}

--- a/std/manifest.json
+++ b/std/manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "std",
   "format": 1,
-  "modules": ["string", "math"]
+  "modules": ["string", "math", "sys", "net", "libc"]
 }

--- a/std/net/udp.wave
+++ b/std/net/udp.wave
@@ -1,0 +1,8 @@
+import("../sys/linux/syscall");
+
+const AF_INET: i64 = 2;
+const SOCK_DGRAM: i64 = 2;
+
+fun udp_socket() -> i64 {
+    return sys_socket(AF_INET, SOCK_DGRAM, 0);
+}

--- a/std/sys/linux/syscall.wave
+++ b/std/sys/linux/syscall.wave
@@ -1,0 +1,14 @@
+const SYS_SOCKET: i64 = 41;
+
+fun sys_socket(domain: i64, ty: i64, proto: i64) -> i64 {
+    let fd: i64;
+    asm {
+        "syscall"
+        in("rax") SYS_SOCKET
+        in("rdi") domain
+        in("rsi") ty
+        in("rdx") proto
+        out("rax") fd
+    }
+    return fd;
+}


### PR DESCRIPTION
This PR introduces the unary negation operator (`-`) to allow negative expressions beyond just literals, integrates `let` and `const` into the statement parser, and significantly expands the standard library with low-level Linux syscalls and networking capabilities. These updates bridge the gap between high-level language ergonomics and low-level system programming.

### Key Changes

#### 1. Unary Negation Support (`-`)
The compiler now supports negating any numeric expression, not just constant literals (e.g., `-(a + b)`).
*   **AST & Type System**: Added `Operator::Neg` and updated type inference logic to ensure negation applies to numeric types while the logical NOT (`!`) operator correctly yields a boolean.
*   **Parser**: Refactored the unary expression engine to handle the `-` prefix for general expressions.
*   **LLVM Codegen**: Implemented IR generation for negation using `0 - x` logic for integers (`build_int_sub`) and `0.0 - x` for floats (`build_float_sub`).

#### 2. Parser Enhancements
*   **Declaration Statements**: Formally integrated `let` and `const` keywords into the statement parsing loop. This allows for immutable local bindings and constant declarations in a way that matches industry-standard syntax.

#### 3. Standard Library (std) Expansion
*   **Linux Syscalls**: Added `std/sys/linux/syscall.wave`. This module leverages Wave's inline assembly to implement the `socket` syscall directly.
*   **Networking**: Added `std/net/udp.wave`, providing a higher-level abstraction for creating UDP sockets using the underlying syscalls.
*   **FFI & C ABI**: Introduced `std/libc/c.wave` as a foundational module for maintaining C ABI compatibility and FFI documentation.
*   **Manifest Update**: Updated `std/manifest.json` to register the new `sys`, `net`, and `libc` namespaces.
