### PR TITLE
feat: implement TypeFlavor and enhance inline assembly operand handling

### DIFF
--- a/front/parser/src/import.rs
+++ b/front/parser/src/import.rs
@@ -1,4 +1,4 @@
-use crate::ast::{ASTNode, StatementNode};
+use crate::ast::{ASTNode};
 use crate::parse;
 use error::error::{WaveError, WaveErrorKind};
 use lexer::Lexer;

--- a/llvm_temporary/src/llvm_temporary/expression/rvalue/literals.rs
+++ b/llvm_temporary/src/llvm_temporary/expression/rvalue/literals.rs
@@ -54,6 +54,11 @@ pub(crate) fn gen<'ctx, 'a>(
                 iv.as_basic_value_enum()
             }
 
+            Some(BasicTypeEnum::ArrayType(at)) => {
+                let elem = at.get_element_type();
+                return gen(env, lit, Some(elem));
+            }
+
             Some(BasicTypeEnum::PointerType(ptr_ty)) => {
                 let s = v.as_str();
                 let (neg, raw) = parse_signed_decimal(s);

--- a/llvm_temporary/src/llvm_temporary/expression/rvalue/structs.rs
+++ b/llvm_temporary/src/llvm_temporary/expression/rvalue/structs.rs
@@ -1,6 +1,6 @@
 use super::ExprGenEnv;
 use inkwell::values::{BasicValue, BasicValueEnum};
-use parser::ast::{Expression, WaveType};
+use parser::ast::{Expression};
 use crate::llvm_temporary::llvm_codegen::generate_address_ir;
 
 pub(crate) fn gen_struct_literal<'ctx, 'a>(

--- a/llvm_temporary/src/llvm_temporary/llvm_codegen/consts.rs
+++ b/llvm_temporary/src/llvm_temporary/llvm_codegen/consts.rs
@@ -5,7 +5,7 @@ use inkwell::values::{BasicValue, BasicValueEnum};
 use parser::ast::{Expression, Literal, WaveType};
 use std::collections::HashMap;
 
-use super::types::wave_type_to_llvm_type;
+use super::types::{wave_type_to_llvm_type, TypeFlavor};
 
 fn parse_signed_decimal<'a>(s: &'a str) -> (bool, &'a str) {
     if let Some(rest) = s.strip_prefix('-') {
@@ -28,7 +28,7 @@ pub(super) fn create_llvm_const_value<'ctx>(
     expr: &Expression,
 ) -> BasicValueEnum<'ctx> {
     let struct_types = HashMap::new();
-    let llvm_type = wave_type_to_llvm_type(context, ty, &struct_types);
+    let llvm_type = wave_type_to_llvm_type(context, ty, &struct_types, TypeFlavor::AbiC);
 
     match (expr, llvm_type) {
         // new: int literal is string-based

--- a/llvm_temporary/src/llvm_temporary/llvm_codegen/types.rs
+++ b/llvm_temporary/src/llvm_temporary/llvm_codegen/types.rs
@@ -8,6 +8,12 @@ use std::collections::HashMap;
 
 pub type StructFieldMap = HashMap<String, HashMap<String, u32>>;
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum TypeFlavor {
+    Value,
+    AbiC,
+}
+
 pub fn build_field_map(fields: &[(String, parser::ast::WaveType)]) -> HashMap<String, u32> {
     let mut m = HashMap::new();
     for (i, (name, _ty)) in fields.iter().enumerate() {
@@ -32,40 +38,46 @@ pub fn wave_type_to_llvm_type<'ctx>(
     context: &'ctx Context,
     wave_type: &WaveType,
     struct_types: &HashMap<String, inkwell::types::StructType<'ctx>>,
+    flavor: TypeFlavor,
 ) -> BasicTypeEnum<'ctx> {
     match wave_type {
-        WaveType::Int(bits) => context
-            .custom_width_int_type(*bits as u32)
-            .as_basic_type_enum(),
-        WaveType::Uint(bits) => context
-            .custom_width_int_type(*bits as u32)
-            .as_basic_type_enum(),
+        WaveType::Int(bits) | WaveType::Uint(bits) => {
+            context.custom_width_int_type(*bits as u32).as_basic_type_enum()
+        }
+
         WaveType::Float(bits) => match bits {
             32 => context.f32_type().as_basic_type_enum(),
             64 => context.f64_type().as_basic_type_enum(),
             _ => panic!("Unsupported float bit width: {}", bits),
         },
-        WaveType::Bool => context.bool_type().as_basic_type_enum(),
-        WaveType::Char => context.i8_type().as_basic_type_enum(),
-        WaveType::Byte => context.i8_type().as_basic_type_enum(),
-        WaveType::Void => context.i8_type().as_basic_type_enum(), // fallback (shouldn't be used)
-        WaveType::Pointer(inner) => wave_type_to_llvm_type(context, inner, struct_types)
+
+        WaveType::Bool => {
+            if flavor == TypeFlavor::AbiC {
+                context.i8_type().as_basic_type_enum()
+            } else {
+                context.bool_type().as_basic_type_enum()
+            }
+        }
+
+        WaveType::Char | WaveType::Byte => context.i8_type().as_basic_type_enum(),
+
+        WaveType::Void => context.i8_type().as_basic_type_enum(),
+
+        WaveType::Pointer(inner) => wave_type_to_llvm_type(context, inner, struct_types, flavor)
             .ptr_type(AddressSpace::default())
             .as_basic_type_enum(),
+
         WaveType::Array(inner, size) => {
-            let inner_ty = wave_type_to_llvm_type(context, inner, struct_types);
+            let inner_ty = wave_type_to_llvm_type(context, inner, struct_types, flavor);
             inner_ty.array_type(*size as u32).as_basic_type_enum()
         }
-        WaveType::String => context
-            .i8_type()
-            .ptr_type(AddressSpace::default())
+
+        WaveType::String => context.i8_type().ptr_type(AddressSpace::default()).as_basic_type_enum(),
+
+        WaveType::Struct(name) => struct_types
+            .get(name)
+            .unwrap_or_else(|| panic!("Struct type '{}' not found", name))
             .as_basic_type_enum(),
-        WaveType::Struct(name) => {
-            let struct_ty = struct_types
-                .get(name)
-                .unwrap_or_else(|| panic!("Struct type '{}' not found", name));
-            struct_ty.as_basic_type_enum()
-        }
     }
 }
 

--- a/llvm_temporary/src/llvm_temporary/statement/variable.rs
+++ b/llvm_temporary/src/llvm_temporary/statement/variable.rs
@@ -5,6 +5,7 @@ use inkwell::types::{BasicTypeEnum, StructType};
 use inkwell::values::{BasicValue, BasicValueEnum};
 use parser::ast::{Expression, VariableNode, WaveType};
 use std::collections::HashMap;
+use crate::llvm_temporary::llvm_codegen::types::TypeFlavor;
 
 #[derive(Copy, Clone, Debug)]
 pub enum CoercionMode {
@@ -111,7 +112,7 @@ pub(super) fn gen_variable_ir<'ctx>(
     } = var_node;
 
     unsafe {
-        let llvm_type = wave_type_to_llvm_type(context, type_name, struct_types);
+        let llvm_type = wave_type_to_llvm_type(context, type_name, struct_types, TypeFlavor::AbiC);
         let alloca = builder.build_alloca(llvm_type, name).unwrap();
 
         if let (WaveType::Array(element_type, size), Some(Expression::ArrayLiteral(values))) =
@@ -125,7 +126,7 @@ pub(super) fn gen_variable_ir<'ctx>(
                 );
             }
 
-            let llvm_element_type = wave_type_to_llvm_type(context, element_type, struct_types);
+            let llvm_element_type = wave_type_to_llvm_type(context, element_type, struct_types, TypeFlavor::AbiC);
 
             for (i, value_expr) in values.iter().enumerate() {
                 let value = generate_expression_ir(


### PR DESCRIPTION
This PR introduces a significant enhancement to Wave's type system and LLVM backend by implementing "Type Flavors." This architectural change allows the compiler to distinguish between high-level value representations and ABI-compliant types required for C FFI. Additionally, the inline assembly (`asm`) engine has been overhauled to handle register bit-width normalization and sign-aware operand promotion, making system-level programming more predictable and robust.

### Key Changes

#### 1. Type Flavoring & ABI Compatibility
*   **`TypeFlavor` Enum**: Introduced `TypeFlavor` in `types.rs` with two variants: `Value` (internal representation) and `AbiC` (C ABI compliant).
*   **Context-Aware Mapping**: Updated `wave_type_to_llvm_type` to adjust types based on the flavor. For example, when using `AbiC`, Booleans are now emitted as `i8` rather than `i1` to ensure correct parameter passing when calling external C functions.
*   **System-Wide Integration**: Refactored all codegen entry points—including function signatures, struct definitions, and variable declarations—to utilize the appropriate flavor based on the context.

#### 2. Robust Inline Assembly (`asm`) Improvements
*   **Sign-Aware Input Promotion**: Implemented automatic integer promotion for assembly inputs. The compiler now uses the `infer_signedness` utility to decide between sign-extension (`sext`) and zero-extension (`zext`) when promoting values to match target register widths.
*   **Output Normalization**: Added logic to handle bit-width mismatches for assembly outputs. If a target register (e.g., a 64-bit 'r' constraint) returns a value larger than the destination variable, the backend now correctly truncates or extends the result.
*   **Enhanced Coercion**: Refactored `coerce_basic_value_for_store` to support a wider range of conversions for assembly results, including complex integer-to-pointer and float-to-int mappings.

#### 3. LLVM Backend Utilities
*   **Recursive Literals**: Added support for recursive literal generation when the expected target is an `ArrayType`. This allows complex nested initializers to be generated more reliably.
*   **Signedness Inference**: Introduced the `infer_signedness` helper to assist the codegen engine in making mathematically correct decisions during type promotion and comparison.

#### 4. Maintenance & Hygiene
*   Cleaned up unused imports across the parser and codegen submodules.
*   Improved internal documentation and error messages within the backend to assist with debugging complex IR generation scenarios.

### Impact
**Before**: Passing a `bool` to a C function might result in `i1` being passed, which some C ABIs handle inconsistently.
**After**: With `TypeFlavor::AbiC`, the `bool` is correctly passed as an `i8` (0 or 1), matching standard C expectations.

### Benefits
*   **FFI Reliability**: Better compatibility with external C libraries by respecting standard ABI type widths.
*   **Low-Level Safety**: Predictable register handling in `asm` blocks prevents subtle bugs related to sign-extension and bit-truncation.
*   **Code Quality**: A more modular and context-aware type system simplifies future backend development.
