### PR TITLE
feat: implement static globals, explicit type casting, and pointer arithmetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,49 @@ fun main() {
 
 ---
 
+## Build From Source
+
+```bash
+git clone https://github.com/wavefnd/Wave.git
+cd Wave
+cargo build
+```
+
+Compiler binary path:
+
+- `target/debug/wavec` (development build)
+- `target/release/wavec` (release build)
+
+---
+
+## Target Support
+
+- Linux `x86_64`
+- macOS (Darwin) `arm64` (Apple Silicon)
+- Windows: not supported yet
+
+---
+
+## CLI Usage
+
+```bash
+wavec run <file>
+wavec build <file>
+wavec build -o <file>
+wavec img <file>
+```
+
+Useful global options:
+
+- `-O0..-O3`, `-Os`, `-Oz`, `-Ofast`
+- `--debug-wave=tokens,ast,ir,mc,hex,all`
+- `--link=<lib>`
+- `-L <path>`
+- `--dep-root=<path>`
+- `--dep=<name>=<path>`
+
+---
+
 <p align="center">
 <a href="https://star-history.com/#wavefnd/Wave&Date">
 <img src="https://api.star-history.com/svg?repos=wavefnd/Wave&type=Date" alt="Star History Chart" width="80%">

--- a/front/lexer/src/ident.rs
+++ b/front/lexer/src/ident.rs
@@ -14,7 +14,11 @@ use crate::{Lexer, Token};
 
 impl<'a> Lexer<'a> {
     pub(crate) fn identifier(&mut self) -> String {
-        let start = if self.current > 0 { self.current - 1 } else { 0 };
+        let start = if self.current > 0 {
+            self.current - 1
+        } else {
+            0
+        };
 
         while !self.is_at_end() {
             let c = self.peek();
@@ -48,6 +52,11 @@ impl<'a> Lexer<'a> {
             "enum" => Token {
                 token_type: TokenType::Enum,
                 lexeme: "enum".to_string(),
+                line: self.line,
+            },
+            "static" => Token {
+                token_type: TokenType::Static,
+                lexeme: "static".to_string(),
                 line: self.line,
             },
             "var" => Token {
@@ -133,6 +142,11 @@ impl<'a> Lexer<'a> {
             "is" => Token {
                 token_type: TokenType::Is,
                 lexeme: "is".to_string(),
+                line: self.line,
+            },
+            "as" => Token {
+                token_type: TokenType::As,
+                lexeme: "as".to_string(),
                 line: self.line,
             },
             "asm" => Token {

--- a/front/lexer/src/token.rs
+++ b/front/lexer/src/token.rs
@@ -83,6 +83,7 @@ pub enum TokenType {
     Extern,
     Type,
     Enum,
+    Static,
     Var,
     Let,
     Mut,
@@ -118,6 +119,7 @@ pub enum TokenType {
     In,           // in
     Out,          // out
     Is,           // is
+    As,           // as
     Asm,
     Rol,
     Ror,

--- a/front/parser/src/ast.rs
+++ b/front/parser/src/ast.rs
@@ -178,6 +178,10 @@ pub enum Expression {
         operator: Operator,
         expr: Box<Expression>,
     },
+    Cast {
+        expr: Box<Expression>,
+        target_type: WaveType,
+    },
     IncDec {
         kind: IncDecKind,
         target: Box<Expression>,
@@ -300,6 +304,7 @@ pub enum StatementNode {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Mutability {
+    Static,
     Var,
     Let,
     LetMut,
@@ -354,17 +359,16 @@ impl Expression {
             Expression::Unary { operator, expr } => {
                 let t = expr.get_wave_type(variables);
                 match operator {
-                    Operator::Neg => {
-                        match &t {
-                            WaveType::Int(_) | WaveType::Uint(_) | WaveType::Float(_) => t,
-                            _ => panic!("unary '-' not allowed for type {:?}", t),
-                        }
-                    }
+                    Operator::Neg => match &t {
+                        WaveType::Int(_) | WaveType::Uint(_) | WaveType::Float(_) => t,
+                        _ => panic!("unary '-' not allowed for type {:?}", t),
+                    },
                     Operator::Not | Operator::LogicalNot => WaveType::Bool,
                     Operator::BitwiseNot => t,
                     _ => panic!("unary op type inference not supported: {:?}", operator),
                 }
             }
+            Expression::Cast { target_type, .. } => target_type.clone(),
             _ => panic!("get_wave_type not implemented for {:?}", self),
         }
     }

--- a/front/parser/src/import.rs
+++ b/front/parser/src/import.rs
@@ -10,7 +10,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use crate::ast::{ASTNode};
-use crate::{parse, ParseError};
+use crate::{parse_syntax_only, ParseError};
 use error::error::{WaveError, WaveErrorKind};
 use lexer::Lexer;
 use std::collections::{HashMap, HashSet};
@@ -347,7 +347,7 @@ fn parse_wave_file(
     let mut lexer = Lexer::new_with_file(&content, abs_path.display().to_string());
     let tokens = lexer.tokenize()?;
 
-    let ast = parse(&tokens).map_err(|e| {
+    let ast = parse_syntax_only(&tokens).map_err(|e| {
         let (kind, phase, code) = match &e {
             ParseError::Syntax(_) => (WaveErrorKind::SyntaxError(e.message().to_string()), "syntax", "E2001"),
             ParseError::Semantic(_) => (WaveErrorKind::InvalidStatement(e.message().to_string()), "semantic", "E3001"),

--- a/front/parser/src/parser/control.rs
+++ b/front/parser/src/parser/control.rs
@@ -230,8 +230,12 @@ fn parse_for_initializer(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> 
             parse_typed_for_initializer(tokens, mutability)
         }
         Some(TokenType::Const) => {
-            tokens.next(); // consume `const`
-            parse_typed_for_initializer(tokens, Mutability::Const)
+            println!("Error: `const` is not allowed in local for-loop initializer");
+            None
+        }
+        Some(TokenType::Static) => {
+            println!("Error: `static` is not allowed in local for-loop initializer");
+            None
         }
         _ if is_typed_for_initializer(tokens) => parse_typed_for_initializer(tokens, Mutability::Var),
         _ => {

--- a/front/parser/src/parser/functions.rs
+++ b/front/parser/src/parser/functions.rs
@@ -203,6 +203,14 @@ pub fn extract_body(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> 
                 tokens.next(); // consume 'let'
                 body.push(parse_let(tokens)?);
             }
+            TokenType::Const => {
+                println!("Error: `const` is only allowed at top level");
+                return None;
+            }
+            TokenType::Static => {
+                println!("Error: `static` is only allowed at top level");
+                return None;
+            }
             TokenType::Println => {
                 tokens.next(); // consume 'println'
                 let node = parse_println(tokens)?;

--- a/front/parser/src/parser/mod.rs
+++ b/front/parser/src/parser/mod.rs
@@ -20,4 +20,4 @@ pub mod items;
 pub mod stmt;
 pub mod types;
 
-pub use parse::{parse, ParseError};
+pub use parse::{parse, parse_syntax_only, ParseError};

--- a/front/parser/src/parser/stmt.rs
+++ b/front/parser/src/parser/stmt.rs
@@ -16,7 +16,7 @@ use lexer::token::TokenType;
 use crate::ast::{ASTNode, AssignOperator, Expression, Operator, StatementNode};
 use crate::expr::{is_assignable, parse_expression, parse_expression_from_token};
 use crate::parser::control::{parse_for, parse_if, parse_match, parse_while};
-use crate::parser::decl::{parse_const, parse_let, parse_var};
+use crate::parser::decl::{parse_let, parse_var};
 use crate::parser::io::*;
 use crate::parser::types::is_expression_start;
 
@@ -174,8 +174,12 @@ pub fn parse_statement(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
             parse_let(tokens)
         }
         TokenType::Const => {
-            tokens.next();
-            parse_const(tokens)
+            println!("Error: `const` is only allowed at top level");
+            None
+        }
+        TokenType::Static => {
+            println!("Error: `static` is only allowed at top level");
+            None
         }
         TokenType::Println => {
             tokens.next();

--- a/front/parser/src/parser/types.rs
+++ b/front/parser/src/parser/types.rs
@@ -9,12 +9,11 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::iter::Peekable;
-use std::slice::Iter;
-use lexer::Token;
-use lexer::token::*;
 use crate::ast::WaveType;
 use crate::decl::collect_generic_inner;
+use lexer::token::*;
+use lexer::Token;
+use std::iter::Peekable;
 
 pub fn token_type_to_wave_type(token_type: &TokenType) -> Option<WaveType> {
     match token_type {
@@ -223,21 +222,31 @@ pub fn parse_type_from_token(token_opt: Option<&&Token>) -> Option<WaveType> {
     }
 }
 
-pub fn parse_type_from_stream(tokens: &mut Peekable<Iter<Token>>) -> Option<WaveType> {
-    while matches!(tokens.peek().map(|t| &t.token_type), Some(TokenType::Whitespace)) {
+pub fn parse_type_from_stream<'a, T>(tokens: &mut Peekable<T>) -> Option<WaveType>
+where
+    T: Iterator<Item = &'a Token>,
+{
+    while matches!(
+        tokens.peek().map(|t| &t.token_type),
+        Some(TokenType::Whitespace)
+    ) {
         tokens.next();
     }
 
     let type_token = tokens.next()?;
 
     if let TokenType::Identifier(name) = &type_token.token_type {
-        while matches!(tokens.peek().map(|t| &t.token_type),
+        while matches!(
+            tokens.peek().map(|t| &t.token_type),
             Some(TokenType::Whitespace | TokenType::Newline)
         ) {
             tokens.next();
         }
 
-        if matches!(tokens.peek().map(|t| &t.token_type), Some(TokenType::Lchevr)) {
+        if matches!(
+            tokens.peek().map(|t| &t.token_type),
+            Some(TokenType::Lchevr)
+        ) {
             tokens.next(); // consume '<'
 
             let inner = collect_generic_inner(tokens)?;

--- a/llvm/src/codegen/mod.rs
+++ b/llvm/src/codegen/mod.rs
@@ -9,14 +9,15 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-pub mod ir;
+pub mod abi_c;
+pub mod address;
 pub mod consts;
 pub mod format;
-pub mod types;
-pub mod address;
+pub mod ir;
 pub mod legacy;
 pub mod plan;
-pub mod abi_c;
+pub mod target;
+pub mod types;
 
 pub use address::{generate_address_and_type_ir, generate_address_ir};
 pub use format::{wave_format_to_c, wave_format_to_scanf};

--- a/llvm/src/codegen/target.rs
+++ b/llvm/src/codegen/target.rs
@@ -1,0 +1,81 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024–2026 Wave Foundation
+// Copyright (c) 2024–2026 LunaStev and contributors
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+use inkwell::module::Module;
+use inkwell::targets::TargetTriple;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodegenTarget {
+    LinuxX86_64,
+    DarwinArm64,
+}
+
+impl CodegenTarget {
+    pub fn from_triple_str(triple: &str) -> Option<Self> {
+        let t = triple.to_ascii_lowercase();
+
+        let is_x86_64 = t.starts_with("x86_64");
+        let is_arm64 = t.starts_with("arm64") || t.starts_with("aarch64");
+        let is_linux = t.contains("linux");
+        let is_darwin = t.contains("darwin");
+
+        if is_x86_64 && is_linux {
+            return Some(Self::LinuxX86_64);
+        }
+        if is_arm64 && is_darwin {
+            return Some(Self::DarwinArm64);
+        }
+
+        None
+    }
+
+    pub fn from_target_triple(triple: &TargetTriple) -> Option<Self> {
+        let raw = triple.as_str().to_string_lossy();
+        Self::from_triple_str(raw.as_ref())
+    }
+
+    pub fn from_module(module: &Module<'_>) -> Option<Self> {
+        let triple = module.get_triple();
+        Self::from_target_triple(&triple)
+    }
+
+    pub fn desc(self) -> &'static str {
+        match self {
+            Self::LinuxX86_64 => "linux x86_64",
+            Self::DarwinArm64 => "darwin arm64",
+        }
+    }
+}
+
+pub fn require_supported_target_from_triple(triple: &TargetTriple) -> CodegenTarget {
+    if let Some(t) = CodegenTarget::from_target_triple(triple) {
+        return t;
+    }
+
+    let raw = triple.as_str().to_string_lossy();
+    panic!(
+        "unsupported target triple '{}': Wave currently supports only linux x86_64 and darwin arm64 (Windows not supported yet)",
+        raw
+    );
+}
+
+pub fn require_supported_target_from_module(module: &Module<'_>) -> CodegenTarget {
+    if let Some(t) = CodegenTarget::from_module(module) {
+        return t;
+    }
+
+    let triple = module.get_triple();
+    let raw = triple.as_str().to_string_lossy();
+    panic!(
+        "unsupported target triple '{}': Wave currently supports only linux x86_64 and darwin arm64 (Windows not supported yet)",
+        raw
+    );
+}

--- a/llvm/src/expression/rvalue/cast.rs
+++ b/llvm/src/expression/rvalue/cast.rs
@@ -1,0 +1,49 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024–2026 Wave Foundation
+// Copyright (c) 2024–2026 LunaStev and contributors
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+use super::ExprGenEnv;
+use crate::codegen::types::{wave_type_to_llvm_type, TypeFlavor};
+use crate::statement::variable::{coerce_basic_value, CoercionMode};
+use inkwell::types::{BasicType, BasicTypeEnum};
+use inkwell::values::BasicValueEnum;
+use parser::ast::{Expression, Literal, WaveType};
+
+pub(crate) fn gen<'ctx, 'a>(
+    env: &mut ExprGenEnv<'ctx, 'a>,
+    expr: &Expression,
+    target_type: &WaveType,
+) -> BasicValueEnum<'ctx> {
+    let dst_ty = wave_type_to_llvm_type(
+        env.context,
+        target_type,
+        env.struct_types,
+        TypeFlavor::Value,
+    );
+
+    // Integer literals default to i32 with no context.
+    // For explicit cast to pointer, prefer i64 source width.
+    let src_hint = match (expr, dst_ty) {
+        (Expression::Literal(Literal::Int(_)), BasicTypeEnum::PointerType(_)) => {
+            Some(env.context.i64_type().as_basic_type_enum())
+        }
+        _ => None,
+    };
+
+    let src = env.gen(expr, src_hint);
+    coerce_basic_value(
+        env.context,
+        env.builder,
+        src,
+        dst_ty,
+        "as_cast",
+        CoercionMode::Explicit,
+    )
+}

--- a/llvm/src/expression/rvalue/dispatch.rs
+++ b/llvm/src/expression/rvalue/dispatch.rs
@@ -27,31 +27,47 @@ pub(crate) fn gen_expr<'ctx, 'a>(
         Expression::Deref(inner) => pointers::gen_deref(env, inner, expected_type),
         Expression::AddressOf(inner) => pointers::gen_addressof(env, inner, expected_type),
 
-        Expression::MethodCall { object, name, args } => calls::gen_method_call(env, object, name, args),
-        Expression::FunctionCall { name, args } => calls::gen_function_call(env, name, args, expected_type),
-
-        Expression::AssignOperation { target, operator, value } => {
-            assign::gen_assign_operation(env, target, operator, value)
+        Expression::MethodCall { object, name, args } => {
+            calls::gen_method_call(env, object, name, args)
         }
+        Expression::FunctionCall { name, args } => {
+            calls::gen_function_call(env, name, args, expected_type)
+        }
+        Expression::Cast { expr, target_type } => cast::gen(env, expr, target_type),
+
+        Expression::AssignOperation {
+            target,
+            operator,
+            value,
+        } => assign::gen_assign_operation(env, target, operator, value),
         Expression::Assignment { target, value } => assign::gen_assignment(env, target, value),
 
-        Expression::BinaryExpression { left, operator, right } => {
-            binary::gen(env, left, operator, right, expected_type)
-        }
+        Expression::BinaryExpression {
+            left,
+            operator,
+            right,
+        } => binary::gen(env, left, operator, right, expected_type),
 
         Expression::IndexAccess { target, index } => index::gen(env, target, index),
 
-        Expression::AsmBlock { instructions, inputs, outputs, clobbers } => {
-            asm::gen(env, instructions, inputs, outputs, clobbers)
-        }
+        Expression::AsmBlock {
+            instructions,
+            inputs,
+            outputs,
+            clobbers,
+        } => asm::gen(env, instructions, inputs, outputs, clobbers),
 
-        Expression::StructLiteral { name, fields } => structs::gen_struct_literal(env, name, fields),
+        Expression::StructLiteral { name, fields } => {
+            structs::gen_struct_literal(env, name, fields)
+        }
         Expression::FieldAccess { object, field } => structs::gen_field_access(env, object, field),
 
         Expression::Unary { operator, expr } => unary::gen(env, operator, expr, expected_type),
         Expression::IncDec { kind, target } => incdec::gen(env, kind, target),
 
         Expression::Grouped(inner) => env.gen(inner, expected_type),
-        Expression::ArrayLiteral(elements) => arrays::gen_array_literal(env, elements, expected_type),
+        Expression::ArrayLiteral(elements) => {
+            arrays::gen_array_literal(env, elements, expected_type)
+        }
     }
 }

--- a/llvm/src/expression/rvalue/mod.rs
+++ b/llvm/src/expression/rvalue/mod.rs
@@ -9,32 +9,33 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::codegen::VariableInfo;
 use crate::codegen::abi_c::ExternCInfo;
+use crate::codegen::VariableInfo;
 use inkwell::builder::Builder;
 use inkwell::context::Context;
 use inkwell::module::Module;
+use inkwell::targets::TargetData;
 use inkwell::types::{BasicTypeEnum, StructType};
-use inkwell::values::{BasicValueEnum};
+use inkwell::values::BasicValueEnum;
 use parser::ast::Expression;
 use std::collections::HashMap;
-use inkwell::targets::TargetData;
 
 pub mod dispatch;
 pub mod utils;
 
-pub mod literals;
-pub mod variables;
-pub mod pointers;
-pub mod calls;
+pub mod arrays;
+pub mod asm;
 pub mod assign;
 pub mod binary;
+pub mod calls;
+pub mod cast;
+pub mod incdec;
 pub mod index;
-pub mod asm;
+pub mod literals;
+pub mod pointers;
 pub mod structs;
 pub mod unary;
-pub mod incdec;
-pub mod arrays;
+pub mod variables;
 
 pub struct ProtoInfo<'ctx> {
     pub vtable_ty: StructType<'ctx>,

--- a/llvm/src/statement/assign.rs
+++ b/llvm/src/statement/assign.rs
@@ -97,7 +97,7 @@ pub(super) fn gen_assign_ir<'ctx>(
         (info.ptr, info.mutability.clone(), info.ty.clone())
     };
 
-    if matches!(dst_mutability, Mutability::Let) {
+    if matches!(dst_mutability, Mutability::Let | Mutability::Const) {
         panic!("Cannot assign to immutable variable '{}'", variable);
     }
 

--- a/std/buffer/alloc.wave
+++ b/std/buffer/alloc.wave
@@ -20,6 +20,13 @@ fun buffer_new(capacity: i64) -> Buffer {
     }
 
     var data: ptr<u8> = mem_alloc(cap);
+    if (data == null) {
+        return Buffer {
+            data: null,
+            len: 0,
+            cap: 0
+        };
+    }
 
     return Buffer {
         data: data,
@@ -64,6 +71,9 @@ fun buffer_reserve(buf: ptr<Buffer>, required_cap: i64) -> i64 {
     }
 
     var new_data: ptr<u8> = mem_alloc(new_cap);
+    if (new_data == null) {
+        return -1;
+    }
 
     if (deref buf.len > 0) {
         mem_copy(new_data, deref buf.data, deref buf.len);

--- a/std/mem/alloc.wave
+++ b/std/mem/alloc.wave
@@ -10,6 +10,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
 fun mem_alloc(size: i64) -> ptr<u8> {
+    if (size <= 0) {
+        return null;
+    }
+
     var prot: i64 = 1 | 2;
     var flags: i64 = 2 | 32;
     var ret: ptr<u8>;
@@ -26,11 +30,20 @@ fun mem_alloc(size: i64) -> ptr<u8> {
         out("rax") ret
     }
 
+    // Linux syscall returns negative errno on failure.
+    if ((ret as i64) < 0) {
+        return null;
+    }
+
     return ret;
 }
 
 fun mem_alloc_zeroed(size: i64) -> ptr<u8> {
     var p: ptr<u8> = mem_alloc(size);
+    if (p == null) {
+        return null;
+    }
+
     var i: i64 = 0;
     while (i < size) {
         deref p[i] = 0;
@@ -40,6 +53,10 @@ fun mem_alloc_zeroed(size: i64) -> ptr<u8> {
 }
 
 fun mem_free(p: ptr<u8>, size: i64) -> i64 {
+    if (p == null || size <= 0) {
+        return 0;
+    }
+
     var ret: i64;
 
     asm {

--- a/std/net/tcp.wave
+++ b/std/net/tcp.wave
@@ -105,7 +105,7 @@ fun tcp_bind(port: i16) -> TcpListener {
 }
 
 fun tcp_accept(listener: TcpListener) -> TcpStream {
-    let fd: i64 = accept(listener.fd, 0, 0);
+    let fd: i64 = accept(listener.fd, null, null);
     return TcpStream { fd: fd };
 }
 

--- a/std/sys/linux/fs.wave
+++ b/std/sys/linux/fs.wave
@@ -29,7 +29,7 @@ import("std::sys::linux::syscall");
 
 fun open(path: str, flags: i32, mode: i32) -> i64 {
     // syscall: open (2)
-    return syscall3(2, path, flags, mode);
+    return syscall3(2, path as i64, flags as i64, mode as i64);
 }
 
 fun close(fd: i64) -> i64 {
@@ -44,12 +44,12 @@ fun close(fd: i64) -> i64 {
 
 fun read(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
     // syscall: read (0)
-    return syscall3(0, fd, buf, len);
+    return syscall3(0, fd, buf as i64, len);
 }
 
 fun write(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
     // syscall: write (1)
-    return syscall3(1, fd, buf, len);
+    return syscall3(1, fd, buf as i64, len);
 }
 
 
@@ -59,7 +59,7 @@ fun write(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
 
 fun lseek(fd: i64, offset: i64, whence: i32) -> i64 {
     // syscall: lseek (8)
-    return syscall3(8, fd, offset, whence);
+    return syscall3(8, fd, offset, whence as i64);
 }
 
 
@@ -69,17 +69,17 @@ fun lseek(fd: i64, offset: i64, whence: i32) -> i64 {
 
 fun unlink(path: str) -> i64 {
     // syscall: unlink (87)
-    return syscall1(87, path);
+    return syscall1(87, path as i64);
 }
 
 fun mkdir(path: str, mode: i32) -> i64 {
     // syscall: mkdir (83)
-    return syscall2(83, path, mode);
+    return syscall2(83, path as i64, mode as i64);
 }
 
 fun rmdir(path: str) -> i64 {
     // syscall: rmdir (84)
-    return syscall1(84, path);
+    return syscall1(84, path as i64);
 }
 
 
@@ -106,10 +106,10 @@ struct Stat {
 
 fun stat(path: str, st: ptr<Stat>) -> i64 {
     // syscall: stat (4)
-    return syscall2(4, path, st);
+    return syscall2(4, path as i64, st as i64);
 }
 
 fun fstat(fd: i64, st: ptr<Stat>) -> i64 {
     // syscall: fstat (5)
-    return syscall2(5, fd, st);
+    return syscall2(5, fd, st as i64);
 }

--- a/std/sys/linux/memory.wave
+++ b/std/sys/linux/memory.wave
@@ -34,12 +34,20 @@ fun mmap(
     offset: i64
 ) -> ptr<i8> {
     // syscall: mmap (9)
-    return syscall6(9, addr, length, prot, flags, fd, offset);
+    return syscall6(
+        9,
+        addr as i64,
+        length,
+        prot as i64,
+        flags as i64,
+        fd,
+        offset
+    ) as ptr<i8>;
 }
 
 fun munmap(addr: ptr<i8>, length: i64) -> i64 {
     // syscall: munmap (11)
-    return syscall2(11, addr, length);
+    return syscall2(11, addr as i64, length);
 }
 
 
@@ -49,5 +57,5 @@ fun munmap(addr: ptr<i8>, length: i64) -> i64 {
 
 fun brk(addr: ptr<i8>) -> ptr<i8> {
     // syscall: brk (12)
-    return syscall1(12, addr);
+    return syscall1(12, addr as i64) as ptr<i8>;
 }

--- a/std/sys/linux/process.wave
+++ b/std/sys/linux/process.wave
@@ -27,7 +27,7 @@ import("std::sys::linux::syscall");
 
 fun exit(code: i32) -> ! {
     // syscall: exit (60)
-    syscall1(60, code);
+    syscall1(60, code as i64);
     while (true) { }
 }
 
@@ -57,7 +57,7 @@ fun execve(
     envp: ptr<ptr<i8>>
 ) -> i64 {
     // syscall: execve (59)
-    return syscall3(59, path, argv, envp);
+    return syscall3(59, path as i64, argv as i64, envp as i64);
 }
 
 
@@ -68,7 +68,7 @@ fun execve(
 fun waitpid(pid: i64, status: ptr<i32>, options: i32) -> i64 {
     // syscall: wait4 (61)
     // waitpid is implemented via wait4
-    return syscall4(61, pid, status, options, 0);
+    return syscall4(61, pid, status as i64, options as i64, 0);
 }
 
 
@@ -78,5 +78,5 @@ fun waitpid(pid: i64, status: ptr<i32>, options: i32) -> i64 {
 
 fun kill(pid: i64, sig: i32) -> i64 {
     // syscall: kill (62)
-    return syscall2(62, pid, sig);
+    return syscall2(62, pid, sig as i64);
 }

--- a/std/sys/linux/socket.wave
+++ b/std/sys/linux/socket.wave
@@ -54,32 +54,32 @@ const SO_REUSEADDR: i32 = 2;
 
 fun socket(domain: i32, ty: i32, protocol: i32) -> i64 {
     // syscall: socket (41)
-    return syscall3(41, domain, ty, protocol);
+    return syscall3(41, domain as i64, ty as i64, protocol as i64);
 }
 
 fun bind(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
     // syscall: bind (49)
-    return syscall3(49, fd, addr, len);
+    return syscall3(49, fd, addr as i64, len as i64);
 }
 
 fun listen(fd: i64, backlog: i32) -> i64 {
     // syscall: listen (50)
-    return syscall2(50, fd, backlog);
+    return syscall2(50, fd, backlog as i64);
 }
 
 fun accept(fd: i64, addr: ptr<i8>, len: ptr<i32>) -> i64 {
     // syscall: accept (43)
-    return syscall3(43, fd, addr, len);
+    return syscall3(43, fd, addr as i64, len as i64);
 }
 
 fun connect(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
     // syscall: connect (42)
-    return syscall3(42, fd, addr, len);
+    return syscall3(42, fd, addr as i64, len as i64);
 }
 
 fun shutdown(fd: i64, how: i32) -> i64 {
     // syscall: shutdown (48)
-    return syscall2(48, fd, how);
+    return syscall2(48, fd, how as i64);
 }
 
 fun setsockopt(
@@ -90,7 +90,14 @@ fun setsockopt(
     optlen: i32
 ) -> i64 {
     // syscall: setsockopt (54)
-    return syscall5(54, fd, level, optname, optval, optlen);
+    return syscall5(
+        54,
+        fd,
+        level as i64,
+        optname as i64,
+        optval as i64,
+        optlen as i64
+    );
 }
 
 
@@ -99,11 +106,11 @@ fun setsockopt(
 // -----------------------
 
 fun send(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
-    return sendto(fd, buf, len, flags, 0, 0);
+    return sendto(fd, buf, len, flags, null, 0);
 }
 
 fun recv(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
-    return recvfrom(fd, buf, len, flags, 0, 0);
+    return recvfrom(fd, buf, len, flags, null, null);
 }
 
 fun sendto(
@@ -115,7 +122,15 @@ fun sendto(
     addrlen: i32
 ) -> i64 {
     // syscall: sendto (44)
-    return syscall6(44, fd, buf, len, flags, addr, addrlen);
+    return syscall6(
+        44,
+        fd,
+        buf as i64,
+        len,
+        flags as i64,
+        addr as i64,
+        addrlen as i64
+    );
 }
 
 fun recvfrom(
@@ -127,5 +142,13 @@ fun recvfrom(
     addrlen: ptr<i32>
 ) -> i64 {
     // syscall: recvfrom (45)
-    return syscall6(45, fd, buf, len, flags, addr, addrlen);
+    return syscall6(
+        45,
+        fd,
+        buf as i64,
+        len,
+        flags as i64,
+        addr as i64,
+        addrlen as i64
+    );
 }

--- a/std/sys/linux/time.wave
+++ b/std/sys/linux/time.wave
@@ -37,7 +37,7 @@ struct TimeSpec {
 
 fun nanosleep(req: ptr<TimeSpec>, rem: ptr<TimeSpec>) -> i64 {
     // syscall: nanosleep (35)
-    return syscall2(35, req, rem);
+    return syscall2(35, req as i64, rem as i64);
 }
 
 
@@ -47,5 +47,5 @@ fun nanosleep(req: ptr<TimeSpec>, rem: ptr<TimeSpec>) -> i64 {
 
 fun clock_gettime(clock_id: i32, tp: ptr<TimeSpec>) -> i64 {
     // syscall: clock_gettime (228)
-    return syscall2(228, clock_id, tp);
+    return syscall2(228, clock_id as i64, tp as i64);
 }

--- a/test/test87.wave
+++ b/test/test87.wave
@@ -1,0 +1,21 @@
+fun main() -> i32 {
+    var addr: i64 = 0xb8000;
+    var vga: ptr<char> = addr as ptr<char>;
+    var back: i64 = vga as i64;
+
+    if (back != addr) {
+        return 1;
+    }
+
+    var narrowed: i8 = 300 as i8;
+    if (narrowed != 44) {
+        return 2;
+    }
+
+    var p0: ptr<u8> = 0 as ptr<u8>;
+    if ((p0 as i64) != 0) {
+        return 3;
+    }
+
+    return 0;
+}

--- a/test/test88.wave
+++ b/test/test88.wave
@@ -1,0 +1,21 @@
+static COUNTER: i32 = 1;
+static VGA_BUFFER: ptr<char> = 0xb8000 as ptr<char>;
+const BASE: i32 = 41;
+
+fun main() -> i32 {
+    COUNTER = COUNTER + 1;
+    if (COUNTER != 2) {
+        return 1;
+    }
+
+    var addr: i64 = VGA_BUFFER as i64;
+    if (addr != 0xb8000) {
+        return 2;
+    }
+
+    if (BASE != 41) {
+        return 3;
+    }
+
+    return 0;
+}

--- a/test/test89.wave
+++ b/test/test89.wave
@@ -1,0 +1,25 @@
+fun main() -> i32 {
+    var base: ptr<i32> = 0x1000 as ptr<i32>;
+
+    var p_add: ptr<i32> = base + 3;
+    if ((p_add as i64) != (0x1000 + 12)) {
+        return 1;
+    }
+
+    var p_add_rev: ptr<i32> = 2 + base;
+    if ((p_add_rev as i64) != (0x1000 + 8)) {
+        return 2;
+    }
+
+    var p_sub: ptr<i32> = base - 1;
+    if ((p_sub as i64) != (0x1000 - 4)) {
+        return 3;
+    }
+
+    var diff: i64 = p_add - base;
+    if (diff != 12) {
+        return 4;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR introduces a significant set of core language features and architectural improvements that bridge the gap between high-level safety and low-level systems programming. Key updates include the addition of `static` globals, the `as` casting operator, robust pointer arithmetic, and a "panic-guarded" diagnostic system that maps backend failures back to the Wave source code.

---

### Key Changes

#### 1. Core Language Features
*   **Static Globals**: Introduced the `static` keyword for global variables. These persist for the lifetime of the program and are correctly initialized in the data segment.
*   **Explicit Type Casting (`as`)**: Implemented the `as` operator (e.g., `value as i64`) for explicit type conversions. The backend handles these via LLVM `trunc`, `zext`/`sext`, `fpext`/`fptrunc`, and `bitcast` instructions.
*   **Pointer Arithmetic**: Wave now supports industry-standard pointer operations:
    *   `ptr + int` / `ptr - int`: For navigating memory buffers.
    *   `ptr - ptr`: To calculate the distance (offset) between two memory addresses.
*   **Match Statement Finalization**: Finalized the `match` expression syntax and added a verification pass to prevent duplicate patterns in match arms.

#### 2. Compiler Infrastructure & Diagnostics
*   **Panic-Guarded Diagnostics**: Introduced a robust runner that captures backend panics. Using "source-span inference," the compiler can now map low-level LLVM errors or backend crashes back to the specific line and column in the original Wave source code.
*   **Structured `ParseError`**: Refactored the frontend to return detailed error objects. These include "expected vs. found" token information, multi-line context, and actionable "help" hints.
*   **Cross-Platform ABI Support**: Overhauled the `abi_c.rs` module to support target-specific calling conventions for both **Linux x86_64 (System V)** and **macOS arm64 (Darwin)**. This includes correct handling of aggregate splitting and SRet (Structured Return) rules for M1/M2/M3 chips.

#### 3. Standard Library & Safety
*   **Linux Syscall Layer**: Updated the `std/sys/linux` modules (FS, Memory, Socket, Process) to utilize explicit `as i64` casts, complying with the compiler's stricter type-checking rules for system registers.
*   **Allocation Safety**: Improved memory management primitives with mandatory `null` checks and better syscall error propagation.

#### 4. Documentation & Tooling
*   **Documentation**: Expanded the `README.md` with comprehensive build instructions, an updated target support matrix, and a detailed guide for the new CLI subcommands.

---

### Example Usage

```rust
static COUNTER: i32 = 1;
static VGA_BUFFER: ptr<char> = 0xb8000 as ptr<char>;
const BASE: i32 = 41;

fun main() -> i32 {
    COUNTER = COUNTER + 1;
    if (COUNTER != 2) {
        return 1;
    }

    var addr: i64 = VGA_BUFFER as i64;
    if (addr != 0xb8000) {
        return 2;
    }

    if (BASE != 41) {
        return 3;
    }

    return 0;
}
```

---

### Benefits
*   **Portability**: The addition of macOS arm64 support allows Wave to target modern Apple Silicon hardware with ABI-compliant C FFI.
*   **Safety**: Stricter type checks and explicit casting prevent subtle bugs related to implicit integer promotion or narrowing.
*   **Developer Experience**: The panic-guarded diagnostic system ensures that even if the compiler's backend fails, the developer receives helpful feedback in the context of their code.
