### PR TITLE
feat: support clobber clauses in inline assembly blocks

### DIFF
--- a/front/lexer/src/lexer/ident.rs
+++ b/front/lexer/src/lexer/ident.rs
@@ -99,6 +99,11 @@ impl<'a> Lexer<'a> {
                 lexeme: "out".to_string(),
                 line: self.line,
             },
+            "clobber" => Token {
+                token_type: TokenType::Clobber,
+                lexeme: "clobber".to_string(),
+                line: self.line,
+            },
             "is" => Token {
                 token_type: TokenType::Is,
                 lexeme: "is".to_string(),

--- a/front/lexer/src/lexer/literals.rs
+++ b/front/lexer/src/lexer/literals.rs
@@ -57,6 +57,14 @@ impl<'a> Lexer<'a> {
                 '\\' => '\\',
                 '\'' => '\'',
                 '"' => '"',
+                'x' => {
+                    let h1 = self.advance();
+                    let h2 = self.advance();
+                    let hex = format!("{}{}", h1, h2);
+                    let value = u8::from_str_radix(&hex, 16)
+                        .unwrap_or_else(|_| panic!("Invalid hex escape: \\x{}", hex));
+                    value as char
+                }
                 _ => panic!("Invalid escape sequence in char literal"),
             }
         } else {

--- a/front/lexer/src/token.rs
+++ b/front/lexer/src/token.rs
@@ -166,4 +166,5 @@ pub enum TokenType {
     TypeVoid,
     CharLiteral(char),
     BoolLiteral(bool),
+    Clobber,
 }

--- a/front/parser/src/ast.rs
+++ b/front/parser/src/ast.rs
@@ -125,6 +125,7 @@ pub enum Expression {
         instructions: Vec<String>,
         inputs: Vec<(String, Expression)>,
         outputs: Vec<(String, Expression)>,
+        clobbers: Vec<String>,
     },
     FieldAccess {
         object: Box<Expression>,
@@ -229,6 +230,7 @@ pub enum StatementNode {
         instructions: Vec<String>,
         inputs: Vec<(String, Expression)>,
         outputs: Vec<(String, Expression)>,
+        clobbers: Vec<String>,
     },
     Break,
     Continue,

--- a/llvm_temporary/src/llvm_temporary/expression/rvalue/asm.rs
+++ b/llvm_temporary/src/llvm_temporary/expression/rvalue/asm.rs
@@ -1,117 +1,161 @@
 use super::ExprGenEnv;
-use inkwell::types::{BasicMetadataTypeEnum, StringRadix};
+use inkwell::types::{AnyTypeEnum, BasicMetadataTypeEnum, BasicType, BasicTypeEnum, StringRadix};
 use inkwell::values::{BasicMetadataValueEnum, BasicValue, BasicValueEnum, CallableValue};
 use inkwell::InlineAsmDialect;
 use parser::ast::{Expression, Literal};
-use std::collections::HashSet;
+use crate::llvm_temporary::llvm_codegen::plan::*;
 
 pub(crate) fn gen<'ctx, 'a>(
     env: &mut ExprGenEnv<'ctx, 'a>,
     instructions: &[String],
     inputs: &[(String, Expression)],
     outputs: &[(String, Expression)],
+    clobbers: &[String],
 ) -> BasicValueEnum<'ctx> {
-    let asm_code: String = instructions.join("\n");
+    let plan = AsmPlan::build(instructions, inputs, outputs, clobbers, AsmSafetyMode::ConservativeKernel);
+    let constraints_str = plan.constraints_string();
 
-    if outputs.len() > 1 {
-        panic!("asm expression supports at most 1 output for now (got {})", outputs.len());
+    let mut operand_vals: Vec<BasicMetadataValueEnum<'ctx>> = Vec::with_capacity(plan.inputs.len());
+    for inp in &plan.inputs {
+        let v = eval_asm_in_expr(env, inp.value);
+        operand_vals.push(v.into());
     }
-
-    let mut constraint_parts: Vec<String> = vec![];
-    let mut seen_regs: HashSet<String> = HashSet::new();
-
-    if let Some((out_reg, _out_expr)) = outputs.first() {
-        if !seen_regs.insert(out_reg.to_string()) {
-            panic!("Register '{}' duplicated in outputs", out_reg);
-        }
-        // output constraint
-        constraint_parts.push(format!("={{{}}}", out_reg));
-    }
-
-    // inputs: operand + constraint
-    let mut operand_vals: Vec<BasicMetadataValueEnum<'ctx>> = Vec::with_capacity(inputs.len());
-
-    for (reg, var) in inputs {
-        if !seen_regs.insert(reg.to_string()) {
-            panic!("Register '{}' duplicated in asm operands", reg);
-        }
-
-        let val: BasicMetadataValueEnum<'ctx> = match var {
-            Expression::Literal(Literal::Int(n)) => {
-                let s = n.as_str();
-
-                let (neg, digits) = if let Some(rest) = s.strip_prefix('-') {
-                    (true, rest)
-                } else {
-                    (false, s)
-                };
-
-                let ty = env.context.i64_type();
-
-                let mut iv = ty
-                    .const_int_from_string(digits, StringRadix::Decimal)
-                    .unwrap_or_else(|| panic!("invalid int literal: {}", s));
-
-                if neg {
-                    iv = iv.const_neg();
-                }
-
-                iv.as_basic_value_enum().into()
-            }
-            Expression::Literal(Literal::Float(_)) => {
-                panic!("float literal in asm input not supported yet");
-            }
-            _ => {
-                if let Some(name) = var.as_identifier() {
-                    let info = env
-                        .variables
-                        .get(name)
-                        .unwrap_or_else(|| panic!("Input variable '{}' not found", name));
-                    env.builder.build_load(info.ptr, name).unwrap().into()
-                } else {
-                    panic!("Unsupported asm input expr: {:?}", var);
-                }
-            }
-        };
-
-        operand_vals.push(val);
-        constraint_parts.push(format!("{{{}}}", reg));
-    }
-
-    let constraints_str = constraint_parts.join(",");
 
     let param_types: Vec<BasicMetadataTypeEnum<'ctx>> =
         operand_vals.iter().map(meta_val_type).collect();
 
-    let fn_type = if outputs.is_empty() {
-        env.context.void_type().fn_type(&param_types, false)
-    } else {
-        env.context.i64_type().fn_type(&param_types, false)
-    };
+    if plan.outputs.is_empty() {
+        let fn_type = env.context.void_type().fn_type(&param_types, false);
+
+        let inline_asm = env.context.create_inline_asm(
+            fn_type,
+            plan.asm_code.clone(),     // inkwell 0.5.0 -> String
+            constraints_str,           // String
+            plan.has_side_effects,
+            false,
+            Some(InlineAsmDialect::Intel),
+            false,
+        );
+
+        let callable =
+            CallableValue::try_from(inline_asm).expect("Failed to convert inline asm");
+
+        env.builder
+            .build_call(callable, &operand_vals, "inline_asm_void")
+            .unwrap();
+
+        return env.context.i64_type().const_int(0, false).as_basic_value_enum();
+    }
+
+    if plan.outputs.len() != 1 {
+        panic!("asm expression requires exactly 1 output (got {})", plan.outputs.len());
+    }
+
+    let out_ty = resolve_expr_out_type(env, plan.outputs[0].target);
+    let fn_type = out_ty.fn_type(&param_types, false);
 
     let inline_asm = env.context.create_inline_asm(
         fn_type,
-        asm_code,
+        plan.asm_code.clone(),
         constraints_str,
-        true,  // sideeffect
-        false, // alignstack
+        plan.has_side_effects,
+        false,
         Some(InlineAsmDialect::Intel),
         false,
     );
 
     let callable =
-        CallableValue::try_from(inline_asm).expect("Failed to convert inline asm to CallableValue");
+        CallableValue::try_from(inline_asm).expect("Failed to convert inline asm");
 
     let call = env
         .builder
         .build_call(callable, &operand_vals, "inline_asm_expr")
         .unwrap();
 
-    if outputs.is_empty() {
-        panic!("asm expression must have an output");
-    }
-
     call.try_as_basic_value().left().unwrap()
+}
+
+fn resolve_expr_out_type<'ctx, 'a>(
+    env: &ExprGenEnv<'ctx, 'a>,
+    target: &Expression,
+) -> BasicTypeEnum<'ctx> {
+    match target {
+        Expression::Variable(name) => {
+            let info = env.variables.get(name).unwrap_or_else(|| panic!("Output var '{}' not found", name));
+            let elem_any = info.ptr.get_type().get_element_type();
+            any_to_basic_type(elem_any, "asm expr output var element type")
+        }
+        Expression::Deref(inner) => {
+            match inner.as_ref() {
+                Expression::Variable(name) => {
+                    let info = env.variables.get(name).unwrap_or_else(|| panic!("Pointer var '{}' not found", name));
+                    let loaded = env.builder.build_load(info.ptr, "asm_expr_out_ptr").unwrap();
+                    if !loaded.is_pointer_value() {
+                        panic!("deref output '{}' is not a pointer", name);
+                    }
+                    let p = loaded.into_pointer_value();
+                    let elem_any = p.get_type().get_element_type();
+                    any_to_basic_type(elem_any, "asm expr deref output element type")
+                }
+                other => panic!("Unsupported expr deref output: {:?}", other),
+            }
+        }
+        other => panic!("asm expr out(...) target must be variable/deref var for now: {:?}", other),
+    }
+}
+
+fn eval_asm_in_expr<'ctx, 'a>(env: &mut ExprGenEnv<'ctx, 'a>, e: &Expression) -> BasicValueEnum<'ctx> {
+    match e {
+        Expression::Literal(Literal::Int(n)) => {
+            let s = n.as_str();
+            let (neg, digits) = if let Some(rest) = s.strip_prefix('-') {
+                (true, rest)
+            } else {
+                (false, s)
+            };
+
+            let ty = env.context.i64_type();
+            let mut iv = ty
+                .const_int_from_string(digits, StringRadix::Decimal)
+                .unwrap_or_else(|| panic!("invalid int literal: {}", s));
+
+            if neg {
+                iv = iv.const_neg();
+            }
+            iv.as_basic_value_enum()
+        }
+
+        Expression::Variable(name) => {
+            let info = env.variables.get(name).unwrap_or_else(|| panic!("Input variable '{}' not found", name));
+            env.builder.build_load(info.ptr, name).unwrap()
+        }
+
+        Expression::AddressOf(inner) => {
+            match inner.as_ref() {
+                Expression::Variable(name) => {
+                    let info = env.variables.get(name).unwrap_or_else(|| panic!("Input variable '{}' not found", name));
+                    info.ptr.as_basic_value_enum()
+                }
+                _ => panic!("Unsupported address-of input: {:?}", inner),
+            }
+        }
+
+        Expression::Deref(inner) => {
+            match inner.as_ref() {
+                Expression::Variable(name) => {
+                    let info = env.variables.get(name).unwrap_or_else(|| panic!("Input pointer '{}' not found", name));
+                    let pv = env.builder.build_load(info.ptr, "asm_in_ptr").unwrap();
+                    if !pv.is_pointer_value() {
+                        panic!("deref input '{}' is not a pointer", name);
+                    }
+                    env.builder.build_load(pv.into_pointer_value(), "asm_in_deref").unwrap()
+                }
+                _ => panic!("Unsupported deref input: {:?}", inner),
+            }
+        }
+
+        other => panic!("Unsupported asm input expr: {:?}", other),
+    }
 }
 
 fn meta_val_type<'ctx>(v: &BasicMetadataValueEnum<'ctx>) -> BasicMetadataTypeEnum<'ctx> {
@@ -122,9 +166,20 @@ fn meta_val_type<'ctx>(v: &BasicMetadataValueEnum<'ctx>) -> BasicMetadataTypeEnu
         BasicMetadataValueEnum::StructValue(sv) => sv.get_type().into(),
         BasicMetadataValueEnum::VectorValue(vv) => vv.get_type().into(),
         BasicMetadataValueEnum::ArrayValue(av) => av.get_type().into(),
-
         BasicMetadataValueEnum::MetadataValue(_) => {
             panic!("MetadataValue cannot be used as an inline asm operand");
         }
+    }
+}
+
+fn any_to_basic_type<'ctx>(ty: AnyTypeEnum<'ctx>, what: &str) -> BasicTypeEnum<'ctx> {
+    match ty {
+        AnyTypeEnum::IntType(t) => t.as_basic_type_enum(),
+        AnyTypeEnum::FloatType(t) => t.as_basic_type_enum(),
+        AnyTypeEnum::PointerType(t) => t.as_basic_type_enum(),
+        AnyTypeEnum::StructType(t) => t.as_basic_type_enum(),
+        AnyTypeEnum::ArrayType(t) => t.as_basic_type_enum(),
+        AnyTypeEnum::VectorType(t) => t.as_basic_type_enum(),
+        other => panic!("{}: expected basic type, got {:?}", what, other),
     }
 }

--- a/llvm_temporary/src/llvm_temporary/expression/rvalue/dispatch.rs
+++ b/llvm_temporary/src/llvm_temporary/expression/rvalue/dispatch.rs
@@ -29,8 +29,8 @@ pub(crate) fn gen_expr<'ctx, 'a>(
 
         Expression::IndexAccess { target, index } => index::gen(env, target, index),
 
-        Expression::AsmBlock { instructions, inputs, outputs } => {
-            asm::gen(env, instructions, inputs, outputs)
+        Expression::AsmBlock { instructions, inputs, outputs, clobbers } => {
+            asm::gen(env, instructions, inputs, outputs, clobbers)
         }
 
         Expression::StructLiteral { name, fields } => structs::gen_struct_literal(env, name, fields),

--- a/llvm_temporary/src/llvm_temporary/llvm_codegen/mod.rs
+++ b/llvm_temporary/src/llvm_temporary/llvm_codegen/mod.rs
@@ -4,6 +4,7 @@ pub mod format;
 pub mod types;
 pub mod address;
 pub mod legacy;
+pub mod plan;
 
 pub use address::generate_address_ir;
 pub use format::{wave_format_to_c, wave_format_to_scanf};

--- a/llvm_temporary/src/llvm_temporary/llvm_codegen/plan.rs
+++ b/llvm_temporary/src/llvm_temporary/llvm_codegen/plan.rs
@@ -1,0 +1,428 @@
+// codegen/asm/plan.rs
+use parser::ast::Expression;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone)]
+pub struct AsmPlan<'a> {
+    pub asm_code: String,
+
+    // outputs are first in constraints
+    pub outputs: Vec<AsmOut<'a>>,
+
+    // inputs are call arguments (constraints after outputs)
+    pub inputs: Vec<AsmIn<'a>>,
+
+    // clobbers go last
+    pub clobbers: Vec<String>,
+
+    pub has_side_effects: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct AsmOut<'a> {
+    pub reg_raw: String,      // user wrote (e.g. "rax", "%rax", "RAX", "r")
+    pub reg_norm: String,     // normalized token (e.g. "rax", "r")
+    pub phys_group: Option<String>, // Some("rax") for real regs (al/ax/eax/rax -> rax), None for constraint classes (r/rm/m/..)
+    pub target: &'a Expression,
+}
+
+#[derive(Debug, Clone)]
+pub struct AsmIn<'a> {
+    pub constraint: String,   // "{rax}" or "r" or "0" (tied)
+    pub phys_group: Option<String>, // Some("rax") if it binds a concrete reg token, None if it is a class constraint
+    pub value: &'a Expression,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum AsmSafetyMode {
+    ConservativeKernel,
+}
+
+#[derive(Debug, Clone)]
+struct RegToken {
+    raw_norm: String,             // normalized token (no %, no braces, lowercase)
+    phys_group: Option<String>,   // physical register group for real regs
+}
+
+impl RegToken {
+    fn is_real_reg(&self) -> bool {
+        self.phys_group.is_some()
+    }
+}
+
+/// Normalize user reg/constraint token:
+/// - trims spaces
+/// - strips leading '%'
+/// - strips surrounding '{...}' if user wrote them
+/// - lowercase
+fn normalize_token(s: &str) -> String {
+    let s = s.trim();
+    let s = s.trim_start_matches('%');
+
+    let s = if let Some(inner) = s.strip_prefix('{').and_then(|x| x.strip_suffix('}')) {
+        inner
+    } else {
+        s
+    };
+
+    s.trim().to_ascii_lowercase()
+}
+
+/// If token is a real x86_64 GPR/subreg, return its *physical group*:
+/// - al/ax/eax/rax -> "rax"
+/// - dl/dx/edx/rdx -> "rdx"
+/// - r8b/r8w/r8d/r8 -> "r8"
+fn reg_phys_group(token: &str) -> Option<&'static str> {
+    match token {
+        // rax group
+        "al" | "ah" | "ax" | "eax" | "rax" => Some("rax"),
+        // rbx group
+        "bl" | "bh" | "bx" | "ebx" | "rbx" => Some("rbx"),
+        // rcx group
+        "cl" | "ch" | "cx" | "ecx" | "rcx" => Some("rcx"),
+        // rdx group
+        "dl" | "dh" | "dx" | "edx" | "rdx" => Some("rdx"),
+
+        // rsi group
+        "sil" | "si" | "esi" | "rsi" => Some("rsi"),
+        // rdi group
+        "dil" | "di" | "edi" | "rdi" => Some("rdi"),
+
+        // rbp group
+        "bpl" | "bp" | "ebp" | "rbp" => Some("rbp"),
+        // rsp group
+        "spl" | "sp" | "esp" | "rsp" => Some("rsp"),
+
+        // r8~r15 groups
+        "r8b" | "r8w" | "r8d" | "r8" => Some("r8"),
+        "r9b" | "r9w" | "r9d" | "r9" => Some("r9"),
+        "r10b" | "r10w" | "r10d" | "r10" => Some("r10"),
+        "r11b" | "r11w" | "r11d" | "r11" => Some("r11"),
+        "r12b" | "r12w" | "r12d" | "r12" => Some("r12"),
+        "r13b" | "r13w" | "r13d" | "r13" => Some("r13"),
+        "r14b" | "r14w" | "r14d" | "r14" => Some("r14"),
+        "r15b" | "r15w" | "r15d" | "r15" => Some("r15"),
+
+        _ => None,
+    }
+}
+
+/// Decide whether user string is:
+/// - real register (rax/eax/al/r8d/...)
+/// - or a constraint class (r/rm/m/i/n/g/...)
+fn parse_token(raw: &str) -> RegToken {
+    let raw_norm = normalize_token(raw);
+    let phys_group = reg_phys_group(&raw_norm).map(|s| s.to_string());
+    RegToken { raw_norm, phys_group }
+}
+
+/// For conservative kernel mode:
+/// - ALWAYS clobber memory + flags-ish
+/// - If ANY operand uses a *class constraint* (no concrete phys reg),
+///   DO NOT auto-clobber GPRs (otherwise allocator can't satisfy "r"/"rm").
+/// - If all operands are concrete regs only, you may clobber the rest GPRs safely.
+fn build_default_clobbers(
+    mode: AsmSafetyMode,
+    inputs: &[(String, Expression)],
+    outputs: &[(String, Expression)],
+) -> Vec<String> {
+    match mode {
+        AsmSafetyMode::ConservativeKernel => {
+            let mut clobbers = vec![
+                "~{memory}".to_string(),
+                "~{dirflag}".to_string(),
+                "~{fpsr}".to_string(),
+                "~{flags}".to_string(),
+            ];
+
+            // Collect concrete used physical register groups
+            let mut used_phys: HashSet<String> = HashSet::new();
+            let mut has_class_constraint = false;
+
+            for (r, _) in inputs {
+                let t = parse_token(r);
+                if let Some(pg) = t.phys_group {
+                    used_phys.insert(pg);
+                } else {
+                    has_class_constraint = true;
+                }
+            }
+            for (r, _) in outputs {
+                let t = parse_token(r);
+                if let Some(pg) = t.phys_group {
+                    used_phys.insert(pg);
+                } else {
+                    has_class_constraint = true;
+                }
+            }
+
+            // If any class constraint exists, don't auto-clobber GPRs.
+            if has_class_constraint {
+                return clobbers;
+            }
+
+            // Otherwise: clobber all GPRs not explicitly used.
+            const GPRS: [&str; 16] = [
+                "rax","rbx","rcx","rdx","rsi","rdi","rbp","rsp",
+                "r8","r9","r10","r11","r12","r13","r14","r15",
+            ];
+
+            for r in GPRS {
+                if !used_phys.contains(r) {
+                    clobbers.push(format!("~{{{}}}", r));
+                }
+            }
+
+            clobbers
+        }
+    }
+}
+
+fn gcc_percent_to_llvm_dollar(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            // "%%" -> literal '%'
+            if i + 1 < bytes.len() && bytes[i + 1] == b'%' {
+                out.push('%');
+                i += 2;
+                continue;
+            }
+
+            // "%123" -> "$123"
+            let mut j = i + 1;
+            if j < bytes.len() && bytes[j].is_ascii_digit() {
+                out.push('$');
+                while j < bytes.len() && bytes[j].is_ascii_digit() {
+                    out.push(bytes[j] as char);
+                    j += 1;
+                }
+                i = j;
+                continue;
+            }
+        }
+
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+
+    out
+}
+
+fn normalize_clobber_item(s: &str) -> String {
+    let t = s.trim();
+
+    if let Some(inner) = t.strip_prefix("~{").and_then(|x| x.strip_suffix('}')) {
+        let n = normalize_token(inner);
+
+        match n.as_str() {
+            "memory" => return "~{memory}".to_string(),
+            "cc" | "flags" | "eflags" | "rflags" => return "~{flags}".to_string(),
+            "dirflag" => return "~{dirflag}".to_string(),
+            "fpsr" => return "~{fpsr}".to_string(),
+            _ => {}
+        }
+
+        if let Some(pg) = reg_phys_group(&n) {
+            return format!("~{{{}}}", pg);
+        }
+
+        panic!("Invalid clobber token: '{}'", inner);
+    }
+
+    // "{...}" 형태
+    if let Some(inner) = t.strip_prefix('{').and_then(|x| x.strip_suffix('}')) {
+        let n = normalize_token(inner);
+
+        match n.as_str() {
+            "memory" => return "~{memory}".to_string(),
+            "cc" | "flags" | "eflags" | "rflags" => return "~{flags}".to_string(),
+            "dirflag" => return "~{dirflag}".to_string(),
+            "fpsr" => return "~{fpsr}".to_string(),
+            _ => {}
+        }
+
+        if let Some(pg) = reg_phys_group(&n) {
+            return format!("~{{{}}}", pg);
+        }
+
+        panic!("Invalid clobber token: '{}'", inner);
+    }
+
+    // specials (plain)
+    let lower = t.to_ascii_lowercase();
+    match lower.as_str() {
+        "memory" => return "~{memory}".to_string(),
+        "cc" | "flags" | "eflags" | "rflags" => return "~{flags}".to_string(),
+        "dirflag" => return "~{dirflag}".to_string(),
+        "fpsr" => return "~{fpsr}".to_string(),
+        _ => {}
+    }
+
+    let rt = parse_token(t);
+    if let Some(pg) = rt.phys_group {
+        return format!("~{{{}}}", pg);
+    }
+
+    panic!("Invalid clobber token: '{}'", t);
+}
+
+
+fn merge_clobbers(
+    mut base: Vec<String>,
+    user: &[String],
+    used_phys: &HashSet<String>,
+) -> Vec<String> {
+    let mut seen: HashSet<String> = base.iter().cloned().collect();
+
+    for raw in user {
+        let c = normalize_clobber_item(raw);
+
+        if let Some(inner) = c.strip_prefix("~{").and_then(|x| x.strip_suffix('}')) {
+            let inner_norm = normalize_token(inner);
+            if used_phys.contains(&inner_norm) {
+                panic!(
+                    "clobber '{}' conflicts with an input/output operand register",
+                    raw
+                );
+            }
+        }
+
+        if seen.insert(c.clone()) {
+            base.push(c);
+        }
+    }
+
+    base
+}
+
+impl<'a> AsmPlan<'a> {
+    pub fn build(
+        instructions: &'a [String],
+        inputs_raw: &'a [(String, Expression)],
+        outputs_raw: &'a [(String, Expression)],
+        user_clobbers_raw: &'a [String],
+        mode: AsmSafetyMode,
+    ) -> Self {
+        let asm_code = instructions.join("\n");
+        let asm_code = gcc_percent_to_llvm_dollar(&asm_code);
+
+        // outputs
+        let mut used_out_phys: HashSet<String> = HashSet::new();
+        let mut out_index_by_exact_reg: HashMap<String, usize> = HashMap::new();
+        let mut outputs: Vec<AsmOut<'a>> = Vec::with_capacity(outputs_raw.len());
+
+        for (reg, target) in outputs_raw {
+            let t = parse_token(reg);
+
+            // real reg outputs: disallow duplicates by physical group
+            if let Some(pg) = &t.phys_group {
+                if !used_out_phys.insert(pg.clone()) {
+                    panic!("Register '{}' duplicated in asm outputs (same phys group '{}')", reg, pg);
+                }
+                // enable tied input only when exact same token used (ex: out("rax") + in("rax"))
+                out_index_by_exact_reg.insert(t.raw_norm.clone(), outputs.len());
+            }
+            // class constraints (r/rm/m/...) -> allow duplicates
+
+            outputs.push(AsmOut {
+                reg_raw: reg.clone(),
+                reg_norm: t.raw_norm,
+                phys_group: t.phys_group,
+                target,
+            });
+        }
+
+        // inputs
+        let mut used_in_phys: HashSet<String> = HashSet::new();
+        let mut inputs: Vec<AsmIn<'a>> = Vec::with_capacity(inputs_raw.len());
+
+        for (reg, expr) in inputs_raw {
+            let t = parse_token(reg);
+
+            // real reg inputs: disallow duplicates by physical group
+            if let Some(pg) = &t.phys_group {
+                if !used_in_phys.insert(pg.clone()) {
+                    panic!("Register '{}' duplicated in asm inputs (same phys group '{}')", reg, pg);
+                }
+
+                // tied only when exact same reg token matches a real-reg output token
+                if let Some(&out_idx) = out_index_by_exact_reg.get(&t.raw_norm) {
+                    inputs.push(AsmIn {
+                        constraint: out_idx.to_string(), // "0", "1", ...
+                        phys_group: Some(pg.clone()),
+                        value: expr,
+                    });
+                    continue;
+                }
+
+                inputs.push(AsmIn {
+                    constraint: format!("{{{}}}", t.raw_norm), // "{rax}", "{dl}", "{r8d}", ...
+                    phys_group: Some(pg.clone()),
+                    value: expr,
+                });
+                continue;
+            }
+
+            // class constraint: allow duplicates, pass through as-is
+            inputs.push(AsmIn {
+                constraint: t.raw_norm, // "r", "rm", "m", "i", ...
+                phys_group: None,
+                value: expr,
+            });
+        }
+
+        let mut used_phys: HashSet<String> = HashSet::new();
+        for o in &outputs {
+            if let Some(pg) = &o.phys_group {
+                used_phys.insert(pg.clone());
+            }
+        }
+        for i in &inputs {
+            if let Some(pg) = &i.phys_group {
+                used_phys.insert(pg.clone());
+            }
+        }
+
+        let default_clobbers = build_default_clobbers(mode, inputs_raw, outputs_raw);
+        let clobbers = merge_clobbers(default_clobbers, user_clobbers_raw, &used_phys);
+
+        Self {
+            asm_code,
+            outputs,
+            inputs,
+            clobbers,
+            has_side_effects: true,
+        }
+    }
+
+    pub fn constraints_string(&self) -> String {
+        let mut parts: Vec<String> = Vec::new();
+
+        // outputs first
+        for o in &self.outputs {
+            if o.phys_group.is_some() {
+                // concrete register
+                parts.push(format!("={{{}}}", o.reg_norm)); // "={rax}", "={dl}", ...
+            } else {
+                // class constraint
+                parts.push(format!("={}", o.reg_norm)); // "=r", "=m", ...
+            }
+        }
+
+        // inputs next
+        for i in &self.inputs {
+            parts.push(i.constraint.clone()); // "{rsi}" or "r" or "0" ...
+        }
+
+        // clobbers last
+        for c in &self.clobbers {
+            parts.push(c.clone());
+        }
+
+        parts.join(",")
+    }
+}

--- a/llvm_temporary/src/llvm_temporary/statement/asm.rs
+++ b/llvm_temporary/src/llvm_temporary/statement/asm.rs
@@ -1,10 +1,59 @@
 use crate::llvm_temporary::llvm_codegen::VariableInfo;
 use inkwell::module::Module;
-use inkwell::values::{BasicMetadataValueEnum, BasicValue, BasicValueEnum, CallableValue};
+use inkwell::values::{BasicMetadataValueEnum, BasicValue, BasicValueEnum, CallableValue, PointerValue};
 use inkwell::{InlineAsmDialect};
 use parser::ast::{Expression, Literal};
 use std::collections::{HashMap, HashSet};
 use inkwell::types::{AnyTypeEnum, BasicMetadataTypeEnum, BasicType, BasicTypeEnum, StringRadix};
+use crate::llvm_temporary::llvm_codegen::plan::*;
+
+enum AsmOutPlace<'ctx> {
+    VarAlloca {
+        ptr: PointerValue<'ctx>
+    },
+    MemPtr {
+        ptr: PointerValue<'ctx>,
+        elem_ty: BasicTypeEnum<'ctx>
+    },
+}
+
+fn reg_width_bits(reg: &str) -> Option<u32> {
+    match reg {
+        // 8-bit
+        "al" | "bl" | "cl" | "dl" |
+        "sil" | "dil" |
+        "r8b" | "r9b" | "r10b" | "r11b" |
+        "r12b" | "r13b" | "r14b" | "r15b" => Some(8),
+
+        // 16-bit
+        "ax" | "bx" | "cx" | "dx" |
+        "si" | "di" |
+        "r8w" | "r9w" | "r10w" | "r11w" |
+        "r12w" | "r13w" | "r14w" | "r15w" => Some(16),
+
+        // 32-bit
+        "eax" | "ebx" | "ecx" | "edx" |
+        "esi" | "edi" |
+        "r8d" | "r9d" | "r10d" | "r11d" |
+        "r12d" | "r13d" | "r14d" | "r15d" => Some(32),
+
+        // 64-bit
+        "rax" | "rbx" | "rcx" | "rdx" |
+        "rsi" | "rdi" | "rbp" | "rsp" |
+        "r8" | "r9" | "r10" | "r11" |
+        "r12" | "r13" | "r14" | "r15" => Some(64),
+
+        _ => None,
+    }
+}
+
+fn extract_reg_from_constraint(c: &str) -> Option<String> {
+    // "{rdx}" → rdx
+    if let Some(inner) = c.strip_prefix('{').and_then(|s| s.strip_suffix('}')) {
+        return Some(inner.to_ascii_lowercase());
+    }
+    None
+}
 
 pub(super) fn gen_asm_stmt_ir<'ctx>(
     context: &'ctx inkwell::context::Context,
@@ -13,72 +62,67 @@ pub(super) fn gen_asm_stmt_ir<'ctx>(
     instructions: &[String],
     inputs: &[(String, Expression)],
     outputs: &[(String, Expression)],
+    clobbers: &[String],
     variables: &mut HashMap<String, VariableInfo<'ctx>>,
     global_consts: &HashMap<String, BasicValueEnum<'ctx>>,
 ) {
-    let asm_code: String = instructions.join("\n");
+    let plan = AsmPlan::build(instructions, inputs, outputs, clobbers, AsmSafetyMode::ConservativeKernel);
+    let constraints_str = plan.constraints_string();
 
-    let mut operand_vals: Vec<BasicMetadataValueEnum<'ctx>> = vec![];
-    let mut param_types: Vec<BasicMetadataTypeEnum<'ctx>> = vec![];
+    let mut operand_vals: Vec<BasicMetadataValueEnum<'ctx>> = Vec::with_capacity(plan.inputs.len());
+    let mut param_types: Vec<BasicMetadataTypeEnum<'ctx>> = Vec::with_capacity(plan.inputs.len());
 
-    let mut constraint_parts: Vec<String> = vec![];
+    for inp in &plan.inputs {
+        let mut val =
+            asm_operand_to_value(context, builder, variables, global_consts, inp.value);
 
-    let mut seen_out_regs: HashSet<String> = HashSet::new();
-    for (reg, _) in outputs {
-        if !seen_out_regs.insert(reg.to_string()) {
-            panic!("Register '{}' duplicated in outputs", reg);
+        if let Some(reg) = extract_reg_from_constraint(&inp.constraint) {
+            if let Some(bits) = reg_width_bits(&reg) {
+                if val.is_int_value() {
+                    let iv = val.into_int_value();
+                    let target_ty = context.custom_width_int_type(bits);
+
+                    if iv.get_type() != target_ty {
+                        val = builder
+                            .build_int_truncate(iv, target_ty, "asm_in_trunc")
+                            .unwrap()
+                            .as_basic_value_enum();
+                    }
+                }
+            }
         }
-        constraint_parts.push(format!("={{{}}}", reg));
-    }
 
-    let mut seen_in_regs: HashSet<String> = HashSet::new();
-    for (reg, expr) in inputs {
-        if !seen_in_regs.insert(reg.to_string()) {
-            panic!("Register '{}' duplicated in inputs", reg);
-        }
-
-        let val = asm_operand_to_value(context, builder, variables, global_consts, expr);
         param_types.push(val.get_type().into());
         operand_vals.push(val.into());
-
-        constraint_parts.push(format!("{{{}}}", reg));
     }
 
-    let constraints_str = constraint_parts.join(",");
 
-    let fn_type = if outputs.is_empty() {
+    let mut out_places: Vec<AsmOutPlace<'ctx>> = Vec::with_capacity(plan.outputs.len());
+    let mut out_tys: Vec<BasicTypeEnum<'ctx>> = Vec::with_capacity(plan.outputs.len());
+
+    for o in &plan.outputs {
+        let (place, ty) = resolve_out_place_and_type(context, builder, variables, o.target);
+        out_places.push(place);
+        out_tys.push(ty);
+    }
+
+    let fn_type = if out_tys.is_empty() {
         context.void_type().fn_type(&param_types, false)
+    } else if out_tys.len() == 1 {
+        out_tys[0].fn_type(&param_types, false)
     } else {
-        let mut tys: Vec<BasicTypeEnum<'ctx>> = Vec::new();
-
-        for (_, target_expr) in outputs {
-            let var_name = asm_output_target(target_expr);
-            let info = variables
-                .get(var_name)
-                .unwrap_or_else(|| panic!("Output variable '{}' not found", var_name));
-
-            // var alloca pointer element type == var's LLVM type
-            let elem_any = info.ptr.get_type().get_element_type(); // AnyTypeEnum
-            let elem_ty = any_to_basic_type(elem_any, "asm output var element type");
-            tys.push(elem_ty);
-        }
-
-        if tys.len() == 1 {
-            tys[0].fn_type(&param_types, false)
-        } else {
-            let st = context.struct_type(&tys, false);
-            st.fn_type(&param_types, false)
-        }
+        let st = context.struct_type(&out_tys, false);
+        st.fn_type(&param_types, false)
     };
 
     let inline_asm_ptr = context.create_inline_asm(
         fn_type,
-        asm_code,
+        plan.asm_code.clone(),
         constraints_str,
-        true,  // has_side_effects
-        false, // is_align_stack
+        plan.has_side_effects,
+        false, // alignstack
         Some(InlineAsmDialect::Intel),
-        false, // can_throw
+        false,
     );
 
     let inline_asm_fn =
@@ -88,31 +132,84 @@ pub(super) fn gen_asm_stmt_ir<'ctx>(
         .build_call(inline_asm_fn, &operand_vals, "inline_asm")
         .unwrap();
 
-    if outputs.is_empty() {
+    if out_places.is_empty() {
         return;
     }
 
     let ret_val = call.try_as_basic_value().left().unwrap();
 
-    if outputs.len() == 1 {
-        let (_, target_expr) = &outputs[0];
-        let var_name = asm_output_target(target_expr);
-        let info = variables.get(var_name).unwrap();
-
-        store_asm_output(context, builder, info, ret_val, var_name);
+    if out_places.len() == 1 {
+        store_asm_out_place(context, builder, &out_places[0], ret_val, "asm_out");
         return;
     }
 
     let struct_val = ret_val.into_struct_value();
-    for (idx, (_, target_expr)) in outputs.iter().enumerate() {
-        let out_elem = builder
-            .build_extract_value(struct_val, idx as u32, "asm_out")
+    for (idx, place) in out_places.iter().enumerate() {
+        let elem = builder
+            .build_extract_value(struct_val, idx as u32, "asm_out_elem")
             .unwrap();
+        store_asm_out_place(context, builder, place, elem, "asm_out");
+    }
+}
 
-        let var_name = asm_output_target(target_expr);
-        let info = variables.get(var_name).unwrap();
+fn resolve_out_place_and_type<'ctx>(
+    context: &'ctx inkwell::context::Context,
+    builder: &'ctx inkwell::builder::Builder<'ctx>,
+    variables: &HashMap<String, VariableInfo<'ctx>>,
+    target: &Expression,
+) -> (AsmOutPlace<'ctx>, BasicTypeEnum<'ctx>) {
+    match target {
+        Expression::Variable(name) => {
+            let info = variables.get(name).unwrap_or_else(|| panic!("Output var '{}' not found", name));
+            let elem_any = info.ptr.get_type().get_element_type();
+            let elem_ty = any_to_basic_type(elem_any, "asm output var element type");
+            (AsmOutPlace::VarAlloca { ptr: info.ptr }, elem_ty)
+        }
 
-        store_asm_output(context, builder, info, out_elem, var_name);
+        // allow: out("rax") deref p
+        Expression::Deref(inner) => {
+            match inner.as_ref() {
+                Expression::Variable(name) => {
+                    let info = variables.get(name).unwrap_or_else(|| panic!("Pointer var '{}' not found", name));
+                    let loaded = builder.build_load(info.ptr, "asm_out_ptr").unwrap();
+
+                    if !loaded.is_pointer_value() {
+                        panic!("deref target '{}' is not a pointer value", name);
+                    }
+
+                    let dst_ptr = loaded.into_pointer_value();
+                    let elem_any = dst_ptr.get_type().get_element_type();
+                    let elem_ty = any_to_basic_type(elem_any, "asm deref output element type");
+
+                    (AsmOutPlace::MemPtr { ptr: dst_ptr, elem_ty }, elem_ty)
+                }
+                other => panic!("Unsupported deref out target: {:?}", other),
+            }
+        }
+
+        other => panic!("out(...) target must be variable or deref var for now: {:?}", other),
+    }
+}
+
+fn store_asm_out_place<'ctx>(
+    context: &'ctx inkwell::context::Context,
+    builder: &'ctx inkwell::builder::Builder<'ctx>,
+    place: &AsmOutPlace<'ctx>,
+    value: BasicValueEnum<'ctx>,
+    name: &str,
+) {
+    match place {
+        AsmOutPlace::VarAlloca { ptr } => {
+            let dst_any = ptr.get_type().get_element_type();
+            let dst_ty = any_to_basic_type(dst_any, "asm output dst type");
+            let v = coerce_basic_value_for_store(context, builder, value, dst_ty, name);
+            builder.build_store(*ptr, v).unwrap();
+        }
+
+        AsmOutPlace::MemPtr { ptr, elem_ty } => {
+            let v = coerce_basic_value_for_store(context, builder, value, *elem_ty, name);
+            builder.build_store(*ptr, v).unwrap();
+        }
     }
 }
 
@@ -307,6 +404,24 @@ fn asm_operand_to_value<'ctx>(
 
         Expression::Grouped(inner) => {
             asm_operand_to_value(context, builder, variables, global_consts, inner)
+        }
+
+        Expression::Deref(inner) => {
+            match inner.as_ref() {
+                Expression::Variable(name) => {
+                    let info = variables
+                        .get(name)
+                        .unwrap_or_else(|| panic!("Input pointer var '{}' not found", name));
+
+                    let ptr_val = builder.build_load(info.ptr, "asm_in_ptr").unwrap();
+                    if !ptr_val.is_pointer_value() {
+                        panic!("deref input '{}' is not a pointer", name);
+                    }
+                    let p = ptr_val.into_pointer_value();
+                    builder.build_load(p, "asm_in_deref").unwrap()
+                }
+                _ => panic!("Unsupported asm deref input: {:?}", inner),
+            }
         }
 
         _ => panic!("Unsupported asm operand expression: {:?}", expr),

--- a/llvm_temporary/src/llvm_temporary/statement/mod.rs
+++ b/llvm_temporary/src/llvm_temporary/statement/mod.rs
@@ -124,6 +124,7 @@ pub fn generate_statement_ir<'ctx>(
                                instructions,
                                inputs,
                                outputs,
+                               clobbers,
                            }) => {
             asm::gen_asm_stmt_ir(
                 context,
@@ -132,6 +133,7 @@ pub fn generate_statement_ir<'ctx>(
                 instructions,
                 inputs,
                 outputs,
+                clobbers,
                 variables,
                 global_consts,
             );

--- a/test/test77.wave
+++ b/test/test77.wave
@@ -1,0 +1,66 @@
+fun main() {
+    println("=== test77: clobber test start ===");
+
+    test_clobber_rax();
+    test_clobber_multiple();
+    test_clobber_memory();
+
+    println("=== test77: done ===");
+}
+
+fun test_clobber_rax() {
+    var x: i64 = 10;
+    var y: i64 = 32;
+
+    var before: i64 = x + y;
+
+    asm {
+        "mov rax, 999"
+        // rax를 의도적으로 오염
+        clobber("rax")
+    }
+
+    var after: i64 = x + y;
+
+    println("[clobber rax]");
+    println("before = {}", before);
+    println("after  = {}", after);
+}
+
+fun test_clobber_multiple() {
+    var a: i64 = 1;
+    var b: i64 = 2;
+    var c: i64 = 3;
+
+    var sum1: i64 = a + b + c;
+
+    asm {
+        "xor rax, rax"
+        "xor rcx, rcx"
+        "xor rdx, rdx"
+        clobber("rax")
+        clobber("rcx")
+        clobber("rdx")
+    }
+
+    var sum2: i64 = a + b + c;
+
+    println("[clobber rax rcx rdx]");
+    println("sum before = {}", sum1);
+    println("sum after  = {}", sum2);
+}
+
+fun test_clobber_memory() {
+    var buf: i64 = 123;
+
+    println("[clobber memory]");
+    println("before = {}", buf);
+
+    asm {
+        "mov QWORD PTR [$0], 777"
+        in("r") &buf
+        clobber("memory")
+    }
+
+    println("after  = {}", buf);
+}


### PR DESCRIPTION
This PR introduces support for **clobber clauses** within inline assembly (`asm`) blocks. This is a critical feature for low-level systems programming, as it allows developers to explicitly inform the compiler which registers or memory states are modified by manual assembly instructions. This ensures the compiler preserves necessary state and prevents data corruption caused by aggressive optimization.

### Key Changes

#### 1. Lexer & Parser Enhancements
*   **New Keyword**: Registered `clobber` as a reserved keyword and added a corresponding `TokenType`.
*   **Syntax Support**: Implemented `parse_asm_clobber_clause` to support the new syntax: `clobber("register_name", "memory", "cc")`.
*   **AST Update**: Updated the `AsmBlock` node to store an optional list of clobbered resources.
*   **Character Literals**: As a consistency fix, added support for hex escape sequences (`\xHH`) in `char` literals, matching the recent update to string literals.

#### 2. LLVM Backend & Codegen
*   **Constraint Normalization**: Added `normalize_clobber_item` to map high-level names to LLVM-specific constraint strings:
    *   `"memory"` → `~{memory}` (prevents reordering across the asm block).
    *   `"cc"` or `"flags"` → `~{flags}` (indicates condition codes are modified).
    *   `"rax"`, `"rbx"`, etc. → `~{rax}`, `~{rbx}` (informs the compiler the register is "trashed").
*   **Conflict Detection**: Implemented `merge_clobbers` within the `AsmPlan` logic. The compiler will now `panic` if a register is used as an input/output operand while also being listed in the clobber clause.
*   **Engine Integration**: Updated both assembly statements and expressions to pass these normalized constraints to the LLVM `inline_asm` engine.

#### 3. Testing
*   **Verification**: Added `test/test77.wave`, which includes test cases for:
    *   Register trashing (ensuring the compiler saves/restores registers around the block).
    *   Memory side-effects (ensuring writes in `asm` are visible to subsequent Wave code).

### Example Usage
```kotlin
fun clobber_memory() {
    var buf: i64 = 123;

    println("before = {}", buf);

    asm {
        "mov QWORD PTR [$0], 777"
        in("r") &buf
        clobber("memory")
    }

    println("after  = {}", buf);
}
```

### Benefits
*   **Safety**: Prevents subtle bugs where the compiler assumes a register still holds a specific value after an `asm` block.
*   **Optimization Compatibility**: Allows the LLVM optimizer to work safely around manual assembly without assuming the worst-case scenario for every block.
*   **Predictability**: Brings Wave's inline assembly capabilities closer to the standard found in C (GCC/Clang) and Rust.
