### PR TITLE
feat: implement System V ABI-compliant C FFI lowering

### DIFF
--- a/front/parser/src/expr/unary.rs
+++ b/front/parser/src/expr/unary.rs
@@ -61,7 +61,7 @@ where
                 });
             }
             TokenType::Minus => {
-                let tok = tokens.next()?; // '-'
+                let _tok = tokens.next()?; // '-'
                 let inner = parse_unary_expression(tokens)?;
 
                 match inner {

--- a/front/parser/src/parser/decl.rs
+++ b/front/parser/src/parser/decl.rs
@@ -431,7 +431,7 @@ fn parse_extern_fun_decl(
         // named param? (Identifier ... :)
         let is_named = match tokens.peek() {
             Some(Token { token_type: TokenType::Identifier(_), .. }) => {
-                let next_ty = peek_non_ws_token_type(tokens);
+                let _next_ty = peek_non_ws_token_type(tokens);
                 if let Some(TokenType::Identifier(_)) = tokens.peek().map(|t| t.token_type.clone()) {
                     let mut la = tokens.clone();
                     la.next(); // consume identifier

--- a/llvm_temporary/src/llvm_temporary/expression/lvalue.rs
+++ b/llvm_temporary/src/llvm_temporary/expression/lvalue.rs
@@ -6,8 +6,10 @@ use inkwell::{
     values::{BasicValueEnum, PointerValue},
 };
 use std::collections::HashMap;
+use inkwell::targets::TargetData;
 use parser::ast::Expression;
 use crate::llvm_temporary::expression::rvalue::generate_expression_ir;
+use crate::llvm_temporary::llvm_codegen::abi_c::ExternCInfo;
 use crate::llvm_temporary::llvm_codegen::VariableInfo;
 
 pub fn generate_lvalue_ir<'ctx>(
@@ -19,6 +21,8 @@ pub fn generate_lvalue_ir<'ctx>(
     global_consts: &HashMap<String, BasicValueEnum<'ctx>>,
     struct_types: &HashMap<String, StructType<'ctx>>,
     struct_field_indices: &HashMap<String, HashMap<String, u32>>,
+    target_data: &'ctx TargetData,
+    extern_c_info: &HashMap<String, ExternCInfo<'ctx>>,
 ) -> PointerValue<'ctx> {
     match expr {
         Expression::Variable(name) => {
@@ -42,6 +46,8 @@ pub fn generate_lvalue_ir<'ctx>(
             global_consts,
             struct_types,
             struct_field_indices,
+            target_data,
+            extern_c_info,
         ),
 
         Expression::Deref(inner) => {
@@ -55,6 +61,8 @@ pub fn generate_lvalue_ir<'ctx>(
                 global_consts,
                 struct_types,
                 struct_field_indices,
+                target_data,
+                extern_c_info,
             );
 
             match v {
@@ -72,6 +80,8 @@ pub fn generate_lvalue_ir<'ctx>(
             global_consts,
             struct_types,
             struct_field_indices,
+            target_data,
+            extern_c_info,
         ),
 
         Expression::IndexAccess { target, index } => {
@@ -85,6 +95,8 @@ pub fn generate_lvalue_ir<'ctx>(
                 global_consts,
                 struct_types,
                 struct_field_indices,
+                target_data,
+                extern_c_info,
             );
 
             let mut idx = match idx_val {
@@ -114,6 +126,8 @@ pub fn generate_lvalue_ir<'ctx>(
                         global_consts,
                         struct_types,
                         struct_field_indices,
+                        target_data,
+                        extern_c_info,
                     );
 
                     let elem_ty = lv.get_type().get_element_type();
@@ -138,6 +152,8 @@ pub fn generate_lvalue_ir<'ctx>(
                         global_consts,
                         struct_types,
                         struct_field_indices,
+                        target_data,
+                        extern_c_info,
                     );
                     match v {
                         BasicValueEnum::PointerValue(p) => p,
@@ -166,6 +182,8 @@ pub fn generate_lvalue_ir<'ctx>(
                 global_consts,
                 struct_types,
                 struct_field_indices,
+                target_data,
+                extern_c_info,
             );
 
             let obj_elem_ty = obj_ptr.get_type().get_element_type();

--- a/llvm_temporary/src/llvm_temporary/expression/rvalue/calls.rs
+++ b/llvm_temporary/src/llvm_temporary/expression/rvalue/calls.rs
@@ -1,8 +1,53 @@
-use inkwell::types::{AsTypeRef, BasicTypeEnum};
+use inkwell::types::{AnyTypeEnum, AsTypeRef, BasicType, BasicTypeEnum};
 use super::ExprGenEnv;
-use inkwell::values::{BasicMetadataValueEnum, BasicValue, BasicValueEnum};
+use inkwell::values::{BasicMetadataValueEnum, BasicValue, BasicValueEnum, PointerValue};
 use parser::ast::{Expression, WaveType};
+use crate::llvm_temporary::llvm_codegen::abi_c::{ParamLowering, RetLowering};
 use crate::llvm_temporary::statement::variable::{coerce_basic_value, CoercionMode};
+
+fn pack_agg_to_int<'ctx, 'a>(
+    env: &ExprGenEnv<'ctx, 'a>,
+    agg: BasicValueEnum<'ctx>,
+    dst: inkwell::types::IntType<'ctx>,
+    tag: &str,
+) -> BasicValueEnum<'ctx> {
+    let agg_ty = agg.get_type();
+    let tmp = env.builder.build_alloca(agg_ty, &format!("{}_agg_tmp", tag)).unwrap();
+    env.builder.build_store(tmp, agg).unwrap();
+
+    let int_ptr_ty = dst.ptr_type(tmp.get_type().get_address_space());
+    let casted = env.builder
+        .build_bit_cast(tmp.as_basic_value_enum(), int_ptr_ty.as_basic_type_enum(), &format!("{}_agg_i_ptr", tag))
+        .unwrap()
+        .into_pointer_value();
+
+    env.builder
+        .build_load(casted, &format!("{}_agg_i", tag))
+        .unwrap()
+        .as_basic_value_enum()
+}
+
+fn unpack_int_to_agg<'ctx, 'a>(
+    env: &ExprGenEnv<'ctx, 'a>,
+    iv: inkwell::values::IntValue<'ctx>,
+    dst_agg_ty: BasicTypeEnum<'ctx>,
+    tag: &str,
+) -> BasicValueEnum<'ctx> {
+    let tmp = env.builder.build_alloca(dst_agg_ty, &format!("{}_i2agg_tmp", tag)).unwrap();
+
+    let int_ptr_ty = iv.get_type().ptr_type(tmp.get_type().get_address_space());
+    let casted = env.builder
+        .build_bit_cast(tmp.as_basic_value_enum(), int_ptr_ty.as_basic_type_enum(), &format!("{}_i_ptr", tag))
+        .unwrap()
+        .into_pointer_value();
+
+    env.builder.build_store(casted, iv).unwrap();
+
+    env.builder
+        .build_load(tmp, &format!("{}_i2agg_load", tag))
+        .unwrap()
+        .as_basic_value_enum()
+}
 
 fn normalize_struct_name(raw: &str) -> &str {
     raw.strip_prefix("struct.").unwrap_or(raw).trim_start_matches('%')
@@ -193,16 +238,138 @@ pub(crate) fn gen_function_call<'ctx, 'a>(
     env: &mut ExprGenEnv<'ctx, 'a>,
     name: &str,
     args: &[Expression],
-    expected_type: Option<inkwell::types::BasicTypeEnum<'ctx>>,
+    expected_type: Option<BasicTypeEnum<'ctx>>,
 ) -> BasicValueEnum<'ctx> {
+
+    if let Some(info) = env.extern_c_info.get(name) {
+        let function = env.module
+            .get_function(name)
+            .unwrap_or_else(|| panic!("Extern function '{}' not found in module (symbol alias?)", name));
+
+        if args.len() != info.params.len() {
+            panic!(
+                "Extern `{}` expects {} arguments (wave-level), got {}",
+                name, info.params.len(), args.len()
+            );
+        }
+
+        let fn_type = function.get_type();
+        let llvm_param_types = fn_type.get_param_types();
+
+        let mut lowered_args: Vec<BasicMetadataValueEnum<'ctx>> = Vec::new();
+        let mut llvm_pi: usize = 0;
+
+        // 1) sret hidden param
+        let mut sret_tmp: Option<PointerValue<'ctx>> = None;
+        if let RetLowering::SRet { ty, .. } = &info.ret {
+            let agg = any_agg_to_basic(*ty);
+            let tmp = env.builder.build_alloca(agg, &format!("{}_sret_tmp", name)).unwrap();
+
+            let expected_ptr = llvm_param_types[0]
+                .into_pointer_type();
+            let tmp2 = coerce_ptr_to(env, tmp, expected_ptr, &format!("{}_sret_ptrcast", name));
+
+            lowered_args.push(tmp2.as_basic_value_enum().into());
+            sret_tmp = Some(tmp);
+            llvm_pi += 1;
+        }
+
+        // 2) wave params
+        for (i, (arg_expr, p)) in args.iter().zip(info.params.iter()).enumerate() {
+            match p {
+                ParamLowering::Direct(t) => {
+                    let mut v = env.gen(arg_expr, Some(*t));
+                    v = coerce_to_expected(env, v, *t, name, i);
+                    lowered_args.push(v.into());
+                    llvm_pi += 1;
+                }
+
+                ParamLowering::ByVal { ty, .. } => {
+                    let agg = any_agg_to_basic(*ty);
+                    let v = env.gen(arg_expr, Some(agg));
+                    let tmp = env.builder.build_alloca(agg, &format!("{}_byval_tmp_{}", name, i)).unwrap();
+                    env.builder.build_store(tmp, v).unwrap();
+
+                    let expected_ptr = llvm_param_types[llvm_pi].into_pointer_type();
+                    let tmp2 = coerce_ptr_to(env, tmp, expected_ptr, &format!("{}_byval_ptrcast_{}", name, i));
+                    lowered_args.push(tmp2.as_basic_value_enum().into());
+                    llvm_pi += 1;
+                }
+
+                ParamLowering::Split(parts) => {
+                    let mut agg_val = env.gen(arg_expr, None);
+
+                    if let BasicValueEnum::PointerValue(pv) = agg_val {
+                        let et = pv.get_type().get_element_type();
+                        if et.is_struct_type() || et.is_array_type() {
+                            agg_val = env.builder
+                                .build_load(pv, &format!("{}_split_load_{}", name, i))
+                                .unwrap()
+                                .as_basic_value_enum();
+                        }
+                    }
+
+                    let split_vals = split_hfa_from_agg(env, agg_val, parts, &format!("{}_split_{}", name, i));
+
+                    for sv in split_vals {
+                        let et = llvm_param_types[llvm_pi];
+                        let vv = coerce_basic_value(env.context, env.builder, sv, et, "split_cast", CoercionMode::Implicit);
+                        lowered_args.push(vv.into());
+                        llvm_pi += 1;
+                    }
+                }
+
+            }
+        }
+
+        let call_name = match info.ret {
+            RetLowering::Void | RetLowering::SRet { .. } => String::new(),
+            _ => format!("call_{}", name),
+        };
+
+        let call_site = env.builder
+            .build_call(function, &lowered_args, &call_name)
+            .unwrap();
+
+        // 3) return
+        match &info.ret {
+            RetLowering::Void => {
+                if expected_type.is_some() {
+                    panic!("Extern '{}' returns void and cannot be used as a value", name);
+                }
+                return env.context.i32_type().const_zero().as_basic_value_enum();
+            }
+
+            RetLowering::SRet { ty, .. } => {
+                let tmp = sret_tmp.expect("SRet lowering requires sret tmp");
+                let agg = any_agg_to_basic(*ty);
+                let v = env.builder.build_load(tmp, &format!("{}_sret_load", name)).unwrap();
+
+                if let Some(et) = expected_type {
+                    return coerce_lowered_ret_to_expected(env, v.as_basic_value_enum(), et, "sret_ret");
+                }
+                return v.as_basic_value_enum();
+            }
+
+            RetLowering::Direct(_t) => {
+                let rv = call_site.try_as_basic_value().left().unwrap();
+
+                if let Some(et) = expected_type {
+                    return coerce_lowered_ret_to_expected(env, rv, et, "direct_ret");
+                }
+                return rv;
+            }
+        }
+    }
+
     let function = env
         .module
         .get_function(name)
         .unwrap_or_else(|| panic!("Function '{}' not found", name));
 
     let fn_type = function.get_type();
-    let param_types: Vec<inkwell::types::BasicTypeEnum> = fn_type.get_param_types();
-    let ret_type: Option<inkwell::types::BasicTypeEnum> = fn_type.get_return_type();
+    let param_types: Vec<BasicTypeEnum> = fn_type.get_param_types();
+    let ret_type: Option<BasicTypeEnum> = fn_type.get_return_type();
 
     if args.len() != param_types.len() {
         panic!(
@@ -213,13 +380,12 @@ pub(crate) fn gen_function_call<'ctx, 'a>(
         );
     }
 
-    let mut call_args: Vec<inkwell::values::BasicMetadataValueEnum> = Vec::with_capacity(args.len());
+    let mut call_args: Vec<BasicMetadataValueEnum> = Vec::with_capacity(args.len());
 
     for (i, arg) in args.iter().enumerate() {
         let expected_param_ty = param_types[i];
         let mut val = env.gen(arg, Some(expected_param_ty));
         val = coerce_to_expected(env, val, expected_param_ty, name, i);
-
         call_args.push(val.into());
     }
 
@@ -309,17 +475,21 @@ fn coerce_to_expected<'ctx, 'a>(
                     .as_basic_value_enum()
             }
 
-        // 3) ptr-to-struct -> struct value (load)
-        (BasicTypeEnum::PointerType(p), BasicTypeEnum::StructType(s))
-        if p.get_element_type().is_struct_type()
-            && p.get_element_type().into_struct_type() == s =>
-            {
-                let ptr = val.into_pointer_value();
-                env.builder
-                    .build_load(ptr, &format!("arg{}_st_load", arg_index))
-                    .unwrap()
-                    .as_basic_value_enum()
-            }
+        // 3) ptr-to-struct -> struct value (load)  (more robust: allow different named struct identities)
+        (BasicTypeEnum::PointerType(_p), BasicTypeEnum::StructType(s)) => {
+            let ptr = val.into_pointer_value();
+
+            let expected_ptr_ty = s.ptr_type(ptr.get_type().get_address_space());
+            let casted = env.builder
+                .build_bit_cast(ptr.as_basic_value_enum(), expected_ptr_ty, &format!("arg{}_st_ptrcast", arg_index))
+                .unwrap()
+                .into_pointer_value();
+
+            env.builder
+                .build_load(casted, &format!("arg{}_st_load", arg_index))
+                .unwrap()
+                .as_basic_value_enum()
+        }
 
         // 4) ptr -> ptr (bitcast)
         (BasicTypeEnum::PointerType(_), BasicTypeEnum::PointerType(dst)) => {
@@ -329,11 +499,181 @@ fn coerce_to_expected<'ctx, 'a>(
                 .as_basic_value_enum()
         }
 
+        // (Struct|Array) -> Int : store-size가 정확히 맞으면 bit-pack
+        (got_ty @ (BasicTypeEnum::StructType(_) | BasicTypeEnum::ArrayType(_)), BasicTypeEnum::IntType(dst)) => {
+            let sz = env.target_data.get_store_size(&got_ty) as u64;
+            let bits = (sz * 8) as u32;
+            if bits == dst.get_bit_width() {
+                return pack_agg_to_int(env, val, dst, &format!("arg{}_pack", arg_index));
+            }
+            panic!(
+                "Cannot pack aggregate to int: agg bits {} != dst bits {} (arg {} of {})",
+                bits, dst.get_bit_width(), arg_index, name
+            );
+        }
+
+        (BasicTypeEnum::IntType(src), dst_agg @ (BasicTypeEnum::StructType(_) | BasicTypeEnum::ArrayType(_))) => {
+            let sz = env.target_data.get_store_size(&dst_agg) as u64;
+            let bits = (sz * 8) as u32;
+            if bits == src.get_bit_width() {
+                let iv = val.into_int_value();
+                return unpack_int_to_agg(env, iv, dst_agg, &format!("arg{}_unpack", arg_index));
+            }
+            panic!(
+                "Cannot unpack int to aggregate: int bits {} != agg bits {} (arg {} of {})",
+                src.get_bit_width(), bits, arg_index, name
+            );
+        }
+
+
         _ => {
             panic!(
                 "Type mismatch for arg {} of '{}': expected {:?}, got {:?}",
                 arg_index, name, expected, got
             );
         }
+    }
+}
+
+fn any_agg_to_basic<'ctx>(ty: AnyTypeEnum<'ctx>) -> BasicTypeEnum<'ctx> {
+    match ty {
+        AnyTypeEnum::StructType(st) => st.as_basic_type_enum(),
+        AnyTypeEnum::ArrayType(at) => at.as_basic_type_enum(),
+        _ => panic!("Expected aggregate AnyTypeEnum (struct/array), got {:?}", ty),
+    }
+}
+
+fn coerce_ptr_to<'ctx, 'a>(
+    env: &ExprGenEnv<'ctx, 'a>,
+    pv: PointerValue<'ctx>,
+    expected_ptr_ty: inkwell::types::PointerType<'ctx>,
+    tag: &str,
+) -> PointerValue<'ctx> {
+    if pv.get_type() == expected_ptr_ty {
+        return pv;
+    }
+    env.builder
+        .build_bit_cast(
+            pv.as_basic_value_enum(),
+            expected_ptr_ty.as_basic_type_enum(),
+            tag,
+        )
+        .unwrap()
+        .into_pointer_value()
+}
+
+fn split_hfa_from_agg<'ctx, 'a>(
+    env: &ExprGenEnv<'ctx, 'a>,
+    agg_val: BasicValueEnum<'ctx>,
+    parts: &[BasicTypeEnum<'ctx>],
+    tag: &str,
+) -> Vec<BasicValueEnum<'ctx>> {
+    let agg_ty = agg_val.get_type();
+    let tmp = env.builder.build_alloca(agg_ty, &format!("{tag}_hfa_tmp")).unwrap();
+    env.builder.build_store(tmp, agg_val).unwrap();
+
+    let float_ty: inkwell::types::FloatType<'ctx> = match parts.first().unwrap() {
+        BasicTypeEnum::FloatType(ft) => *ft,
+        BasicTypeEnum::VectorType(vt) => match vt.get_element_type() {
+            BasicTypeEnum::FloatType(ft) => ft,
+            other => panic!("HFA vector elem is not float: {:?}", other),
+        },
+        other => panic!("HFA part is not float/vector: {:?}", other),
+    };
+
+    let fptr_ty = float_ty.ptr_type(tmp.get_type().get_address_space());
+    let base_fptr = env.builder
+        .build_bit_cast(tmp.as_basic_value_enum(), fptr_ty.as_basic_type_enum(), &format!("{tag}_hfa_fptr"))
+        .unwrap()
+        .into_pointer_value();
+
+    let mut out = Vec::with_capacity(parts.len());
+    let mut idx: u32 = 0;
+
+    for (pi, part_ty) in parts.iter().enumerate() {
+        match part_ty {
+            BasicTypeEnum::FloatType(_) => {
+                let i = env.context.i32_type().const_int(idx as u64, false);
+                let ep = unsafe {
+                    env.builder
+                        .build_gep(base_fptr, &[i], &format!("{tag}_hfa_gep_{pi}"))
+                        .unwrap()
+                };
+                let fv = env.builder.build_load(ep, &format!("{tag}_hfa_f_{pi}")).unwrap();
+                out.push(fv.as_basic_value_enum());
+                idx += 1;
+            }
+            BasicTypeEnum::VectorType(vt) => {
+                let n = vt.get_size(); // element count
+                let mut v = vt.get_undef();
+
+                for j in 0..n {
+                    let i = env.context.i32_type().const_int((idx + j) as u64, false);
+                    let ep = unsafe {
+                        env.builder
+                            .build_gep(base_fptr, &[i], &format!("{tag}_hfa_gep_{pi}_{j}"))
+                            .unwrap()
+                    };
+                    let fv = env.builder.build_load(ep, &format!("{tag}_hfa_f_{pi}_{j}")).unwrap();
+
+                    let jv = env.context.i32_type().const_int(j as u64, false);
+                    v = env.builder
+                        .build_insert_element(v, fv, jv, &format!("{tag}_hfa_ins_{pi}_{j}"))
+                        .unwrap();
+                }
+
+                out.push(v.as_basic_value_enum());
+                idx += n;
+            }
+            other => panic!("Unsupported Split part type: {:?}", other),
+        }
+    }
+
+    out
+}
+
+fn coerce_lowered_ret_to_expected<'ctx, 'a>(
+    env: &ExprGenEnv<'ctx, 'a>,
+    lowered_ret: BasicValueEnum<'ctx>,
+    expected: BasicTypeEnum<'ctx>,
+    tag: &str,
+) -> BasicValueEnum<'ctx> {
+    if lowered_ret.get_type() == expected {
+        return lowered_ret;
+    }
+
+    match (lowered_ret.get_type(), expected) {
+        (BasicTypeEnum::IntType(_), BasicTypeEnum::StructType(_) | BasicTypeEnum::ArrayType(_)) => {
+            let iv = lowered_ret.into_int_value();
+            unpack_int_to_agg(env, iv, expected, tag)
+        }
+        // vector(float) -> struct/array (HFA ret)
+        (BasicTypeEnum::VectorType(vt), BasicTypeEnum::StructType(_) | BasicTypeEnum::ArrayType(_)) => {
+            let tmp = env.builder.build_alloca(expected, &format!("{tag}_v2agg_tmp")).unwrap();
+
+            let vptr_ty = vt.ptr_type(tmp.get_type().get_address_space());
+            let vptr = env.builder
+                .build_bit_cast(tmp.as_basic_value_enum(), vptr_ty.as_basic_type_enum(), &format!("{tag}_vptr"))
+                .unwrap()
+                .into_pointer_value();
+
+            env.builder.build_store(vptr, lowered_ret).unwrap();
+
+            env.builder
+                .build_load(tmp, &format!("{tag}_v2agg_load"))
+                .unwrap()
+                .as_basic_value_enum()
+        }
+        (BasicTypeEnum::FloatType(ft), BasicTypeEnum::StructType(_) | BasicTypeEnum::ArrayType(_)) => {
+            let tmp = env.builder.build_alloca(expected, &format!("{tag}_f2agg_tmp")).unwrap();
+            let fptr_ty = ft.ptr_type(tmp.get_type().get_address_space());
+            let fptr = env.builder
+                .build_bit_cast(tmp.as_basic_value_enum(), fptr_ty.as_basic_type_enum(), &format!("{tag}_fptr"))
+                .unwrap()
+                .into_pointer_value();
+            env.builder.build_store(fptr, lowered_ret).unwrap();
+            env.builder.build_load(tmp, &format!("{tag}_f2agg_load")).unwrap().as_basic_value_enum()
+        }
+        _ => lowered_ret,
     }
 }

--- a/llvm_temporary/src/llvm_temporary/expression/rvalue/dispatch.rs
+++ b/llvm_temporary/src/llvm_temporary/expression/rvalue/dispatch.rs
@@ -41,7 +41,5 @@ pub(crate) fn gen_expr<'ctx, 'a>(
 
         Expression::Grouped(inner) => env.gen(inner, expected_type),
         Expression::ArrayLiteral(elements) => arrays::gen_array_literal(env, elements, expected_type),
-
-        _ => unimplemented!("Unsupported expression type"),
     }
 }

--- a/llvm_temporary/src/llvm_temporary/expression/rvalue/mod.rs
+++ b/llvm_temporary/src/llvm_temporary/expression/rvalue/mod.rs
@@ -6,6 +6,8 @@ use inkwell::types::{BasicTypeEnum, StructType};
 use inkwell::values::{BasicValueEnum};
 use parser::ast::Expression;
 use std::collections::HashMap;
+use inkwell::targets::TargetData;
+use crate::llvm_temporary::llvm_codegen::abi_c::ExternCInfo;
 
 pub mod dispatch;
 pub mod utils;
@@ -37,6 +39,8 @@ pub(crate) struct ExprGenEnv<'ctx, 'a> {
     pub global_consts: &'a HashMap<String, BasicValueEnum<'ctx>>,
     pub struct_types: &'a HashMap<String, StructType<'ctx>>,
     pub struct_field_indices: &'a HashMap<String, HashMap<String, u32>>,
+    pub target_data: &'a TargetData,
+    pub extern_c_info: &'a HashMap<String, ExternCInfo<'ctx>>,
 }
 
 impl<'ctx, 'a> ExprGenEnv<'ctx, 'a> {
@@ -60,6 +64,8 @@ pub fn generate_expression_ir<'ctx>(
     global_consts: &HashMap<String, BasicValueEnum<'ctx>>,
     struct_types: &HashMap<String, StructType<'ctx>>,
     struct_field_indices: &HashMap<String, HashMap<String, u32>>,
+    target_data: &'ctx TargetData,
+    extern_c_info: &HashMap<String, ExternCInfo<'ctx>>,
 ) -> BasicValueEnum<'ctx> {
     let mut env = ExprGenEnv {
         context,
@@ -69,6 +75,8 @@ pub fn generate_expression_ir<'ctx>(
         global_consts,
         struct_types,
         struct_field_indices,
+        target_data,
+        extern_c_info,
     };
 
     env.gen(expr, expected_type)

--- a/llvm_temporary/src/llvm_temporary/llvm_codegen/abi_c.rs
+++ b/llvm_temporary/src/llvm_temporary/llvm_codegen/abi_c.rs
@@ -1,0 +1,353 @@
+// src/llvm_temporary/llvm_codegen/abi_c.rs
+use std::collections::HashMap;
+use inkwell::AddressSpace;
+use inkwell::attributes::{Attribute, AttributeLoc};
+use inkwell::context::Context;
+use inkwell::targets::TargetData;
+use inkwell::types::{AnyType, AnyTypeEnum, BasicMetadataTypeEnum, BasicType, BasicTypeEnum};
+use inkwell::values::FunctionValue;
+
+use parser::ast::{ExternFunctionNode, WaveType};
+
+use super::types::{wave_type_to_llvm_type, TypeFlavor};
+
+#[derive(Clone)]
+pub enum ParamLowering<'ctx> {
+    Direct(BasicTypeEnum<'ctx>),                 // pass as this llvm type
+    Split(Vec<BasicTypeEnum<'ctx>>),             // pass as multiple params
+    ByVal { ty: AnyTypeEnum<'ctx>, align: u32 }, // pass ptr + byval + align
+}
+
+#[derive(Clone)]
+pub enum RetLowering<'ctx> {
+    Void,
+    Direct(BasicTypeEnum<'ctx>),
+    SRet { ty: AnyTypeEnum<'ctx>, align: u32 }, // hidden first param
+}
+
+#[derive(Clone)]
+pub struct ExternCInfo<'ctx> {
+    pub wave_ret: WaveType,              // Wave-level return type (needed when sret => llvm void)
+    pub ret: RetLowering<'ctx>,
+    pub params: Vec<ParamLowering<'ctx>>, // per-wave param
+    pub llvm_param_types: Vec<BasicMetadataTypeEnum<'ctx>>, // final lowered param list (including sret ptr, split, byval ptr)
+}
+
+pub struct LoweredExtern<'ctx> {
+    pub info: ExternCInfo<'ctx>,
+    pub llvm_name: String,
+    pub fn_type: inkwell::types::FunctionType<'ctx>,
+}
+
+fn is_float_ty<'ctx>(td: &TargetData, t: BasicTypeEnum<'ctx>) -> Option<u32> {
+    match t {
+        BasicTypeEnum::FloatType(_) => Some(td.get_store_size(&t) as u32), // 4 or 8
+        _ => None,
+    }
+}
+
+fn any_ptr_basic<'ctx>(ty: AnyTypeEnum<'ctx>) -> BasicTypeEnum<'ctx> {
+    let aspace = AddressSpace::default();
+    match ty {
+        AnyTypeEnum::ArrayType(t)  => t.ptr_type(aspace).as_basic_type_enum(),
+        AnyTypeEnum::FloatType(t)  => t.ptr_type(aspace).as_basic_type_enum(),
+        AnyTypeEnum::FunctionType(t)=> t.ptr_type(aspace).as_basic_type_enum(),
+        AnyTypeEnum::IntType(t)    => t.ptr_type(aspace).as_basic_type_enum(),
+        AnyTypeEnum::PointerType(t)=> t.ptr_type(aspace).as_basic_type_enum(),
+        AnyTypeEnum::StructType(t) => t.ptr_type(aspace).as_basic_type_enum(),
+        AnyTypeEnum::VectorType(t) => t.ptr_type(aspace).as_basic_type_enum(),
+        _ => panic!("unsupported AnyTypeEnum for ptr"),
+    }
+}
+
+fn flatten_leaf_types<'ctx>(t: BasicTypeEnum<'ctx>, out: &mut Vec<BasicTypeEnum<'ctx>>) {
+    match t {
+        BasicTypeEnum::StructType(st) => {
+            for i in 0..st.count_fields() {
+                let f = st.get_field_type_at_index(i).unwrap();
+                flatten_leaf_types(f, out);
+            }
+        }
+        BasicTypeEnum::ArrayType(at) => {
+            let elem = at.get_element_type();
+            for _ in 0..at.len() {
+                flatten_leaf_types(elem, out);
+            }
+        }
+        _ => out.push(t),
+    }
+}
+
+fn classify_param<'ctx>(
+    context: &'ctx Context,
+    td: &TargetData,
+    t: BasicTypeEnum<'ctx>,
+) -> ParamLowering<'ctx> {
+    let size = td.get_store_size(&t) as u64;
+
+    // large aggregates => byval
+    if matches!(t, BasicTypeEnum::StructType(_) | BasicTypeEnum::ArrayType(_)) && size > 16 {
+        let align = td.get_abi_alignment(&t) as u32;
+        return ParamLowering::ByVal { ty: t.as_any_type_enum(), align };
+    }
+
+    // small aggregates: try integer-only or homogeneous float
+    if matches!(t, BasicTypeEnum::StructType(_) | BasicTypeEnum::ArrayType(_)) && size <= 16 {
+        let mut leaves = vec![];
+        flatten_leaf_types(t, &mut leaves);
+
+        // homogeneous float aggregate
+        let mut float_kind: Option<u32> = None;
+        let mut all_float = true;
+        for lt in &leaves {
+            if let Some(sz) = is_float_ty(td, *lt) {
+                float_kind.get_or_insert(sz);
+                if float_kind != Some(sz) {
+                    all_float = false;
+                    break;
+                }
+            } else {
+                all_float = false;
+                break;
+            }
+        }
+
+        if all_float {
+            let count = leaves.len();
+            let fsz = float_kind.unwrap_or(0);
+            if fsz == 4 {
+                let f = context.f32_type();
+                return match count {
+                    1 => ParamLowering::Direct(f.as_basic_type_enum()),
+                    2 => ParamLowering::Direct(f.vec_type(2).as_basic_type_enum()),
+                    3 => ParamLowering::Split(vec![
+                        f.vec_type(2).as_basic_type_enum(),
+                        f.as_basic_type_enum(),
+                    ]),
+                    4 => ParamLowering::Direct(f.vec_type(4).as_basic_type_enum()),
+                    _ => {
+                        let align = td.get_abi_alignment(&t) as u32;
+                        ParamLowering::ByVal { ty: t.as_any_type_enum(), align }
+                    }
+                };
+            } else if fsz == 8 {
+                let f = context.f64_type();
+                return match count {
+                    1 => ParamLowering::Direct(f.as_basic_type_enum()),
+                    2 => ParamLowering::Direct(f.vec_type(2).as_basic_type_enum()),
+                    _ => {
+                        let align = td.get_abi_alignment(&t) as u32;
+                        ParamLowering::ByVal { ty: t.as_any_type_enum(), align }
+                    }
+                };
+            }
+        }
+
+        // integer-only aggregate: coerce to i{size*8}
+        let mut all_intlike = true;
+        for lt in &leaves {
+            match lt {
+                BasicTypeEnum::IntType(_) | BasicTypeEnum::PointerType(_) => {}
+                _ => { all_intlike = false; break; }
+            }
+        }
+        if all_intlike {
+            let bits = (size * 8) as u32;
+            let it = context.custom_width_int_type(bits);
+            return ParamLowering::Direct(it.as_basic_type_enum());
+        }
+
+        // mixed small aggregate: safest is byval (conservative but correct)
+        let align = td.get_abi_alignment(&t) as u32;
+        return ParamLowering::ByVal { ty: t.as_any_type_enum(), align };
+    }
+
+    // non-aggregate: direct
+    ParamLowering::Direct(t)
+}
+
+fn classify_ret<'ctx>(
+    context: &'ctx Context,
+    td: &TargetData,
+    t: Option<BasicTypeEnum<'ctx>>,
+) -> RetLowering<'ctx> {
+    let Some(t) = t else { return RetLowering::Void; };
+
+    let size = td.get_store_size(&t) as u64;
+    let is_agg = matches!(t, BasicTypeEnum::StructType(_) | BasicTypeEnum::ArrayType(_));
+
+    if is_agg && size > 16 {
+        let align = td.get_abi_alignment(&t) as u32;
+        return RetLowering::SRet { ty: t.as_any_type_enum(), align };
+    }
+
+    if is_agg && size <= 16 {
+        // integer-only ret => i{size*8}
+        let mut leaves = vec![];
+        flatten_leaf_types(t, &mut leaves);
+
+        let mut all_intlike = true;
+        for lt in &leaves {
+            match lt {
+                BasicTypeEnum::IntType(_) | BasicTypeEnum::PointerType(_) => {}
+                _ => { all_intlike = false; break; }
+            }
+        }
+        if all_intlike {
+            let bits = (size * 8) as u32;
+            let it = context.custom_width_int_type(bits);
+            return RetLowering::Direct(it.as_basic_type_enum());
+        }
+
+        // homogeneous float ret (2 or 4 only to avoid multi-reg return complexity)
+        let mut float_kind: Option<u32> = None;
+        let mut all_float = true;
+        for lt in &leaves {
+            if let Some(sz) = is_float_ty(td, *lt) {
+                float_kind.get_or_insert(sz);
+                if float_kind != Some(sz) { all_float = false; break; }
+            } else { all_float = false; break; }
+        }
+        if all_float {
+            let count = leaves.len();
+            if float_kind == Some(4) {
+                let f = context.f32_type();
+                return match count {
+                    1 => RetLowering::Direct(f.as_basic_type_enum()),
+                    2 => RetLowering::Direct(f.vec_type(2).as_basic_type_enum()),
+                    4 => RetLowering::Direct(f.vec_type(4).as_basic_type_enum()),
+                    _ => {
+                        // 3-float ret 같은 건 일단 sret로 안전하게
+                        let align = td.get_abi_alignment(&t) as u32;
+                        RetLowering::SRet { ty: t.as_any_type_enum(), align }
+                    }
+                };
+            }
+            if float_kind == Some(8) {
+                let f = context.f64_type();
+                return match count {
+                    1 => RetLowering::Direct(f.as_basic_type_enum()),
+                    2 => RetLowering::Direct(f.vec_type(2).as_basic_type_enum()),
+                    _ => {
+                        let align = td.get_abi_alignment(&t) as u32;
+                        RetLowering::SRet { ty: t.as_any_type_enum(), align }
+                    }
+                };
+            }
+        }
+
+        // mixed small aggregate ret: safest sret
+        let align = td.get_abi_alignment(&t) as u32;
+        return RetLowering::SRet { ty: t.as_any_type_enum(), align };
+    }
+
+    RetLowering::Direct(t)
+}
+
+pub fn lower_extern_c<'ctx>(
+    context: &'ctx Context,
+    td: &TargetData,
+    ext: &ExternFunctionNode,
+    struct_types: &HashMap<String, inkwell::types::StructType<'ctx>>,
+) -> LoweredExtern<'ctx> {
+    let llvm_name = ext.symbol.as_deref().unwrap_or(ext.name.as_str()).to_string();
+
+    // wave types -> layout types
+    let wave_param_layout: Vec<BasicTypeEnum<'ctx>> = ext.params.iter()
+        .map(|(_, ty)| wave_type_to_llvm_type(context, ty, struct_types, TypeFlavor::AbiC))
+        .collect();
+
+    let wave_ret_layout: Option<BasicTypeEnum<'ctx>> = match &ext.return_type {
+        WaveType::Void => None,
+        ty => Some(wave_type_to_llvm_type(context, ty, struct_types, TypeFlavor::AbiC)),
+    };
+
+    let ret = classify_ret(context, td, wave_ret_layout);
+    let mut params: Vec<ParamLowering<'ctx>> = vec![];
+    for p in wave_param_layout {
+        params.push(classify_param(context, td, p));
+    }
+
+    // build lowered param list (sret first, then params possibly split)
+    let mut llvm_param_types: Vec<BasicMetadataTypeEnum<'ctx>> = vec![];
+
+    if let RetLowering::SRet { ty, .. } = &ret {
+        // sret param is ptr to the return aggregate
+        let ptr = any_ptr_basic(ty.clone());
+        llvm_param_types.push(ptr.into());
+    }
+
+    for p in &params {
+        match p {
+            ParamLowering::Direct(t) => llvm_param_types.push((*t).into()),
+            ParamLowering::Split(parts) => {
+                for pt in parts {
+                    llvm_param_types.push((*pt).into());
+                }
+            }
+            ParamLowering::ByVal { ty, .. } => {
+                let ptr = any_ptr_basic(ty.clone());
+                llvm_param_types.push(ptr.into());
+            }
+        }
+    }
+
+    let fn_type = match &ret {
+        RetLowering::Void | RetLowering::SRet { .. } => context.void_type().fn_type(&llvm_param_types, false),
+        RetLowering::Direct(t) => t.fn_type(&llvm_param_types, false),
+    };
+
+    LoweredExtern {
+        llvm_name,
+        fn_type,
+        info: ExternCInfo {
+            wave_ret: ext.return_type.clone(),
+            ret,
+            params,
+            llvm_param_types,
+        },
+    }
+}
+
+pub fn apply_extern_c_attrs<'ctx>(
+    context: &'ctx Context,
+    f: FunctionValue<'ctx>,
+    info: &ExternCInfo<'ctx>,
+) {
+    let mut llvm_param_index: u32 = 0;
+
+    // sret first param
+    if let RetLowering::SRet { ty, align } = &info.ret {
+        let sret_kind = Attribute::get_named_enum_kind_id("sret");
+        let sret_attr = context.create_type_attribute(sret_kind, *ty);
+        f.add_attribute(AttributeLoc::Param(0), sret_attr);
+
+        let align_kind = Attribute::get_named_enum_kind_id("align");
+        let align_attr = context.create_enum_attribute(align_kind, *align as u64);
+        f.add_attribute(AttributeLoc::Param(0), align_attr);
+
+        llvm_param_index += 1;
+    }
+
+    for p in &info.params {
+        match p {
+            ParamLowering::Direct(_) => {
+                llvm_param_index += 1;
+            }
+            ParamLowering::Split(parts) => {
+                llvm_param_index += parts.len() as u32;
+            }
+            ParamLowering::ByVal { ty, align } => {
+                let byval_kind = Attribute::get_named_enum_kind_id("byval");
+                let byval_attr = context.create_type_attribute(byval_kind, *ty);
+                f.add_attribute(AttributeLoc::Param(llvm_param_index), byval_attr);
+
+                let align_kind = Attribute::get_named_enum_kind_id("align");
+                let align_attr = context.create_enum_attribute(align_kind, *align as u64);
+                f.add_attribute(AttributeLoc::Param(llvm_param_index), align_attr);
+
+                llvm_param_index += 1;
+            }
+        }
+    }
+}

--- a/llvm_temporary/src/llvm_temporary/llvm_codegen/mod.rs
+++ b/llvm_temporary/src/llvm_temporary/llvm_codegen/mod.rs
@@ -5,6 +5,7 @@ pub mod types;
 pub mod address;
 pub mod legacy;
 pub mod plan;
+pub mod abi_c;
 
 pub use address::generate_address_ir;
 pub use format::{wave_format_to_c, wave_format_to_scanf};

--- a/llvm_temporary/src/llvm_temporary/llvm_codegen/types.rs
+++ b/llvm_temporary/src/llvm_temporary/llvm_codegen/types.rs
@@ -5,6 +5,7 @@ use inkwell::AddressSpace;
 
 use parser::ast::{Mutability, WaveType};
 use std::collections::HashMap;
+use inkwell::targets::TargetData;
 
 pub type StructFieldMap = HashMap<String, HashMap<String, u32>>;
 
@@ -79,6 +80,58 @@ pub fn wave_type_to_llvm_type<'ctx>(
             .unwrap_or_else(|| panic!("Struct type '{}' not found", name))
             .as_basic_type_enum(),
     }
+}
+
+fn flatten_leaves<'ctx>(t: BasicTypeEnum<'ctx>, out: &mut Vec<BasicTypeEnum<'ctx>>) {
+    match t {
+        BasicTypeEnum::StructType(st) => {
+            for i in 0..st.count_fields() {
+                let f = st.get_field_type_at_index(i).unwrap();
+                flatten_leaves(f, out);
+            }
+        }
+        BasicTypeEnum::ArrayType(at) => {
+            let elem = at.get_element_type();
+            for _ in 0..at.len() {
+                flatten_leaves(elem, out);
+            }
+        }
+        _ => out.push(t),
+    }
+}
+
+fn is_integer_only_aggregate<'ctx>(t: BasicTypeEnum<'ctx>) -> bool {
+    match t {
+        BasicTypeEnum::StructType(_) | BasicTypeEnum::ArrayType(_) => {
+            let mut leaves = vec![];
+            flatten_leaves(t, &mut leaves);
+            leaves.iter().all(|lt| matches!(lt, BasicTypeEnum::IntType(_) | BasicTypeEnum::PointerType(_)))
+        }
+        _ => false,
+    }
+}
+
+pub fn abi_c_lower_extern_param_type<'ctx>(
+    context: &'ctx inkwell::context::Context,
+    td: &TargetData,
+    layout_ty: BasicTypeEnum<'ctx>,
+) -> BasicTypeEnum<'ctx> {
+    if is_integer_only_aggregate(layout_ty) {
+        let size = td.get_store_size(&layout_ty) as u64;
+        if size > 0 && size <= 16 {
+            let bits = (size * 8) as u32;
+            return context.custom_width_int_type(bits).as_basic_type_enum();
+        }
+    }
+    layout_ty
+}
+
+pub fn abi_c_lower_extern_ret_type<'ctx>(
+    context: &'ctx inkwell::context::Context,
+    td: &TargetData,
+    layout_ty: BasicTypeEnum<'ctx>,
+) -> BasicTypeEnum<'ctx> {
+    abi_c_lower_extern_param_type(context, td, layout_ty)
 }
 
 #[derive(Clone)]

--- a/llvm_temporary/src/llvm_temporary/statement/assign.rs
+++ b/llvm_temporary/src/llvm_temporary/statement/assign.rs
@@ -5,6 +5,8 @@ use inkwell::types::{AnyTypeEnum, BasicTypeEnum, StructType};
 use inkwell::values::{BasicValue, BasicValueEnum};
 use parser::ast::{Expression, Mutability};
 use std::collections::HashMap;
+use inkwell::targets::TargetData;
+use crate::llvm_temporary::llvm_codegen::abi_c::ExternCInfo;
 
 pub(super) fn gen_assign_ir<'ctx>(
     context: &'ctx inkwell::context::Context,
@@ -16,6 +18,8 @@ pub(super) fn gen_assign_ir<'ctx>(
     global_consts: &HashMap<String, BasicValueEnum<'ctx>>,
     struct_types: &HashMap<String, StructType<'ctx>>,
     struct_field_indices: &HashMap<String, HashMap<String, u32>>,
+    target_data: &'ctx TargetData,
+    extern_c_info: &HashMap<String, ExternCInfo<'ctx>>,
 ) {
     if variable == "deref" {
         if let Expression::BinaryExpression { left, right, .. } = value {
@@ -33,6 +37,8 @@ pub(super) fn gen_assign_ir<'ctx>(
                     global_consts,
                     struct_types,
                     struct_field_indices,
+                    target_data,
+                    extern_c_info,
                 );
 
                 builder.build_store(target_ptr, val).unwrap();
@@ -72,6 +78,8 @@ pub(super) fn gen_assign_ir<'ctx>(
         global_consts,
         struct_types,
         struct_field_indices,
+        target_data,
+        extern_c_info,
     );
 
     let casted_val = match (val, element_type) {

--- a/llvm_temporary/src/llvm_temporary/statement/control.rs
+++ b/llvm_temporary/src/llvm_temporary/statement/control.rs
@@ -7,6 +7,8 @@ use inkwell::values::{BasicValueEnum, FunctionValue};
 use inkwell::{FloatPredicate, IntPredicate};
 use parser::ast::{ASTNode, Expression};
 use std::collections::HashMap;
+use inkwell::targets::TargetData;
+use crate::llvm_temporary::llvm_codegen::abi_c::ExternCInfo;
 use crate::llvm_temporary::statement::variable::{coerce_basic_value, CoercionMode};
 
 fn truthy_to_i1<'ctx>(
@@ -53,6 +55,8 @@ pub(super) fn gen_if_ir<'ctx>(
     global_consts: &HashMap<String, BasicValueEnum<'ctx>>,
     struct_types: &HashMap<String, StructType<'ctx>>,
     struct_field_indices: &HashMap<String, HashMap<String, u32>>,
+    target_data: &'ctx TargetData,
+    extern_c_info: &HashMap<String, ExternCInfo<'ctx>>,
 ) {
     let current_fn = builder.get_insert_block().unwrap().get_parent().unwrap();
 
@@ -66,6 +70,8 @@ pub(super) fn gen_if_ir<'ctx>(
         global_consts,
         struct_types,
         struct_field_indices,
+        target_data,
+        extern_c_info,
     );
 
     let cond_i1 = truthy_to_i1(context, builder, cond_any, "if_cond");
@@ -93,6 +99,8 @@ pub(super) fn gen_if_ir<'ctx>(
             global_consts,
             struct_types,
             struct_field_indices,
+            target_data,
+            extern_c_info,
         );
     }
 
@@ -118,6 +126,8 @@ pub(super) fn gen_if_ir<'ctx>(
                 global_consts,
                 struct_types,
                 struct_field_indices,
+                target_data,
+                extern_c_info,
             );
             let c_i1 = truthy_to_i1(context, builder, c_any, "elif_cond");
 
@@ -143,6 +153,8 @@ pub(super) fn gen_if_ir<'ctx>(
                     global_consts,
                     struct_types,
                     struct_field_indices,
+                    target_data,
+                    extern_c_info,
                 );
             }
 
@@ -171,6 +183,8 @@ pub(super) fn gen_if_ir<'ctx>(
                     global_consts,
                     struct_types,
                     struct_field_indices,
+                    target_data,
+                    extern_c_info,
                 );
             }
         }
@@ -201,6 +215,8 @@ pub(super) fn gen_if_ir<'ctx>(
                 global_consts,
                 struct_types,
                 struct_field_indices,
+                target_data,
+                extern_c_info,
             );
         }
     }
@@ -227,6 +243,8 @@ pub(super) fn gen_while_ir<'ctx>(
     global_consts: &HashMap<String, BasicValueEnum<'ctx>>,
     struct_types: &HashMap<String, StructType<'ctx>>,
     struct_field_indices: &HashMap<String, HashMap<String, u32>>,
+    target_data: &'ctx TargetData,
+    extern_c_info: &HashMap<String, ExternCInfo<'ctx>>,
 ) {
     let current_fn = builder.get_insert_block().unwrap().get_parent().unwrap();
 
@@ -250,6 +268,8 @@ pub(super) fn gen_while_ir<'ctx>(
         global_consts,
         struct_types,
         struct_field_indices,
+        target_data,
+        extern_c_info,
     );
 
     let cond_bool = truthy_to_i1(context, builder, cond_val, "while_cond");
@@ -272,6 +292,8 @@ pub(super) fn gen_while_ir<'ctx>(
             global_consts,
             struct_types,
             struct_field_indices,
+            target_data,
+            extern_c_info,
         );
     }
 
@@ -318,6 +340,8 @@ pub(super) fn gen_return_ir<'ctx>(
     global_consts: &HashMap<String, BasicValueEnum<'ctx>>,
     struct_types: &HashMap<String, StructType<'ctx>>,
     struct_field_indices: &HashMap<String, HashMap<String, u32>>,
+    target_data: &'ctx TargetData,
+    extern_c_info: &HashMap<String, ExternCInfo<'ctx>>,
 ) {
     let expected_ret = current_function.get_type().get_return_type(); // Option<BasicTypeEnum>
 
@@ -345,6 +369,8 @@ pub(super) fn gen_return_ir<'ctx>(
                 global_consts,
                 struct_types,
                 struct_field_indices,
+                target_data,
+                extern_c_info,
             );
 
             if v.get_type() != ret_ty {

--- a/llvm_temporary/src/llvm_temporary/statement/expr_stmt.rs
+++ b/llvm_temporary/src/llvm_temporary/statement/expr_stmt.rs
@@ -5,6 +5,8 @@ use inkwell::types::StructType;
 use inkwell::values::BasicValueEnum;
 use parser::ast::Expression;
 use std::collections::HashMap;
+use inkwell::targets::TargetData;
+use crate::llvm_temporary::llvm_codegen::abi_c::ExternCInfo;
 
 pub(super) fn gen_expr_stmt_ir<'ctx>(
     context: &'ctx inkwell::context::Context,
@@ -15,6 +17,8 @@ pub(super) fn gen_expr_stmt_ir<'ctx>(
     global_consts: &HashMap<String, BasicValueEnum<'ctx>>,
     struct_types: &HashMap<String, StructType<'ctx>>,
     struct_field_indices: &HashMap<String, HashMap<String, u32>>,
+    target_data: &'ctx TargetData,
+    extern_c_info: &HashMap<String, ExternCInfo<'ctx>>,
 ) {
     let _ = generate_expression_ir(
         context,
@@ -26,5 +30,7 @@ pub(super) fn gen_expr_stmt_ir<'ctx>(
         global_consts,
         struct_types,
         struct_field_indices,
+        target_data,
+        extern_c_info,
     );
 }

--- a/llvm_temporary/src/llvm_temporary/statement/io.rs
+++ b/llvm_temporary/src/llvm_temporary/statement/io.rs
@@ -7,6 +7,8 @@ use inkwell::values::{BasicMetadataValueEnum, BasicValueEnum, BasicValue};
 use inkwell::{AddressSpace, IntPredicate};
 use parser::ast::Expression;
 use std::collections::HashMap;
+use inkwell::targets::TargetData;
+use crate::llvm_temporary::llvm_codegen::abi_c::ExternCInfo;
 
 fn make_global_cstr<'ctx>(
     context: &'ctx inkwell::context::Context,
@@ -86,6 +88,8 @@ pub(super) fn gen_print_format_ir<'ctx>(
     global_consts: &HashMap<String, BasicValueEnum<'ctx>>,
     struct_types: &HashMap<String, StructType<'ctx>>,
     struct_field_indices: &HashMap<String, HashMap<String, u32>>,
+    target_data: &'ctx TargetData,
+    extern_c_info: &HashMap<String, ExternCInfo<'ctx>>,
 ) {
     // NOTE: Avoid evaluating arguments twice to prevent side effects
     let mut arg_vals: Vec<BasicValueEnum<'ctx>> = Vec::with_capacity(args.len());
@@ -102,6 +106,8 @@ pub(super) fn gen_print_format_ir<'ctx>(
             global_consts,
             struct_types,
             struct_field_indices,
+            target_data,
+            extern_c_info,
         );
         arg_types.push(val.get_type());
         arg_vals.push(val);
@@ -191,6 +197,8 @@ pub(super) fn gen_input_ir<'ctx>(
     global_consts: &HashMap<String, BasicValueEnum<'ctx>>,
     struct_types: &HashMap<String, StructType<'ctx>>,
     struct_field_indices: &HashMap<String, HashMap<String, u32>>,
+    target_data: &'ctx TargetData,
+    extern_c_info: &HashMap<String, ExternCInfo<'ctx>>,
 ) {
     let mut ptrs = Vec::with_capacity(args.len());
     let mut arg_types = Vec::with_capacity(args.len());
@@ -205,6 +213,8 @@ pub(super) fn gen_input_ir<'ctx>(
             global_consts,
             struct_types,
             struct_field_indices,
+            target_data,
+            extern_c_info,
         );
         arg_types.push(ptr.get_type().get_element_type());
         ptrs.push(ptr);

--- a/llvm_temporary/src/llvm_temporary/statement/mod.rs
+++ b/llvm_temporary/src/llvm_temporary/statement/mod.rs
@@ -12,6 +12,8 @@ use inkwell::types::StructType;
 use inkwell::values::{BasicValueEnum, FunctionValue};
 use parser::ast::{ASTNode, StatementNode};
 use std::collections::HashMap;
+use inkwell::targets::TargetData;
+use crate::llvm_temporary::llvm_codegen::abi_c::ExternCInfo;
 
 pub fn generate_statement_ir<'ctx>(
     context: &'ctx Context,
@@ -26,6 +28,8 @@ pub fn generate_statement_ir<'ctx>(
     global_consts: &HashMap<String, BasicValueEnum<'ctx>>,
     struct_types: &HashMap<String, StructType<'ctx>>,
     struct_field_indices: &HashMap<String, HashMap<String, u32>>,
+    target_data: &'ctx TargetData,
+    extern_c_info: &HashMap<String, ExternCInfo<'ctx>>,
 ) {
     match stmt {
         ASTNode::Variable(var_node) => {
@@ -38,6 +42,8 @@ pub fn generate_statement_ir<'ctx>(
                 global_consts,
                 struct_types,
                 struct_field_indices,
+                target_data,
+                extern_c_info,
             );
         }
 
@@ -59,6 +65,8 @@ pub fn generate_statement_ir<'ctx>(
                 global_consts,
                 struct_types,
                 struct_field_indices,
+                target_data,
+                extern_c_info,
             );
         }
 
@@ -74,6 +82,8 @@ pub fn generate_statement_ir<'ctx>(
                 global_consts,
                 struct_types,
                 struct_field_indices,
+                target_data,
+                extern_c_info,
             );
         }
 
@@ -99,6 +109,8 @@ pub fn generate_statement_ir<'ctx>(
                 global_consts,
                 struct_types,
                 struct_field_indices,
+                target_data,
+                extern_c_info,
             );
         }
 
@@ -117,6 +129,8 @@ pub fn generate_statement_ir<'ctx>(
                 global_consts,
                 struct_types,
                 struct_field_indices,
+                target_data,
+                extern_c_info,
             );
         }
 
@@ -149,6 +163,8 @@ pub fn generate_statement_ir<'ctx>(
                 global_consts,
                 struct_types,
                 struct_field_indices,
+                target_data,
+                extern_c_info,
             );
         }
 
@@ -163,6 +179,8 @@ pub fn generate_statement_ir<'ctx>(
                 global_consts,
                 struct_types,
                 struct_field_indices,
+                target_data,
+                extern_c_info,
             );
         }
 
@@ -185,6 +203,8 @@ pub fn generate_statement_ir<'ctx>(
                 global_consts,
                 struct_types,
                 struct_field_indices,
+                target_data,
+                extern_c_info,
             );
         }
 

--- a/llvm_temporary/src/llvm_temporary/statement/variable.rs
+++ b/llvm_temporary/src/llvm_temporary/statement/variable.rs
@@ -5,6 +5,8 @@ use inkwell::types::{BasicTypeEnum, StructType};
 use inkwell::values::{BasicValue, BasicValueEnum};
 use parser::ast::{Expression, VariableNode, WaveType};
 use std::collections::HashMap;
+use inkwell::targets::TargetData;
+use crate::llvm_temporary::llvm_codegen::abi_c::ExternCInfo;
 use crate::llvm_temporary::llvm_codegen::types::TypeFlavor;
 
 #[derive(Copy, Clone, Debug)]
@@ -103,6 +105,8 @@ pub(super) fn gen_variable_ir<'ctx>(
     global_consts: &HashMap<String, BasicValueEnum<'ctx>>,
     struct_types: &HashMap<String, StructType<'ctx>>,
     struct_field_indices: &HashMap<String, HashMap<String, u32>>,
+    target_data: &'ctx TargetData,
+    extern_c_info: &HashMap<String, ExternCInfo<'ctx>>,
 ) {
     let VariableNode {
         name,
@@ -139,6 +143,8 @@ pub(super) fn gen_variable_ir<'ctx>(
                     global_consts,
                     struct_types,
                     struct_field_indices,
+                    target_data,
+                    extern_c_info,
                 );
 
                 let gep = builder
@@ -181,6 +187,7 @@ pub(super) fn gen_variable_ir<'ctx>(
                 context, builder, init, variables, module,
                 Some(llvm_type),
                 global_consts, struct_types, struct_field_indices,
+                target_data, extern_c_info,
             );
 
             let casted = coerce_basic_value(


### PR DESCRIPTION
This PR introduces a robust C calling convention (ABI) lowering layer to the Wave compiler's LLVM backend. Until now, calling external C functions was limited to simple types. This update allows Wave to interface with complex C APIs that involve passing or returning structures and arrays by value, strictly adhering to the System V ABI (x86_64) standards.

### Key Changes

#### 1. ABI Lowering Logic (`abi_c.rs`)
Implemented a new lowering engine to classify how Wave types should be translated for the C ABI:
*   **SRet (Structured Return)**: Handles large return types by automatically inserting a hidden first parameter that points to a caller-allocated memory block.
*   **ByVal (By Value)**: Implements the `ByVal` attribute for structures, ensuring they are passed on the stack or in registers with correct alignment as expected by C.
*   **Split & HFA (Homogeneous Floating-point Aggregate)**: Implements logic to decompose small structs into multiple registers (integer or floating-point/SSE), allowing for efficient "register-splitting" of aggregates.
*   **Direct & Bit-Packing**: Small structures are now "packed" into a single integer register (`pack_agg_to_int`) when possible, matching the standard optimization behavior of C compilers.

#### 2. Backend Infrastructure & Metadata
*   **Target-Aware Codegen**: The backend now initializes and propagates LLVM `TargetData` and `TargetMachine`. This ensures the compiler has precise information about the host's size and alignment requirements.
*   **`ExternCInfo`**: Introduced a metadata container to track lowered function signatures, ensuring that the calling site (at the LLVM level) matches the ABI transformations applied to the declaration.
*   **Context Propagation**: Propagated `TargetData` and ABI info through all major generators, including `gen_function_call` and `generate_lvalue_ir`.

#### 3. Refactored Function Calls
*   **Call-site Transformation**: The `gen_function_call` logic has been refactored to check if a target is an `extern(c)` function. If so, it applies the necessary transformations:
    *   Casting arguments to the lowered ABI types.
    *   Unpacking split registers back into a single Wave struct.
    *   Managing SRet pointers for functions that return large aggregates.

#### 4. Maintenance
*   Removed several unused variables and refined internal type inference logic in the parser to accommodate the stricter backend requirements.

### Example Impact
Previously, passing a struct like `struct Vec2 { x: f32, y: f32 }` to a C function might fail if the ABI expected them in a single SSE register. Now, Wave correctly identifies this as an HFA and emits the proper IR to match C's expected register layout.

### Benefits
*   **Full FFI Compatibility**: Wave can now reliably invoke any C library function, including those that use complex `struct` passing (e.g., `stat`, `ioctl`, or high-performance math libraries).
*   **Performance**: Register-based aggregate passing is significantly faster than always falling back to stack-based pointers.
*   **Safety**: Stricter alignment and size tracking prevents buffer overflows and memory corruption during FFI boundaries.
