### PR TITLE
feat: implement AI training ban and major CLI/Build pipeline overhaul

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 #
 # SPDX-License-Identifier: MPL-2.0
+# AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 FROM ubuntu:22.04
 

--- a/ai.txt
+++ b/ai.txt
@@ -1,0 +1,127 @@
+# Wave AI Usage Policy (Global)
+# Updated: 2026-03-27
+
+User-agent: *
+Disallow: /
+
+Policy: STRICT_NO_AI_TRAINING
+Scope: all files in this repository, including source code, docs, tests, build outputs, metadata, and revision history.
+
+# Human reading is allowed.
+# Any AI or ML usage requires explicit prior written permission from the copyright holders.
+
+# Prohibited uses (non-exhaustive)
+Disallow-Action: crawl-for-training
+Disallow-Action: scrape-for-training
+Disallow-Action: dataset-construction
+Disallow-Action: pretraining
+Disallow-Action: finetuning
+Disallow-Action: distillation
+Disallow-Action: model-evaluation-for-improvement
+Disallow-Action: embedding-generation
+Disallow-Action: vector-indexing-for-model-development
+Disallow-Action: synthetic-data-generation-from-repo-content
+Disallow-Action: style-or-pattern-imitation-learning
+Disallow-Action: summarization-for-corpus-building
+Disallow-Action: translation-for-corpus-building
+Disallow-Action: redistribution-for-ai-use
+
+No-Third-Party-Relay: true
+No-Derivative-Dataset: true
+No-Commercial-AI-Use: true
+No-Research-AI-Use-Without-Permission: true
+
+Contact: legal@wave-lang.dev
+
+# Multilingual notices (major regions and high-usage AI corpus languages)
+# Format: Lang=<bcp47>; Notice=<text>
+
+Lang: en
+Notice: This repository must not be used to train, finetune, distill, evaluate, or improve any AI or ML model without prior written permission.
+
+Lang: ko
+Notice: 이 저장소는 사전 서면 허가 없이 AI/ML 모델의 학습, 미세조정, 증류, 평가, 성능 개선에 사용할 수 없습니다.
+
+Lang: ja
+Notice: このリポジトリは、事前の書面許可なく、AI/MLモデルの学習、微調整、蒸留、評価、改善に使用できません。
+
+Lang: zh-CN
+Notice: 未经事先书面许可，本仓库不得用于AI/ML模型的训练、微调、蒸馏、评估或改进。
+
+Lang: zh-TW
+Notice: 未經事先書面許可，本儲存庫不得用於AI/ML模型的訓練、微調、蒸餾、評估或改進。
+
+Lang: es
+Notice: Este repositorio no puede usarse para entrenar, ajustar, destilar, evaluar o mejorar modelos de IA o ML sin permiso previo por escrito.
+
+Lang: es-419
+Notice: Este repositorio no puede usarse para entrenar, ajustar, destilar, evaluar o mejorar modelos de IA o ML sin permiso previo por escrito.
+
+Lang: pt
+Notice: Este repositório não pode ser usado para treinar, ajustar, destilar, avaliar ou melhorar modelos de IA/ML sem permissão prévia por escrito.
+
+Lang: pt-BR
+Notice: Este repositório não pode ser usado para treinar, ajustar, destilar, avaliar ou melhorar modelos de IA/ML sem autorização prévia por escrito.
+
+Lang: fr
+Notice: Ce dépôt ne doit pas être utilisé pour entraîner, affiner, distiller, évaluer ou améliorer des modèles IA/ML sans autorisation écrite préalable.
+
+Lang: de
+Notice: Dieses Repository darf ohne vorherige schriftliche Genehmigung nicht zum Trainieren, Fine-Tuning, Destillieren, Bewerten oder Verbessern von KI/ML-Modellen verwendet werden.
+
+Lang: it
+Notice: Questo repository non può essere usato per addestrare, perfezionare, distillare, valutare o migliorare modelli IA/ML senza autorizzazione scritta preventiva.
+
+Lang: nl
+Notice: Deze repository mag niet worden gebruikt om AI/ML-modellen te trainen, finetunen, distilleren, evalueren of verbeteren zonder voorafgaande schriftelijke toestemming.
+
+Lang: pl
+Notice: Tego repozytorium nie wolno używać do trenowania, dostrajania, destylacji, oceny ani ulepszania modeli AI/ML bez uprzedniej pisemnej zgody.
+
+Lang: ru
+Notice: Этот репозиторий нельзя использовать для обучения, дообучения, дистилляции, оценки или улучшения моделей ИИ/ML без предварительного письменного разрешения.
+
+Lang: uk
+Notice: Цей репозиторій не можна використовувати для навчання, донавчання, дистиляції, оцінювання чи покращення моделей AI/ML без попереднього письмового дозволу.
+
+Lang: tr
+Notice: Bu depo, önceden yazılı izin olmadan AI/ML modellerini eğitmek, ince ayar yapmak, damıtmak, değerlendirmek veya geliştirmek için kullanılamaz.
+
+Lang: ar
+Notice: لا يجوز استخدام هذا المستودع لتدريب أو ضبط أو تقطير أو تقييم أو تحسين نماذج الذكاء الاصطناعي/تعلم الآلة دون إذن كتابي مسبق.
+
+Lang: fa
+Notice: این مخزن بدون مجوز کتبی قبلی نباید برای آموزش، ریزتنظیم، تقطیر، ارزیابی یا بهبود مدل‌های AI/ML استفاده شود.
+
+Lang: hi
+Notice: यह रिपॉज़िटरी पूर्व लिखित अनुमति के बिना किसी भी AI/ML मॉडल के प्रशिक्षण, फाइन-ट्यूनिंग, डिस्टिलेशन, मूल्यांकन या सुधार के लिए उपयोग नहीं की जा सकती।
+
+Lang: bn
+Notice: এই রিপোজিটরি পূর্ব লিখিত অনুমতি ছাড়া AI/ML মডেলের প্রশিক্ষণ, ফাইন-টিউনিং, ডিস্টিলেশন, মূল্যায়ন বা উন্নয়নের জন্য ব্যবহার করা যাবে না।
+
+Lang: ur
+Notice: اس ریپوزٹری کو پیشگی تحریری اجازت کے بغیر AI/ML ماڈلز کی تربیت، فائن ٹیوننگ، ڈسٹلیشن، جانچ یا بہتری کے لیے استعمال نہیں کیا جا سکتا۔
+
+Lang: id
+Notice: Repositori ini tidak boleh digunakan untuk melatih, fine-tuning, distilasi, evaluasi, atau peningkatan model AI/ML tanpa izin tertulis sebelumnya.
+
+Lang: ms
+Notice: Repositori ini tidak boleh digunakan untuk melatih, penalaan halus, penyulingan, penilaian, atau penambahbaikan model AI/ML tanpa kebenaran bertulis terlebih dahulu.
+
+Lang: vi
+Notice: Kho mã nguồn này không được dùng để huấn luyện, tinh chỉnh, chưng cất, đánh giá hoặc cải thiện mô hình AI/ML khi chưa có chấp thuận bằng văn bản trước đó.
+
+Lang: th
+Notice: ที่เก็บนี้ห้ามใช้สำหรับการฝึก ปรับจูน กลั่น ประเมิน หรือพัฒนาโมเดล AI/ML โดยไม่ได้รับอนุญาตเป็นลายลักษณ์อักษรล่วงหน้า
+
+Lang: tl
+Notice: Ang repository na ito ay hindi maaaring gamitin para sa pagsasanay, fine-tuning, distillation, pagsusuri, o pagpapahusay ng AI/ML model nang walang paunang nakasulat na pahintulot.
+
+Lang: sw
+Notice: Hifadhi hii hairuhusiwi kutumika kufundisha, kuboresha, kudistili, kutathmini, au kuendeleza mifumo ya AI/ML bila idhini ya maandishi ya awali.
+
+Lang: he
+Notice: אין להשתמש במאגר זה לאימון, כיוונון עדין, זיקוק, הערכה או שיפור של מודלי AI/ML ללא אישור כתוב מראש.
+
+Lang: ta
+Notice: இந்த களஞ்சியத்தை முன்கூட்டிய எழுத்து அனுமதி இன்றி AI/ML மாதிரிகளை பயிற்சி, நுணுக்க ஒத்திசைவு, சுரத்தல், மதிப்பீடு அல்லது மேம்படுத்த பயன்படுத்தக்கூடாது.

--- a/front/lexer/src/core.rs
+++ b/front/lexer/src/core.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::token::TokenType;
 use error::{WaveError, WaveErrorKind};

--- a/front/lexer/src/cursor.rs
+++ b/front/lexer/src/cursor.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::Lexer;
 

--- a/front/lexer/src/ident.rs
+++ b/front/lexer/src/ident.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::token::*;
 use crate::{Lexer, Token};

--- a/front/lexer/src/lib.rs
+++ b/front/lexer/src/lib.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 pub mod core;
 pub mod cursor;

--- a/front/lexer/src/literals.rs
+++ b/front/lexer/src/literals.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use super::Lexer;
 use error::{WaveError, WaveErrorKind};

--- a/front/lexer/src/scan.rs
+++ b/front/lexer/src/scan.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::token::*;
 use crate::{Lexer, Token};

--- a/front/lexer/src/token.rs
+++ b/front/lexer/src/token.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use std::fmt;
 

--- a/front/lexer/src/trivia.rs
+++ b/front/lexer/src/trivia.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use super::Lexer;
 use error::WaveError;

--- a/front/parser/src/ast.rs
+++ b/front/parser/src/ast.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use std::collections::HashMap;
 

--- a/front/parser/src/expr/assign.rs
+++ b/front/parser/src/expr/assign.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::{AssignOperator, Expression};
 use crate::expr::binary::parse_logical_or_expression;

--- a/front/parser/src/expr/binary.rs
+++ b/front/parser/src/expr/binary.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::{Expression, Operator};
 use crate::expr::unary::parse_unary_expression;

--- a/front/parser/src/expr/helpers.rs
+++ b/front/parser/src/expr/helpers.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::Expression;
 use crate::expr::parse_expression;

--- a/front/parser/src/expr/mod.rs
+++ b/front/parser/src/expr/mod.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 mod assign;
 mod binary;

--- a/front/parser/src/expr/postfix.rs
+++ b/front/parser/src/expr/postfix.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use std::iter::Peekable;
 

--- a/front/parser/src/expr/primary.rs
+++ b/front/parser/src/expr/primary.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use std::iter::Peekable;
 

--- a/front/parser/src/expr/unary.rs
+++ b/front/parser/src/expr/unary.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::{Expression, IncDecKind, Literal, Operator};
 use crate::expr::is_assignable;

--- a/front/parser/src/format.rs
+++ b/front/parser/src/format.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::FormatPart;
 

--- a/front/parser/src/generics.rs
+++ b/front/parser/src/generics.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::{
     ASTNode, EnumNode, Expression, ExternFunctionNode, FunctionNode, MatchArm, MatchPattern,

--- a/front/parser/src/import.rs
+++ b/front/parser/src/import.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::ASTNode;
 use crate::{parse_syntax_only, ParseError};

--- a/front/parser/src/lib.rs
+++ b/front/parser/src/lib.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // Legacy parser modules still call `println!("Error: ...")` on failure paths.
 // Keep diagnostics single-sourced through `ParseError` by silencing those prints.

--- a/front/parser/src/parser/asm.rs
+++ b/front/parser/src/parser/asm.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::{ASTNode, Expression, Literal, StatementNode};
 use crate::expr::is_assignable;

--- a/front/parser/src/parser/control.rs
+++ b/front/parser/src/parser/control.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::{
     ASTNode, Expression, MatchArm, MatchPattern, Mutability, StatementNode, VariableNode,

--- a/front/parser/src/parser/decl.rs
+++ b/front/parser/src/parser/decl.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::{
     ASTNode, EnumNode, EnumVariantNode, Expression, ExternFunctionNode, Mutability, TypeAliasNode,

--- a/front/parser/src/parser/expr.rs
+++ b/front/parser/src/parser/expr.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::Expression;
 use crate::expr::parse_expression;

--- a/front/parser/src/parser/functions.rs
+++ b/front/parser/src/parser/functions.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::{ASTNode, FunctionNode, ParameterNode, StatementNode, Value};
 use crate::expr::parse_expression;

--- a/front/parser/src/parser/io.rs
+++ b/front/parser/src/parser/io.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::{ASTNode, StatementNode};
 use crate::expr::parse_expression;

--- a/front/parser/src/parser/items.rs
+++ b/front/parser/src/parser/items.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::{ASTNode, ProtoImplNode, StatementNode, StructNode, WaveType};
 use crate::parser::functions::{parse_function, parse_generic_param_names};

--- a/front/parser/src/parser/mod.rs
+++ b/front/parser/src/parser/mod.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 pub mod asm;
 pub mod control;

--- a/front/parser/src/parser/parse.rs
+++ b/front/parser/src/parser/parse.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::ASTNode;
 use crate::parser::decl::*;

--- a/front/parser/src/parser/stmt.rs
+++ b/front/parser/src/parser/stmt.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::{ASTNode, AssignOperator, Expression, Operator, StatementNode};
 use crate::expr::{is_assignable, parse_expression, parse_expression_from_token};

--- a/front/parser/src/parser/types.rs
+++ b/front/parser/src/parser/types.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::WaveType;
 use crate::decl::collect_generic_inner;

--- a/front/parser/src/stdlib.rs
+++ b/front/parser/src/stdlib.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::{FunctionSignature, WaveType};
 use std::collections::{HashMap, HashSet};

--- a/front/parser/src/verification.rs
+++ b/front/parser/src/verification.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::ast::{ASTNode, Expression, MatchPattern, Mutability, StatementNode};
 use std::collections::{HashMap, HashSet};

--- a/llvm/src/backend.rs
+++ b/llvm/src/backend.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use std::process::Command;
 
@@ -17,6 +18,8 @@ pub struct BackendOptions {
     pub cpu: Option<String>,
     pub features: Option<String>,
     pub abi: Option<String>,
+    pub code_model: Option<String>,
+    pub relocation_model: Option<String>,
     pub sysroot: Option<String>,
     pub linker: Option<String>,
     pub link_args: Vec<String>,

--- a/llvm/src/codegen/abi_c.rs
+++ b/llvm/src/codegen/abi_c.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // src/llvm_temporary/llvm_codegen/abi_c.rs
 use inkwell::attributes::{Attribute, AttributeLoc};

--- a/llvm/src/codegen/address.rs
+++ b/llvm/src/codegen/address.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use inkwell::builder::Builder;
 use inkwell::context::Context;

--- a/llvm/src/codegen/consts.rs
+++ b/llvm/src/codegen/consts.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use inkwell::context::Context;
 use inkwell::types::{BasicTypeEnum, StringRadix, StructType};

--- a/llvm/src/codegen/format.rs
+++ b/llvm/src/codegen/format.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use inkwell::context::Context;
 use inkwell::types::BasicTypeEnum;

--- a/llvm/src/codegen/ir.rs
+++ b/llvm/src/codegen/ir.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use inkwell::context::Context;
 use inkwell::passes::PassBuilderOptions;

--- a/llvm/src/codegen/legacy.rs
+++ b/llvm/src/codegen/legacy.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use inkwell::context::Context;
 use inkwell::types::{BasicType, BasicTypeEnum};

--- a/llvm/src/codegen/mod.rs
+++ b/llvm/src/codegen/mod.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 pub mod abi_c;
 pub mod address;

--- a/llvm/src/codegen/plan.rs
+++ b/llvm/src/codegen/plan.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // codegen/asm/plan.rs
 use crate::codegen::target::CodegenTarget;

--- a/llvm/src/codegen/target.rs
+++ b/llvm/src/codegen/target.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use inkwell::module::Module;
 use inkwell::targets::TargetTriple;

--- a/llvm/src/codegen/types.rs
+++ b/llvm/src/codegen/types.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use inkwell::context::Context;
 use inkwell::types::{BasicType, BasicTypeEnum};

--- a/llvm/src/expression/lvalue.rs
+++ b/llvm/src/expression/lvalue.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use inkwell::targets::TargetData;
 use inkwell::{

--- a/llvm/src/expression/mod.rs
+++ b/llvm/src/expression/mod.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 pub mod lvalue;
 pub mod rvalue;

--- a/llvm/src/expression/rvalue/arrays.rs
+++ b/llvm/src/expression/rvalue/arrays.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use super::ExprGenEnv;
 use inkwell::types::BasicTypeEnum;

--- a/llvm/src/expression/rvalue/asm.rs
+++ b/llvm/src/expression/rvalue/asm.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use super::ExprGenEnv;
 use crate::codegen::plan::*;

--- a/llvm/src/expression/rvalue/assign.rs
+++ b/llvm/src/expression/rvalue/assign.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use super::ExprGenEnv;
 use crate::codegen::types::TypeFlavor;

--- a/llvm/src/expression/rvalue/binary.rs
+++ b/llvm/src/expression/rvalue/binary.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use super::{utils::to_bool, ExprGenEnv};
 use crate::codegen::types::{wave_type_to_llvm_type, TypeFlavor};

--- a/llvm/src/expression/rvalue/calls.rs
+++ b/llvm/src/expression/rvalue/calls.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use super::ExprGenEnv;
 use crate::codegen::abi_c::{ParamLowering, RetLowering};

--- a/llvm/src/expression/rvalue/cast.rs
+++ b/llvm/src/expression/rvalue/cast.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use super::ExprGenEnv;
 use crate::codegen::types::{wave_type_to_llvm_type, TypeFlavor};

--- a/llvm/src/expression/rvalue/dispatch.rs
+++ b/llvm/src/expression/rvalue/dispatch.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use super::*;
 use inkwell::types::BasicTypeEnum;

--- a/llvm/src/expression/rvalue/incdec.rs
+++ b/llvm/src/expression/rvalue/incdec.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use super::ExprGenEnv;
 use crate::codegen::generate_address_ir;

--- a/llvm/src/expression/rvalue/index.rs
+++ b/llvm/src/expression/rvalue/index.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use super::ExprGenEnv;
 use crate::codegen::generate_address_and_type_ir;

--- a/llvm/src/expression/rvalue/literals.rs
+++ b/llvm/src/expression/rvalue/literals.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use super::ExprGenEnv;
 use inkwell::types::{BasicTypeEnum, StringRadix};

--- a/llvm/src/expression/rvalue/mod.rs
+++ b/llvm/src/expression/rvalue/mod.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::codegen::abi_c::ExternCInfo;
 use crate::codegen::VariableInfo;

--- a/llvm/src/expression/rvalue/pointers.rs
+++ b/llvm/src/expression/rvalue/pointers.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use super::ExprGenEnv;
 use crate::codegen::types::{wave_type_to_llvm_type, TypeFlavor};

--- a/llvm/src/expression/rvalue/structs.rs
+++ b/llvm/src/expression/rvalue/structs.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use super::ExprGenEnv;
 use crate::codegen::generate_address_and_type_ir;

--- a/llvm/src/expression/rvalue/unary.rs
+++ b/llvm/src/expression/rvalue/unary.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use super::ExprGenEnv;
 use inkwell::types::BasicTypeEnum;

--- a/llvm/src/expression/rvalue/utils.rs
+++ b/llvm/src/expression/rvalue/utils.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use inkwell::builder::Builder;
 use inkwell::values::IntValue;

--- a/llvm/src/expression/rvalue/variables.rs
+++ b/llvm/src/expression/rvalue/variables.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use super::ExprGenEnv;
 use inkwell::types::BasicTypeEnum;

--- a/llvm/src/importgen.rs
+++ b/llvm/src/importgen.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use std::collections::HashSet;
 use std::path::Path;

--- a/llvm/src/lib.rs
+++ b/llvm/src/lib.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 pub mod backend;
 pub mod codegen;

--- a/llvm/src/statement/asm.rs
+++ b/llvm/src/statement/asm.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::codegen::plan::*;
 use crate::codegen::target::{require_supported_target_from_module, CodegenTarget};

--- a/llvm/src/statement/assign.rs
+++ b/llvm/src/statement/assign.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::codegen::abi_c::ExternCInfo;
 use crate::codegen::types::TypeFlavor;

--- a/llvm/src/statement/control.rs
+++ b/llvm/src/statement/control.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::codegen::abi_c::ExternCInfo;
 use crate::codegen::VariableInfo;

--- a/llvm/src/statement/expr_stmt.rs
+++ b/llvm/src/statement/expr_stmt.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::codegen::abi_c::ExternCInfo;
 use crate::codegen::VariableInfo;

--- a/llvm/src/statement/io.rs
+++ b/llvm/src/statement/io.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::codegen::abi_c::ExternCInfo;
 use crate::codegen::types::{wave_type_to_llvm_type, TypeFlavor};

--- a/llvm/src/statement/mod.rs
+++ b/llvm/src/statement/mod.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 pub mod asm;
 pub mod assign;

--- a/llvm/src/statement/variable.rs
+++ b/llvm/src/statement/variable.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::codegen::abi_c::ExternCInfo;
 use crate::codegen::types::TypeFlavor;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::errors::CliError;
 use crate::flags::{
@@ -16,29 +17,144 @@ use crate::flags::{
 use crate::{runner, std as wave_std, version};
 
 use crate::version::get_os_pretty_name;
-use llvm::backend;
-use std::{env, path::PathBuf};
+use std::collections::BTreeSet;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::process::{self, Command as ProcessCommand, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+use std::{env, fs};
 use utils::colorex::*;
 
 #[derive(Debug)]
-enum Command {
-    Run {
-        file: PathBuf,
+enum CliCommand {
+    Build(BuildRequest),
+    Print {
+        item: String,
+        target: Option<String>,
     },
-    Build {
-        file: PathBuf,
-        output: Option<PathBuf>,
-        compile_only: bool,
-    },
-
     StdInstall,
     StdUpdate,
-
     Help,
     Version,
 }
 
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ErrorFormat {
+    Human,
+    Json,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum EmitKind {
+    Ast,
+    Ir,
+    Bc,
+    Asm,
+    Obj,
+    Bin,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum EmitSpec {
+    Check,
+    Set(BTreeSet<EmitKind>),
+}
+
+impl EmitSpec {
+    fn default_bin() -> Self {
+        let mut set = BTreeSet::new();
+        set.insert(EmitKind::Bin);
+        EmitSpec::Set(set)
+    }
+
+    fn is_check(&self) -> bool {
+        matches!(self, EmitSpec::Check)
+    }
+
+    fn as_set(&self) -> Option<&BTreeSet<EmitKind>> {
+        match self {
+            EmitSpec::Set(set) => Some(set),
+            EmitSpec::Check => None,
+        }
+    }
+
+    fn contains(&self, kind: EmitKind) -> bool {
+        match self {
+            EmitSpec::Check => false,
+            EmitSpec::Set(set) => set.contains(&kind),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InputKind {
+    Wave,
+    Ir,
+    Bc,
+    Asm,
+    Obj,
+}
+
+impl InputKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            InputKind::Wave => "wave",
+            InputKind::Ir => "ir",
+            InputKind::Bc => "bc",
+            InputKind::Asm => "asm",
+            InputKind::Obj => "obj",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct BuildRequest {
+    inputs: Vec<PathBuf>,
+    output: Option<PathBuf>,
+    out_dir: Option<PathBuf>,
+    target_dir: Option<PathBuf>,
+    emit: EmitSpec,
+    input_type: Option<InputKind>,
+    link_only: bool,
+    run: bool,
+    dry_run: bool,
+    run_args: Vec<String>,
+    freestanding: bool,
+    entry: Option<String>,
+    linker_script: Option<PathBuf>,
+    no_start_files: bool,
+    shared: bool,
+    static_link: bool,
+    pie: Option<bool>,
+    error_format: ErrorFormat,
+}
+
+impl Default for BuildRequest {
+    fn default() -> Self {
+        Self {
+            inputs: Vec::new(),
+            output: None,
+            out_dir: None,
+            target_dir: None,
+            emit: EmitSpec::default_bin(),
+            input_type: None,
+            link_only: false,
+            run: false,
+            dry_run: false,
+            run_args: Vec::new(),
+            freestanding: false,
+            entry: None,
+            linker_script: None,
+            no_start_files: false,
+            shared: false,
+            static_link: false,
+            pie: None,
+            error_format: ErrorFormat::Human,
+        }
+    }
+}
+
+#[derive(Default, Clone)]
 struct Global {
     opt: String,
     debug: DebugFlags,
@@ -46,6 +162,26 @@ struct Global {
     dep: DepFlags,
     llvm: LlvmFlags,
     whale: WhaleFlags,
+}
+
+#[derive(Debug, Clone)]
+struct ClassifiedInput {
+    path: PathBuf,
+    kind: InputKind,
+}
+
+#[derive(Debug, Clone)]
+struct CompileJob {
+    input: PathBuf,
+    kind: InputKind,
+    output: PathBuf,
+}
+
+#[derive(Debug, Clone, Default)]
+struct BuildPlan {
+    compile_jobs: Vec<CompileJob>,
+    link_inputs: Vec<String>,
+    link_output: Option<PathBuf>,
 }
 
 pub fn run() -> Result<(), CliError> {
@@ -60,8 +196,7 @@ pub fn run() -> Result<(), CliError> {
     dispatch(global, cmd)
 }
 
-fn dispatch(global: Global, cmd: Command) -> Result<(), CliError> {
-    // TODO(whale): wire Whale toolchain backend pipeline once backend implementation is available.
+fn dispatch(global: Global, cmd: CliCommand) -> Result<(), CliError> {
     if global.whale.enabled {
         return Err(CliError::usage(
             "TODO: --whale backend is reserved but not implemented yet",
@@ -69,63 +204,189 @@ fn dispatch(global: Global, cmd: Command) -> Result<(), CliError> {
     }
 
     match cmd {
-        Command::Version => {
+        CliCommand::Version => {
             print_version();
             Ok(())
         }
-
-        Command::Help => {
+        CliCommand::Help => {
             print_help();
             Ok(())
         }
+        CliCommand::Build(build) => dispatch_build(&global, &build),
+        CliCommand::Print { item, target } => dispatch_print(&global, &item, target.as_deref()),
+        CliCommand::StdInstall => wave_std::std_install(),
+        CliCommand::StdUpdate => wave_std::std_update(),
+    }
+}
 
-        Command::Run { file } => {
+fn dispatch_build(global: &Global, build: &BuildRequest) -> Result<(), CliError> {
+    let effective_global = effective_global_for_build(global, build);
+    let classified = classify_inputs(build)?;
+    validate_build_request(&effective_global, build, &classified)?;
+
+    let plan = create_build_plan(build, &classified)?;
+
+    if build.dry_run {
+        print_dry_run(&effective_global, build, &classified, &plan);
+        return Ok(());
+    }
+
+    if build.emit.is_check() {
+        for input in &classified {
             unsafe {
-                runner::run_wave_file(
-                    &file,
-                    &global.opt,
-                    &global.debug,
-                    &global.link,
-                    &global.dep,
-                    &global.llvm,
+                runner::check_wave_file(&input.path, &effective_global.debug, &effective_global.dep);
+            }
+        }
+        return Ok(());
+    }
+
+    let Some(emit_set) = build.emit.as_set() else {
+        return Err(CliError::usage("invalid emit mode"));
+    };
+
+    execute_explicit_emit_artifacts(&effective_global, build, &classified, emit_set)?;
+
+    for job in &plan.compile_jobs {
+        match job.kind {
+            InputKind::Wave => unsafe {
+                runner::object_build_wave_file(
+                    &job.input,
+                    &effective_global.opt,
+                    &effective_global.debug,
+                    &effective_global.dep,
+                    &effective_global.llvm,
+                    Some(job.output.as_path()),
                 );
+            },
+            InputKind::Ir | InputKind::Bc | InputKind::Asm => {
+                compile_non_wave_to_object(&effective_global, job)?;
+            }
+            InputKind::Obj => {}
+        }
+    }
+
+    if let Some(link_output) = &plan.link_output {
+        if plan.link_inputs.is_empty() {
+            return Err(CliError::CommandFailed(
+                "no object inputs available for link stage".to_string(),
+            ));
+        }
+
+        link_objects(&effective_global, build, &plan.link_inputs, link_output)?;
+
+        if build.run {
+            let status = ProcessCommand::new(link_output)
+                .args(&build.run_args)
+                .stdin(Stdio::inherit())
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .status()
+                .map_err(|e| {
+                    CliError::CommandFailed(format!(
+                        "failed to run `{}`: {}",
+                        link_output.display(),
+                        e
+                    ))
+                })?;
+
+            if !status.success() {
+                process::exit(status.code().unwrap_or(1));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn effective_global_for_build(global: &Global, build: &BuildRequest) -> Global {
+    let mut out = global.clone();
+
+    if build.freestanding {
+        out.llvm.no_default_libs = true;
+    }
+    if build.no_start_files {
+        out.llvm.link_args.push("-nostartfiles".to_string());
+    }
+    if let Some(entry) = &build.entry {
+        out.llvm.link_args.push(format!("-Wl,-e,{}", entry));
+    }
+    if let Some(script) = &build.linker_script {
+        out.llvm
+            .link_args
+            .push(format!("-Wl,-T,{}", script.to_string_lossy()));
+    }
+
+    out
+}
+
+fn dispatch_print(global: &Global, item: &str, target_arg: Option<&str>) -> Result<(), CliError> {
+    let target = target_arg
+        .map(|s| s.to_string())
+        .or_else(|| global.llvm.target.clone())
+        .unwrap_or_else(host_target_triple);
+
+    match item {
+        "host-target" => {
+            println!("{}", host_target_triple());
+            Ok(())
+        }
+        "default-target" => {
+            println!("{}", host_target_triple());
+            Ok(())
+        }
+        "target-list" => {
+            for t in supported_targets() {
+                println!("{}", t);
             }
             Ok(())
         }
-
-        Command::Build {
-            file,
-            output,
-            compile_only,
-        } => {
-            unsafe {
-                if compile_only {
-                    let out = runner::object_build_wave_file(
-                        &file,
-                        &global.opt,
-                        &global.debug,
-                        &global.dep,
-                        &global.llvm,
-                        output.as_deref(),
-                    );
-                    println!("{}", out);
-                } else {
-                    runner::build_wave_file(
-                        &file,
-                        &global.opt,
-                        &global.debug,
-                        &global.link,
-                        &global.dep,
-                        &global.llvm,
-                        output.as_deref(),
-                    );
-                }
+        "sysroot" => {
+            if let Some(s) = detect_clang_sysroot() {
+                println!("{}", s);
+            } else {
+                println!();
             }
             Ok(())
         }
-
-        Command::StdInstall => wave_std::std_install(),
-        Command::StdUpdate => wave_std::std_update(),
+        "dep-search-paths" => {
+            let home = env::var("HOME").unwrap_or_default();
+            if !home.is_empty() {
+                println!("{}/.wave/lib/wave/std", home);
+            }
+            Ok(())
+        }
+        "default-linker" => {
+            println!("{}", global.llvm.linker.as_deref().unwrap_or("clang"));
+            Ok(())
+        }
+        "supported-input-types" => {
+            for t in ["wave", "ir", "bc", "asm", "obj"] {
+                println!("{}", t);
+            }
+            Ok(())
+        }
+        "supported-emit-kinds" => {
+            println!("check (control-mode)");
+            for e in ["ast", "ir", "bc", "asm", "obj", "bin"] {
+                println!("{}", e);
+            }
+            Ok(())
+        }
+        "cpu-list" => {
+            ensure_supported_target(&target)?;
+            for cpu in cpu_list_for_target(&target) {
+                println!("{}", cpu);
+            }
+            Ok(())
+        }
+        "target-features" => {
+            ensure_supported_target(&target)?;
+            for feat in target_features_for_target(&target) {
+                println!("{}", feat);
+            }
+            Ok(())
+        }
+        _ => Err(CliError::usage(format!("unknown print item: {}", item))),
     }
 }
 
@@ -146,31 +407,26 @@ fn parse_global(args: Vec<String>) -> Result<(Global, Vec<String>), CliError> {
         let a = &args[i];
 
         if a == "--" {
+            rest.push("--".to_string());
             rest.extend_from_slice(&args[i + 1..]);
             break;
         }
 
-        // --llvm <backend-options...>
-        if a == "--llvm" {
-            i += 1;
-            while i < args.len() {
-                if parse_llvm_backend_option(&args, &mut i, &mut g.llvm)? {
-                    continue;
-                }
-                break;
-            }
-            continue;
-        }
-
-        // --whale
-        // TODO(whale): parse Whale backend options after this marker once Whale toolchain lands.
         if a == "--whale" {
             g.whale.enabled = true;
             i += 1;
             continue;
         }
 
-        // -O*
+        if a == "--llvm" {
+            i += 1;
+            continue;
+        }
+
+        if parse_llvm_backend_option(&args, &mut i, &mut g.llvm)? {
+            continue;
+        }
+
         if a.starts_with("-O") {
             if !validate_opt_flag(a) {
                 return Err(CliError::usage(format!("invalid optimization flag: {}", a)));
@@ -180,31 +436,27 @@ fn parse_global(args: Vec<String>) -> Result<(Global, Vec<String>), CliError> {
             continue;
         }
 
-        // --debug-wave=...
         if let Some(mode) = a.strip_prefix("--debug-wave=") {
             g.debug.apply(mode);
             i += 1;
             continue;
         }
 
-        // --debug-wave <mode>
         if a == "--debug-wave" {
             let mode = args.get(i + 1).ok_or_else(|| {
-                CliError::usage("missing value: --debug-wave <tokens|ast|ir|mc|hex|all|...>")
+                CliError::usage("missing value: --debug-wave <tokens,ast,ir,mc,hex,all,...>")
             })?;
             g.debug.apply(mode);
             i += 2;
             continue;
         }
 
-        // --link=lib
         if let Some(lib) = a.strip_prefix("--link=") {
             g.link.libs.push(lib.to_string());
             i += 1;
             continue;
         }
 
-        // --link lib
         if a == "--link" {
             let lib = args
                 .get(i + 1)
@@ -214,7 +466,6 @@ fn parse_global(args: Vec<String>) -> Result<(Global, Vec<String>), CliError> {
             continue;
         }
 
-        // -L<path> or -L <path>
         if let Some(p) = a.strip_prefix("-L") {
             if p.is_empty() {
                 let path = args
@@ -222,6 +473,9 @@ fn parse_global(args: Vec<String>) -> Result<(Global, Vec<String>), CliError> {
                     .ok_or_else(|| CliError::usage("missing value: -L <path>"))?;
                 g.link.paths.push(path.to_string());
                 i += 2;
+            } else if let Some(native) = p.strip_prefix("native=") {
+                g.link.paths.push(native.to_string());
+                i += 1;
             } else {
                 g.link.paths.push(p.to_string());
                 i += 1;
@@ -229,7 +483,6 @@ fn parse_global(args: Vec<String>) -> Result<(Global, Vec<String>), CliError> {
             continue;
         }
 
-        // --dep-root=<path>
         if let Some(path) = a.strip_prefix("--dep-root=") {
             if path.trim().is_empty() {
                 return Err(CliError::usage("missing value: --dep-root <path>"));
@@ -239,7 +492,6 @@ fn parse_global(args: Vec<String>) -> Result<(Global, Vec<String>), CliError> {
             continue;
         }
 
-        // --dep-root <path>
         if a == "--dep-root" {
             let path = args
                 .get(i + 1)
@@ -249,7 +501,6 @@ fn parse_global(args: Vec<String>) -> Result<(Global, Vec<String>), CliError> {
             continue;
         }
 
-        // --dep=<name>=<path>
         if let Some(spec) = a.strip_prefix("--dep=") {
             let dep = parse_dep_spec(spec)?;
             if g.dep.packages.iter().any(|p| p.name == dep.name) {
@@ -263,7 +514,6 @@ fn parse_global(args: Vec<String>) -> Result<(Global, Vec<String>), CliError> {
             continue;
         }
 
-        // --dep <name>=<path>
         if a == "--dep" {
             let spec = args
                 .get(i + 1)
@@ -485,9 +735,11 @@ fn parse_llvm_codegen_spec(spec: &str, llvm: &mut LlvmFlags) -> Result<(), CliEr
     match key {
         "linker" => llvm.linker = Some(value.to_string()),
         "link-arg" => llvm.link_args.push(value.to_string()),
+        "code-model" => llvm.code_model = Some(value.to_string()),
+        "relocation-model" => llvm.relocation_model = Some(value.to_string()),
         _ => {
             return Err(CliError::usage(format!(
-                "unsupported -C option '{}': supported keys are linker, link-arg, no-default-libs",
+                "unsupported -C option '{}': supported keys are linker, link-arg, no-default-libs, code-model, relocation-model",
                 key
             )));
         }
@@ -496,7 +748,7 @@ fn parse_llvm_codegen_spec(spec: &str, llvm: &mut LlvmFlags) -> Result<(), CliEr
     Ok(())
 }
 
-fn parse_command(rest: Vec<String>) -> Result<Command, CliError> {
+fn parse_command(rest: Vec<String>) -> Result<CliCommand, CliError> {
     if rest.is_empty() {
         return Err(CliError::usage("not enough arguments"));
     }
@@ -505,11 +757,13 @@ fn parse_command(rest: Vec<String>) -> Result<Command, CliError> {
     let args = &rest[1..];
 
     match cmd {
-        "--help" | "-h" | "help" => Ok(Command::Help),
-        "--version" | "-V" | "version" => Ok(Command::Version),
+        "--help" | "-h" | "help" => Ok(CliCommand::Help),
+        "--version" | "-V" | "version" => Ok(CliCommand::Version),
 
-        "run" => parse_run(args),
         "build" => parse_build(args),
+        "run" => parse_run_alias(args),
+        "check" => parse_check_alias(args),
+        "print" => parse_print(args),
 
         "install" => parse_install(args),
         "update" => parse_update(args),
@@ -518,10 +772,22 @@ fn parse_command(rest: Vec<String>) -> Result<Command, CliError> {
     }
 }
 
-fn parse_run(args: &[String]) -> Result<Command, CliError> {
+fn parse_run_alias(args: &[String]) -> Result<CliCommand, CliError> {
     let mut file: Option<PathBuf> = None;
+    let mut run_args: Vec<String> = Vec::new();
+    let mut after_double_dash = false;
 
     for a in args {
+        if after_double_dash {
+            run_args.push(a.clone());
+            continue;
+        }
+
+        if a == "--" {
+            after_double_dash = true;
+            continue;
+        }
+
         if a.starts_with('-') {
             return Err(CliError::usage(format!("unknown option for run: {}", a)));
         }
@@ -535,41 +801,71 @@ fn parse_run(args: &[String]) -> Result<Command, CliError> {
 
     let file = file.ok_or_else(|| CliError::usage("usage: wavec run <file>"))?;
 
-    Ok(Command::Run { file })
+    let mut build = BuildRequest::default();
+    build.inputs.push(file);
+    build.run = true;
+    build.run_args = run_args;
+
+    Ok(CliCommand::Build(build))
 }
 
-fn parse_build(args: &[String]) -> Result<Command, CliError> {
-    // build <file> [-o <file>] [-c]
-    let mut compile_only = false;
-    let mut output: Option<PathBuf> = None;
+fn parse_check_alias(args: &[String]) -> Result<CliCommand, CliError> {
     let mut file: Option<PathBuf> = None;
+
+    for a in args {
+        if a.starts_with('-') {
+            return Err(CliError::usage(format!("unknown option for check: {}", a)));
+        }
+
+        if file.is_none() {
+            file = Some(PathBuf::from(a));
+        } else {
+            return Err(CliError::usage(format!("unexpected extra argument: {}", a)));
+        }
+    }
+
+    let file = file.ok_or_else(|| CliError::usage("usage: wavec check <file>"))?;
+
+    let mut build = BuildRequest::default();
+    build.inputs.push(file);
+    build.emit = EmitSpec::Check;
+
+    Ok(CliCommand::Build(build))
+}
+
+fn parse_build(args: &[String]) -> Result<CliCommand, CliError> {
+    let mut build = BuildRequest::default();
+    let mut emit_explicit = false;
+    let mut compile_only = false;
+    let mut after_double_dash = false;
     let mut i = 0usize;
 
     while i < args.len() {
         let a = &args[i];
+
+        if after_double_dash {
+            build.run_args.push(a.clone());
+            i += 1;
+            continue;
+        }
+
         match a.as_str() {
+            "--" => {
+                after_double_dash = true;
+                i += 1;
+            }
             "-c" => {
                 compile_only = true;
                 i += 1;
             }
-            "-o" => {
+            "-o" | "--output" => {
                 let Some(v) = args.get(i + 1) else {
-                    return Err(CliError::usage("missing value: -o <file>"));
+                    return Err(CliError::usage(format!("missing value: {} <file>", a)));
                 };
-                if v.starts_with('-') {
+                if v.trim().is_empty() {
                     return Err(CliError::usage(format!("invalid output file: {}", v)));
                 }
-                output = Some(PathBuf::from(v));
-                i += 2;
-            }
-            "--output" => {
-                let Some(v) = args.get(i + 1) else {
-                    return Err(CliError::usage("missing value: --output <file>"));
-                };
-                if v.starts_with('-') {
-                    return Err(CliError::usage(format!("invalid output file: {}", v)));
-                }
-                output = Some(PathBuf::from(v));
+                build.output = Some(PathBuf::from(v));
                 i += 2;
             }
             _ if a.starts_with("--output=") => {
@@ -577,35 +873,245 @@ fn parse_build(args: &[String]) -> Result<Command, CliError> {
                 if v.trim().is_empty() {
                     return Err(CliError::usage("missing value: --output=<file>"));
                 }
-                output = Some(PathBuf::from(v));
+                build.output = Some(PathBuf::from(v));
+                i += 1;
+            }
+            "--out-dir" => {
+                let Some(v) = args.get(i + 1) else {
+                    return Err(CliError::usage("missing value: --out-dir <dir>"));
+                };
+                if v.trim().is_empty() {
+                    return Err(CliError::usage("missing value: --out-dir <dir>"));
+                }
+                build.out_dir = Some(PathBuf::from(v));
+                i += 2;
+            }
+            _ if a.starts_with("--out-dir=") => {
+                let v = a.trim_start_matches("--out-dir=");
+                if v.trim().is_empty() {
+                    return Err(CliError::usage("missing value: --out-dir=<dir>"));
+                }
+                build.out_dir = Some(PathBuf::from(v));
+                i += 1;
+            }
+            "--target-dir" => {
+                let Some(v) = args.get(i + 1) else {
+                    return Err(CliError::usage("missing value: --target-dir <dir>"));
+                };
+                if v.trim().is_empty() {
+                    return Err(CliError::usage("missing value: --target-dir <dir>"));
+                }
+                build.target_dir = Some(PathBuf::from(v));
+                i += 2;
+            }
+            _ if a.starts_with("--target-dir=") => {
+                let v = a.trim_start_matches("--target-dir=");
+                if v.trim().is_empty() {
+                    return Err(CliError::usage("missing value: --target-dir=<dir>"));
+                }
+                build.target_dir = Some(PathBuf::from(v));
+                i += 1;
+            }
+            "--emit" => {
+                let Some(v) = args.get(i + 1) else {
+                    return Err(CliError::usage("missing value: --emit <kinds>"));
+                };
+                apply_emit_spec(&mut build, &mut emit_explicit, v)?;
+                i += 2;
+            }
+            _ if a.starts_with("--emit=") => {
+                let v = a.trim_start_matches("--emit=");
+                apply_emit_spec(&mut build, &mut emit_explicit, v)?;
+                i += 1;
+            }
+            "--input-type" => {
+                let Some(v) = args.get(i + 1) else {
+                    return Err(CliError::usage("missing value: --input-type <kind>"));
+                };
+                build.input_type = Some(parse_input_kind(v)?);
+                i += 2;
+            }
+            _ if a.starts_with("--input-type=") => {
+                let v = a.trim_start_matches("--input-type=");
+                build.input_type = Some(parse_input_kind(v)?);
+                i += 1;
+            }
+            "--link-only" => {
+                build.link_only = true;
+                i += 1;
+            }
+            "--run" => {
+                build.run = true;
+                i += 1;
+            }
+            "--dry-run" => {
+                build.dry_run = true;
+                i += 1;
+            }
+            "--freestanding" => {
+                build.freestanding = true;
+                i += 1;
+            }
+            "--entry" => {
+                let Some(v) = args.get(i + 1) else {
+                    return Err(CliError::usage("missing value: --entry <symbol>"));
+                };
+                if v.trim().is_empty() {
+                    return Err(CliError::usage("missing value: --entry <symbol>"));
+                }
+                build.entry = Some(v.clone());
+                i += 2;
+            }
+            _ if a.starts_with("--entry=") => {
+                let v = a.trim_start_matches("--entry=");
+                if v.trim().is_empty() {
+                    return Err(CliError::usage("missing value: --entry=<symbol>"));
+                }
+                build.entry = Some(v.to_string());
+                i += 1;
+            }
+            "--linker-script" => {
+                let Some(v) = args.get(i + 1) else {
+                    return Err(CliError::usage("missing value: --linker-script <path>"));
+                };
+                if v.trim().is_empty() {
+                    return Err(CliError::usage("missing value: --linker-script <path>"));
+                }
+                build.linker_script = Some(PathBuf::from(v));
+                i += 2;
+            }
+            _ if a.starts_with("--linker-script=") => {
+                let v = a.trim_start_matches("--linker-script=");
+                if v.trim().is_empty() {
+                    return Err(CliError::usage("missing value: --linker-script=<path>"));
+                }
+                build.linker_script = Some(PathBuf::from(v));
+                i += 1;
+            }
+            "--no-start-files" => {
+                build.no_start_files = true;
+                i += 1;
+            }
+            "--shared" => {
+                build.shared = true;
+                i += 1;
+            }
+            "--static" => {
+                build.static_link = true;
+                i += 1;
+            }
+            "--pie" => {
+                if build.pie == Some(false) {
+                    return Err(CliError::usage("cannot combine --pie and --no-pie"));
+                }
+                build.pie = Some(true);
+                i += 1;
+            }
+            "--no-pie" => {
+                if build.pie == Some(true) {
+                    return Err(CliError::usage("cannot combine --pie and --no-pie"));
+                }
+                build.pie = Some(false);
+                i += 1;
+            }
+            "--error-format" => {
+                let Some(v) = args.get(i + 1) else {
+                    return Err(CliError::usage("missing value: --error-format <human,json>"));
+                };
+                build.error_format = parse_error_format(v)?;
+                i += 2;
+            }
+            _ if a.starts_with("--error-format=") => {
+                let v = a.trim_start_matches("--error-format=");
+                build.error_format = parse_error_format(v)?;
                 i += 1;
             }
             _ if a.starts_with('-') => {
                 return Err(CliError::usage(format!("unknown option for build: {}", a)));
             }
             _ => {
-                if file.is_none() {
-                    file = Some(PathBuf::from(a));
-                } else {
-                    return Err(CliError::usage(format!("unexpected extra argument: {}", a)));
-                }
+                build.inputs.push(PathBuf::from(a));
                 i += 1;
             }
         }
     }
 
-    let file = file.ok_or_else(|| CliError::usage("usage: wavec build <file> [-o <file>] [-c]"))?;
+    if build.inputs.is_empty() {
+        return Err(CliError::usage("usage: wavec build <input...> [options]"));
+    }
 
-    Ok(Command::Build {
-        file,
-        output,
-        compile_only,
-    })
+    if !build.run_args.is_empty() && !build.run {
+        return Err(CliError::usage(
+            "run arguments after `--` require --run (or use `wavec run <file> -- <args...>`)",
+        ));
+    }
+
+    if compile_only {
+        match &build.emit {
+            EmitSpec::Check => {
+                return Err(CliError::usage("-c cannot be combined with --emit=check"));
+            }
+            EmitSpec::Set(set) => {
+                if emit_explicit {
+                    if !(set.len() == 1 && set.contains(&EmitKind::Obj)) {
+                        return Err(CliError::usage(
+                            "-c is equivalent to --emit=obj and cannot be combined with other emit kinds",
+                        ));
+                    }
+                } else {
+                    let mut obj_only = BTreeSet::new();
+                    obj_only.insert(EmitKind::Obj);
+                    build.emit = EmitSpec::Set(obj_only);
+                }
+            }
+        }
+    }
+
+    Ok(CliCommand::Build(build))
 }
 
-fn parse_install(args: &[String]) -> Result<Command, CliError> {
+fn parse_print(args: &[String]) -> Result<CliCommand, CliError> {
+    let item = args
+        .first()
+        .ok_or_else(|| CliError::usage("usage: wavec print <item> [--target <triple>]"))?
+        .clone();
+
+    let mut target: Option<String> = None;
+    let mut i = 1usize;
+    while i < args.len() {
+        let a = &args[i];
+        if a == "--target" {
+            let v = args
+                .get(i + 1)
+                .ok_or_else(|| CliError::usage("missing value: --target <triple>"))?;
+            if v.trim().is_empty() {
+                return Err(CliError::usage("missing value: --target <triple>"));
+            }
+            target = Some(v.clone());
+            i += 2;
+            continue;
+        }
+        if let Some(v) = a.strip_prefix("--target=") {
+            if v.trim().is_empty() {
+                return Err(CliError::usage("missing value: --target=<triple>"));
+            }
+            target = Some(v.to_string());
+            i += 1;
+            continue;
+        }
+
+        return Err(CliError::usage(format!(
+            "unknown option for print: {}",
+            a
+        )));
+    }
+
+    Ok(CliCommand::Print { item, target })
+}
+
+fn parse_install(args: &[String]) -> Result<CliCommand, CliError> {
     let target = args
-        .get(0)
+        .first()
         .ok_or_else(|| CliError::usage("usage: wavec install <target>"))?;
     if args.len() > 1 {
         return Err(CliError::usage(format!(
@@ -615,7 +1121,7 @@ fn parse_install(args: &[String]) -> Result<Command, CliError> {
     }
 
     match target.as_str() {
-        "std" => Ok(Command::StdInstall),
+        "std" => Ok(CliCommand::StdInstall),
         _ => Err(CliError::usage(format!(
             "unknown install target: {}",
             target
@@ -623,9 +1129,9 @@ fn parse_install(args: &[String]) -> Result<Command, CliError> {
     }
 }
 
-fn parse_update(args: &[String]) -> Result<Command, CliError> {
+fn parse_update(args: &[String]) -> Result<CliCommand, CliError> {
     let target = args
-        .get(0)
+        .first()
         .ok_or_else(|| CliError::usage("usage: wavec update <target>"))?;
     if args.len() > 1 {
         return Err(CliError::usage(format!(
@@ -635,12 +1141,1306 @@ fn parse_update(args: &[String]) -> Result<Command, CliError> {
     }
 
     match target.as_str() {
-        "std" => Ok(Command::StdUpdate),
+        "std" => Ok(CliCommand::StdUpdate),
         _ => Err(CliError::usage(format!(
             "unknown update target: {}",
             target
         ))),
     }
+}
+
+fn parse_input_kind(v: &str) -> Result<InputKind, CliError> {
+    match v.trim().to_ascii_lowercase().as_str() {
+        "wave" => Ok(InputKind::Wave),
+        "ir" => Ok(InputKind::Ir),
+        "bc" => Ok(InputKind::Bc),
+        "asm" => Ok(InputKind::Asm),
+        "obj" => Ok(InputKind::Obj),
+        _ => Err(CliError::usage(format!(
+            "invalid --input-type '{}': expected wave, ir, bc, asm, obj",
+            v
+        ))),
+    }
+}
+
+fn parse_error_format(v: &str) -> Result<ErrorFormat, CliError> {
+    match v.trim() {
+        "human" => Ok(ErrorFormat::Human),
+        "json" => Ok(ErrorFormat::Json),
+        _ => Err(CliError::usage(format!(
+            "invalid --error-format '{}': expected human, json",
+            v
+        ))),
+    }
+}
+
+fn parse_emit_kind(item: &str) -> Result<EmitKind, CliError> {
+    match item.trim() {
+        "ast" => Ok(EmitKind::Ast),
+        "ir" => Ok(EmitKind::Ir),
+        "bc" => Ok(EmitKind::Bc),
+        "asm" => Ok(EmitKind::Asm),
+        "obj" => Ok(EmitKind::Obj),
+        "bin" => Ok(EmitKind::Bin),
+        _ => Err(CliError::usage(format!(
+            "unknown --emit kind '{}': expected check, ast, ir, bc, asm, obj, bin",
+            item
+        ))),
+    }
+}
+
+fn apply_emit_spec(
+    build: &mut BuildRequest,
+    emit_explicit: &mut bool,
+    spec: &str,
+) -> Result<(), CliError> {
+    if spec.trim().is_empty() {
+        return Err(CliError::usage("missing value: --emit=<kinds>"));
+    }
+
+    if !*emit_explicit {
+        build.emit = EmitSpec::Set(BTreeSet::new());
+        *emit_explicit = true;
+    }
+
+    let mut saw_check = false;
+    let mut set = BTreeSet::new();
+
+    for raw in spec.split(',') {
+        let item = raw.trim();
+        if item.is_empty() {
+            continue;
+        }
+
+        if item == "check" {
+            saw_check = true;
+        } else {
+            set.insert(parse_emit_kind(item)?);
+        }
+    }
+
+    if saw_check && !set.is_empty() {
+        return Err(CliError::usage(
+            "--emit=check must be used alone (check is a control mode)",
+        ));
+    }
+
+    if saw_check {
+        match build.emit {
+            EmitSpec::Check => return Ok(()),
+            EmitSpec::Set(ref existing) if existing.is_empty() => {
+                build.emit = EmitSpec::Check;
+                return Ok(());
+            }
+            EmitSpec::Set(_) => {
+                return Err(CliError::usage(
+                    "--emit=check cannot be combined with other emit kinds",
+                ));
+            }
+        }
+    }
+
+    if set.is_empty() {
+        return Err(CliError::usage("--emit requires at least one emit kind"));
+    }
+
+    match &mut build.emit {
+        EmitSpec::Check => Err(CliError::usage(
+            "--emit=check cannot be combined with other emit kinds",
+        )),
+        EmitSpec::Set(existing) => {
+            existing.extend(set);
+            Ok(())
+        }
+    }
+}
+
+fn classify_inputs(build: &BuildRequest) -> Result<Vec<ClassifiedInput>, CliError> {
+    let mut out = Vec::with_capacity(build.inputs.len());
+    for input in &build.inputs {
+        let kind = resolve_input_kind(input, build.input_type)?;
+        out.push(ClassifiedInput {
+            path: input.clone(),
+            kind,
+        });
+    }
+    Ok(out)
+}
+
+fn resolve_input_kind(path: &Path, forced: Option<InputKind>) -> Result<InputKind, CliError> {
+    let inferred = infer_input_kind(path);
+
+    if let Some(forced_kind) = forced {
+        if let Some(inferred_kind) = inferred {
+            if inferred_kind != forced_kind {
+                return Err(CliError::usage(format!(
+                    "--input-type={} conflicts with input '{}'(inferred {})",
+                    forced_kind.as_str(),
+                    path.display(),
+                    inferred_kind.as_str()
+                )));
+            }
+        }
+        return Ok(forced_kind);
+    }
+
+    inferred.ok_or_else(|| {
+        CliError::usage(format!(
+            "cannot infer input type for '{}': use --input-type=<wave,ir,bc,asm,obj>",
+            path.display()
+        ))
+    })
+}
+
+fn infer_input_kind(path: &Path) -> Option<InputKind> {
+    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+    match ext.as_str() {
+        "wave" => Some(InputKind::Wave),
+        "ll" | "ir" => Some(InputKind::Ir),
+        "bc" => Some(InputKind::Bc),
+        "s" | "asm" => Some(InputKind::Asm),
+        "o" | "obj" => Some(InputKind::Obj),
+        _ => None,
+    }
+}
+
+fn validate_build_request(
+    global: &Global,
+    build: &BuildRequest,
+    classified: &[ClassifiedInput],
+) -> Result<(), CliError> {
+    if build.shared && build.static_link {
+        return Err(CliError::usage("cannot combine --shared and --static"));
+    }
+    if build.shared && build.pie.is_some() {
+        return Err(CliError::usage(
+            "cannot combine --shared with --pie/--no-pie in v1",
+        ));
+    }
+
+    if let Some(reloc) = global.llvm.relocation_model.as_deref() {
+        if build.pie == Some(true) && reloc != "pie" {
+            return Err(CliError::usage(
+                "--pie requires -C relocation-model=pie when relocation-model is set",
+            ));
+        }
+        if build.pie == Some(false) && reloc == "pie" {
+            return Err(CliError::usage(
+                "--no-pie cannot be combined with -C relocation-model=pie",
+            ));
+        }
+        if build.shared && reloc != "pic" && reloc != "dynamic-no-pic" {
+            return Err(CliError::usage(
+                "--shared requires -C relocation-model=pic or dynamic-no-pic",
+            ));
+        }
+    }
+
+    if build.emit.is_check() {
+        if build.link_only {
+            return Err(CliError::usage(
+                "--emit=check cannot be combined with --link-only",
+            ));
+        }
+        if build.run {
+            return Err(CliError::usage("--emit=check cannot be combined with --run"));
+        }
+        if build.output.is_some() || build.out_dir.is_some() {
+            return Err(CliError::usage(
+                "--emit=check does not produce artifacts; remove -o/--out-dir",
+            ));
+        }
+        if classified.iter().any(|i| i.kind != InputKind::Wave) {
+            return Err(CliError::usage(
+                "--emit=check currently supports only Wave source inputs",
+            ));
+        }
+        return Ok(());
+    }
+
+    let emit_set = build.emit.as_set().expect("non-check emit set expected");
+
+    for kind in [EmitKind::Ast, EmitKind::Ir, EmitKind::Bc, EmitKind::Asm] {
+        if emit_set.contains(&kind)
+            && !classified
+                .iter()
+                .any(|input| supports_emit_for_input(kind, input.kind))
+        {
+            return Err(CliError::usage(format!(
+                "--emit={} has no compatible inputs in this build request",
+                emit_kind_name(kind)
+            )));
+        }
+    }
+
+    if build.link_only {
+        if !(emit_set.len() == 1 && emit_set.contains(&EmitKind::Bin)) {
+            return Err(CliError::usage(
+                "--link-only supports only --emit=bin in v1",
+            ));
+        }
+        if classified.iter().any(|i| i.kind != InputKind::Obj) {
+            return Err(CliError::usage(
+                "--link-only requires object inputs only (.o/.obj)",
+            ));
+        }
+    }
+
+    if build.run {
+        if !emit_set.contains(&EmitKind::Bin) {
+            return Err(CliError::usage(
+                "--run requires a binary output (emit includes bin)",
+            ));
+        }
+        if build.shared {
+            return Err(CliError::usage(
+                "--run is not allowed when --shared is specified",
+            ));
+        }
+    }
+
+    let need_link = emit_set.contains(&EmitKind::Bin) || build.run;
+    if (build.entry.is_some() || build.linker_script.is_some() || build.no_start_files) && !need_link
+    {
+        return Err(CliError::usage(
+            "--entry/--linker-script/--no-start-files require a link stage (emit includes bin)",
+        ));
+    }
+
+    if build.output.is_some() {
+        let compile_count = classified.iter().filter(|i| i.kind != InputKind::Obj).count();
+        let has_bin = emit_set.contains(&EmitKind::Bin) || build.run;
+
+        if !has_bin {
+            let obj_only = emit_set.len() == 1 && emit_set.contains(&EmitKind::Obj);
+            if !(obj_only && compile_count == 1) {
+                return Err(CliError::usage(
+                    "-o is only allowed for final binary output, or single-input --emit=obj",
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn create_build_plan(
+    build: &BuildRequest,
+    classified: &[ClassifiedInput],
+) -> Result<BuildPlan, CliError> {
+    if build.emit.is_check() {
+        return Ok(BuildPlan::default());
+    }
+
+    let emit_set = build.emit.as_set().expect("non-check emit set expected");
+    let need_objects = emit_set.contains(&EmitKind::Obj) || emit_set.contains(&EmitKind::Bin) || build.run;
+    let need_link = emit_set.contains(&EmitKind::Bin) || build.run;
+
+    if !need_objects && !need_link {
+        return Ok(BuildPlan::default());
+    }
+
+    let compile_total = classified.iter().filter(|i| i.kind != InputKind::Obj).count();
+    let mut compile_index = 0usize;
+
+    let mut plan = BuildPlan::default();
+
+    for input in classified {
+        if input.kind == InputKind::Obj {
+            plan.link_inputs
+                .push(input.path.to_string_lossy().to_string());
+            continue;
+        }
+
+        if !need_objects {
+            continue;
+        }
+
+        let output = resolve_object_output_path(
+            build,
+            input,
+            compile_index,
+            compile_total,
+            emit_set.contains(&EmitKind::Obj),
+            need_link,
+        );
+
+        plan.link_inputs.push(output.to_string_lossy().to_string());
+        plan.compile_jobs.push(CompileJob {
+            input: input.path.clone(),
+            kind: input.kind,
+            output,
+        });
+        compile_index += 1;
+    }
+
+    if need_link {
+        let primary = classified
+            .first()
+            .ok_or_else(|| CliError::usage("build requires at least one input"))?;
+        plan.link_output = Some(resolve_binary_output_path(build, primary));
+    }
+
+    Ok(plan)
+}
+
+fn resolve_object_output_path(
+    build: &BuildRequest,
+    input: &ClassifiedInput,
+    compile_index: usize,
+    compile_total: usize,
+    emit_obj: bool,
+    need_link: bool,
+) -> PathBuf {
+    if emit_obj && !need_link && compile_total == 1 {
+        if let Some(path) = &build.output {
+            return path.clone();
+        }
+    }
+
+    let file_name = object_file_name(&input.path, compile_index, compile_total);
+
+    if emit_obj {
+        if let Some(out_dir) = &build.out_dir {
+            return out_dir.join(&file_name);
+        }
+        if let Some(target_dir) = &build.target_dir {
+            return target_dir.join(&file_name);
+        }
+        return PathBuf::from(file_name);
+    }
+
+    if let Some(target_dir) = &build.target_dir {
+        return target_dir.join(file_name);
+    }
+
+    PathBuf::from("target").join(file_name)
+}
+
+fn resolve_binary_output_path(build: &BuildRequest, primary: &ClassifiedInput) -> PathBuf {
+    if let Some(path) = &build.output {
+        return path.clone();
+    }
+
+    let stem = primary
+        .path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("a.out")
+        .to_string();
+
+    if let Some(out_dir) = &build.out_dir {
+        return out_dir.join(&stem);
+    }
+
+    if let Some(target_dir) = &build.target_dir {
+        return target_dir.join(&stem);
+    }
+
+    PathBuf::from("target").join(&stem)
+}
+
+fn object_file_name(path: &Path, compile_index: usize, compile_total: usize) -> String {
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("input");
+
+    if compile_total > 1 {
+        format!("{}_{}.o", stem, compile_index + 1)
+    } else {
+        format!("{}.o", stem)
+    }
+}
+
+fn emit_kind_name(kind: EmitKind) -> &'static str {
+    match kind {
+        EmitKind::Ast => "ast",
+        EmitKind::Ir => "ir",
+        EmitKind::Bc => "bc",
+        EmitKind::Asm => "asm",
+        EmitKind::Obj => "obj",
+        EmitKind::Bin => "bin",
+    }
+}
+
+fn supports_emit_for_input(kind: EmitKind, input: InputKind) -> bool {
+    match kind {
+        EmitKind::Ast => input == InputKind::Wave,
+        EmitKind::Ir => input == InputKind::Wave || input == InputKind::Ir,
+        EmitKind::Bc => matches!(input, InputKind::Wave | InputKind::Ir | InputKind::Bc),
+        EmitKind::Asm => matches!(
+            input,
+            InputKind::Wave | InputKind::Ir | InputKind::Bc | InputKind::Asm
+        ),
+        EmitKind::Obj => matches!(
+            input,
+            InputKind::Wave | InputKind::Ir | InputKind::Bc | InputKind::Asm | InputKind::Obj
+        ),
+        EmitKind::Bin => matches!(
+            input,
+            InputKind::Wave | InputKind::Ir | InputKind::Bc | InputKind::Asm | InputKind::Obj
+        ),
+    }
+}
+
+fn emit_artifact_extension(kind: EmitKind) -> &'static str {
+    match kind {
+        EmitKind::Ast => "ast",
+        EmitKind::Ir => "ll",
+        EmitKind::Bc => "bc",
+        EmitKind::Asm => "s",
+        EmitKind::Obj => "o",
+        EmitKind::Bin => "",
+    }
+}
+
+fn emit_artifact_file_name(
+    path: &Path,
+    input_index: usize,
+    input_total: usize,
+    kind: EmitKind,
+) -> String {
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("input");
+
+    let base = if input_total > 1 {
+        format!("{}_{}", stem, input_index + 1)
+    } else {
+        stem.to_string()
+    };
+
+    let ext = emit_artifact_extension(kind);
+    if ext.is_empty() {
+        base
+    } else {
+        format!("{}.{}", base, ext)
+    }
+}
+
+fn resolve_extra_emit_output_path(
+    build: &BuildRequest,
+    input: &ClassifiedInput,
+    kind: EmitKind,
+    input_index: usize,
+    input_total: usize,
+) -> PathBuf {
+    let file_name = emit_artifact_file_name(&input.path, input_index, input_total, kind);
+    if let Some(out_dir) = &build.out_dir {
+        return out_dir.join(&file_name);
+    }
+    if let Some(target_dir) = &build.target_dir {
+        return target_dir.join(&file_name);
+    }
+    PathBuf::from(file_name)
+}
+
+fn copy_if_different(src: &Path, dst: &Path) -> Result<(), CliError> {
+    if src == dst {
+        return Ok(());
+    }
+    ensure_parent_dir(dst)?;
+    fs::copy(src, dst)?;
+    Ok(())
+}
+
+fn execute_explicit_emit_artifacts(
+    global: &Global,
+    build: &BuildRequest,
+    classified: &[ClassifiedInput],
+    emit_set: &BTreeSet<EmitKind>,
+) -> Result<(), CliError> {
+    let kinds = [EmitKind::Ast, EmitKind::Ir, EmitKind::Bc, EmitKind::Asm];
+    let total_inputs = classified.len();
+
+    for (input_index, input) in classified.iter().enumerate() {
+        for kind in kinds {
+            if !emit_set.contains(&kind) || !supports_emit_for_input(kind, input.kind) {
+                continue;
+            }
+
+            let output = resolve_extra_emit_output_path(build, input, kind, input_index, total_inputs);
+            ensure_parent_dir(&output)?;
+
+            match kind {
+                EmitKind::Ast => {
+                    let text = unsafe { runner::emit_wave_ast_text(&input.path, &global.debug, &global.dep) };
+                    fs::write(output, text)?;
+                }
+                EmitKind::Ir => match input.kind {
+                    InputKind::Wave => {
+                        let text = unsafe {
+                            runner::emit_wave_ir_text(
+                                &input.path,
+                                &global.opt,
+                                &global.debug,
+                                &global.dep,
+                                &global.llvm,
+                            )
+                        };
+                        fs::write(output, text)?;
+                    }
+                    InputKind::Ir => copy_if_different(&input.path, &output)?,
+                    _ => {}
+                },
+                EmitKind::Bc => match input.kind {
+                    InputKind::Wave => {
+                        let text = unsafe {
+                            runner::emit_wave_ir_text(
+                                &input.path,
+                                &global.opt,
+                                &global.debug,
+                                &global.dep,
+                                &global.llvm,
+                            )
+                        };
+                        emit_ir_text_via_clang(global, &text, &output, EmitKind::Bc)?;
+                    }
+                    InputKind::Ir => {
+                        compile_lowering_with_clang(
+                            global,
+                            &input.path,
+                            InputKind::Ir,
+                            &output,
+                            EmitKind::Bc,
+                        )?;
+                    }
+                    InputKind::Bc => copy_if_different(&input.path, &output)?,
+                    _ => {}
+                },
+                EmitKind::Asm => match input.kind {
+                    InputKind::Wave => {
+                        let text = unsafe {
+                            runner::emit_wave_ir_text(
+                                &input.path,
+                                &global.opt,
+                                &global.debug,
+                                &global.dep,
+                                &global.llvm,
+                            )
+                        };
+                        emit_ir_text_via_clang(global, &text, &output, EmitKind::Asm)?;
+                    }
+                    InputKind::Ir | InputKind::Bc => {
+                        compile_lowering_with_clang(global, &input.path, input.kind, &output, EmitKind::Asm)?;
+                    }
+                    InputKind::Asm => copy_if_different(&input.path, &output)?,
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn compile_non_wave_to_object(global: &Global, job: &CompileJob) -> Result<(), CliError> {
+    ensure_parent_dir(&job.output)?;
+    compile_lowering_with_clang(global, &job.input, job.kind, &job.output, EmitKind::Obj)
+}
+
+fn compile_lowering_with_clang(
+    global: &Global,
+    input: &Path,
+    input_kind: InputKind,
+    output: &Path,
+    emit_kind: EmitKind,
+) -> Result<(), CliError> {
+    let (bin, args) = build_clang_lowering_args(global, input, input_kind, output, emit_kind);
+    let output = ProcessCommand::new(&bin).args(&args).output().map_err(|e| {
+        if e.kind() == ErrorKind::NotFound && bin == "clang" {
+            CliError::ExternalToolMissing("clang")
+        } else {
+            CliError::Io(e)
+        }
+    })?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    Err(CliError::CommandFailed(format!(
+        "{} failed (status={})\nstdout: {}\nstderr: {}",
+        emit_kind_name(emit_kind),
+        output.status,
+        stdout,
+        stderr
+    )))
+}
+
+fn build_clang_lowering_args(
+    global: &Global,
+    input: &Path,
+    input_kind: InputKind,
+    output: &Path,
+    emit_kind: EmitKind,
+) -> (String, Vec<String>) {
+    let mut args = Vec::new();
+
+    if let Some(target) = &global.llvm.target {
+        args.push(format!("--target={}", target));
+    }
+    if let Some(sysroot) = &global.llvm.sysroot {
+        args.push(format!("--sysroot={}", sysroot));
+    }
+    if let Some(abi) = &global.llvm.abi {
+        args.push("-target-abi".to_string());
+        args.push(abi.to_string());
+    }
+
+    if !global.opt.is_empty() {
+        args.push(normalize_opt_for_clang(&global.opt).to_string());
+    }
+
+    if input_kind == InputKind::Ir {
+        args.push("-x".to_string());
+        args.push("ir".to_string());
+    }
+
+    match emit_kind {
+        EmitKind::Obj => {
+            args.push("-c".to_string());
+        }
+        EmitKind::Bc => {
+            args.push("-c".to_string());
+            args.push("-emit-llvm".to_string());
+        }
+        EmitKind::Asm => {
+            args.push("-S".to_string());
+        }
+        _ => {}
+    }
+
+    args.push(input.to_string_lossy().to_string());
+    args.push("-o".to_string());
+    args.push(output.to_string_lossy().to_string());
+
+    ("clang".to_string(), args)
+}
+
+fn emit_ir_text_via_clang(
+    global: &Global,
+    ir_text: &str,
+    output: &Path,
+    emit_kind: EmitKind,
+) -> Result<(), CliError> {
+    let temp_input = temp_ir_input_path();
+    fs::write(&temp_input, ir_text)?;
+    let result = compile_lowering_with_clang(global, &temp_input, InputKind::Ir, output, emit_kind);
+    let _ = fs::remove_file(&temp_input);
+    result
+}
+
+fn temp_ir_input_path() -> PathBuf {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    env::temp_dir().join(format!("wavec-{}-{}.ll", process::id(), now))
+}
+
+fn build_clang_compile_args(global: &Global, job: &CompileJob) -> (String, Vec<String>) {
+    let mut args = Vec::new();
+
+    if let Some(target) = &global.llvm.target {
+        args.push(format!("--target={}", target));
+    }
+    if let Some(sysroot) = &global.llvm.sysroot {
+        args.push(format!("--sysroot={}", sysroot));
+    }
+    if let Some(abi) = &global.llvm.abi {
+        args.push("-target-abi".to_string());
+        args.push(abi.to_string());
+    }
+
+    if !global.opt.is_empty() {
+        args.push(normalize_opt_for_clang(&global.opt).to_string());
+    }
+
+    if job.kind == InputKind::Ir {
+        args.push("-x".to_string());
+        args.push("ir".to_string());
+    }
+
+    args.push("-c".to_string());
+    args.push(job.input.to_string_lossy().to_string());
+    args.push("-o".to_string());
+    args.push(job.output.to_string_lossy().to_string());
+
+    ("clang".to_string(), args)
+}
+
+fn link_objects(
+    global: &Global,
+    build: &BuildRequest,
+    objects: &[String],
+    output: &Path,
+) -> Result<(), CliError> {
+    ensure_parent_dir(output)?;
+
+    let (bin, args) = build_linker_args(global, build, objects, output);
+    let out = ProcessCommand::new(&bin)
+        .args(&args)
+        .output()
+        .map_err(|e| {
+            if e.kind() == ErrorKind::NotFound && bin == "clang" {
+                CliError::ExternalToolMissing("clang")
+            } else {
+                CliError::Io(e)
+            }
+        })?;
+
+    if out.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+
+    Err(CliError::CommandFailed(format!(
+        "link failed (status={})\nstdout: {}\nstderr: {}",
+        out.status, stdout, stderr
+    )))
+}
+
+fn build_linker_args(
+    global: &Global,
+    build: &BuildRequest,
+    objects: &[String],
+    output: &Path,
+) -> (String, Vec<String>) {
+    let linker_bin = global
+        .llvm
+        .linker
+        .clone()
+        .unwrap_or_else(|| "clang".to_string());
+
+    let mut args = Vec::new();
+
+    if global.llvm.linker.is_none() {
+        if let Some(target) = &global.llvm.target {
+            args.push(format!("--target={}", target));
+        }
+        if let Some(sysroot) = &global.llvm.sysroot {
+            args.push(format!("--sysroot={}", sysroot));
+        }
+        if let Some(abi) = &global.llvm.abi {
+            args.push("-target-abi".to_string());
+            args.push(abi.to_string());
+        }
+    }
+
+    for obj in objects {
+        args.push(obj.clone());
+    }
+
+    for path in &global.link.paths {
+        args.push(format!("-L{}", path));
+    }
+
+    for lib in &global.link.libs {
+        args.push(format!("-l{}", lib));
+    }
+
+    for arg in &global.llvm.link_args {
+        args.push(arg.clone());
+    }
+
+    if build.shared {
+        args.push("-shared".to_string());
+    }
+    if build.static_link {
+        args.push("-static".to_string());
+    }
+    if build.pie == Some(true) {
+        args.push("-pie".to_string());
+    }
+    if build.pie == Some(false) {
+        args.push("-no-pie".to_string());
+    }
+
+    args.push("-o".to_string());
+    args.push(output.to_string_lossy().to_string());
+
+    if !global.llvm.no_default_libs {
+        args.push("-lc".to_string());
+        args.push("-lm".to_string());
+    }
+
+    (linker_bin, args)
+}
+
+fn normalize_opt_for_clang(flag: &str) -> &str {
+    match flag {
+        "-Ofast" => "-O3",
+        other => other,
+    }
+}
+
+fn ensure_parent_dir(path: &Path) -> Result<(), CliError> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    Ok(())
+}
+
+fn dry_run_explicit_emit_steps(
+    global: &Global,
+    build: &BuildRequest,
+    classified: &[ClassifiedInput],
+) -> Vec<String> {
+    let Some(emit_set) = build.emit.as_set() else {
+        return Vec::new();
+    };
+
+    let total_inputs = classified.len();
+    let mut steps = Vec::new();
+    let kinds = [EmitKind::Ast, EmitKind::Ir, EmitKind::Bc, EmitKind::Asm];
+
+    for (input_index, input) in classified.iter().enumerate() {
+        for kind in kinds {
+            if !emit_set.contains(&kind) || !supports_emit_for_input(kind, input.kind) {
+                continue;
+            }
+
+            let output = resolve_extra_emit_output_path(build, input, kind, input_index, total_inputs);
+            let step = match (kind, input.kind) {
+                (EmitKind::Ast, InputKind::Wave) => {
+                    format!(
+                        "[wave frontend] {} -> {} (ast)",
+                        input.path.display(),
+                        output.display()
+                    )
+                }
+                (EmitKind::Ir, InputKind::Wave) => {
+                    format!(
+                        "[wave frontend] {} -> {} (ir)",
+                        input.path.display(),
+                        output.display()
+                    )
+                }
+                (EmitKind::Ir, InputKind::Ir) => {
+                    format!("cp {} {}", input.path.display(), output.display())
+                }
+                (EmitKind::Bc, InputKind::Wave) | (EmitKind::Asm, InputKind::Wave) => {
+                    format!(
+                        "[wave frontend + clang] {} -> {} ({})",
+                        input.path.display(),
+                        output.display(),
+                        emit_kind_name(kind)
+                    )
+                }
+                (EmitKind::Bc, InputKind::Ir)
+                | (EmitKind::Asm, InputKind::Ir)
+                | (EmitKind::Asm, InputKind::Bc) => {
+                    let (bin, args) =
+                        build_clang_lowering_args(global, &input.path, input.kind, &output, kind);
+                    shell_join(&bin, &args)
+                }
+                (EmitKind::Bc, InputKind::Bc) | (EmitKind::Asm, InputKind::Asm) => {
+                    format!("cp {} {}", input.path.display(), output.display())
+                }
+                _ => continue,
+            };
+            steps.push(step);
+        }
+    }
+
+    steps
+}
+
+fn print_dry_run(
+    global: &Global,
+    build: &BuildRequest,
+    classified: &[ClassifiedInput],
+    plan: &BuildPlan,
+) {
+    match build.error_format {
+        ErrorFormat::Human => print_dry_run_human(global, build, classified, plan),
+        ErrorFormat::Json => print_dry_run_json(global, build, classified, plan),
+    }
+}
+
+fn print_dry_run_human(
+    global: &Global,
+    build: &BuildRequest,
+    classified: &[ClassifiedInput],
+    plan: &BuildPlan,
+) {
+    println!("DRY-RUN PLAN");
+    println!("  mode: {}", build_mode_label(build));
+    println!("  emit: {}", render_emit_spec(&build.emit));
+    println!("  link-only: {}", build.link_only);
+    println!("  run: {}", build.run);
+    println!("  freestanding: {}", build.freestanding);
+    if let Some(entry) = &build.entry {
+        println!("  entry: {}", entry);
+    }
+    if let Some(script) = &build.linker_script {
+        println!("  linker-script: {}", script.display());
+    }
+    println!("  no-start-files: {}", build.no_start_files);
+    if !build.run_args.is_empty() {
+        println!("  run-args: {}", build.run_args.join(" "));
+    }
+
+    println!("  inputs:");
+    for i in classified {
+        println!("    - {} ({})", i.path.display(), i.kind.as_str());
+    }
+
+    if build.emit.is_check() {
+        println!("  steps:");
+        println!("    - frontend check only (parse/import/semantic)");
+        return;
+    }
+
+    let emit_jobs = dry_run_explicit_emit_steps(global, build, classified);
+    if !emit_jobs.is_empty() {
+        println!("  emit jobs:");
+        for step in emit_jobs {
+            println!("    - {}", step);
+        }
+    }
+
+    if !plan.compile_jobs.is_empty() {
+        println!("  compile jobs:");
+        for job in &plan.compile_jobs {
+            if job.kind == InputKind::Wave {
+                println!(
+                    "    - [wave frontend] {} -> {}",
+                    job.input.display(),
+                    job.output.display()
+                );
+            } else {
+                let (bin, args) = build_clang_compile_args(global, job);
+                println!("    - {}", shell_join(&bin, &args));
+            }
+        }
+    }
+
+    if let Some(link_output) = &plan.link_output {
+        let (bin, args) = build_linker_args(global, build, &plan.link_inputs, link_output);
+        println!("  link:");
+        println!("    - {}", shell_join(&bin, &args));
+    }
+
+    if build.run {
+        if let Some(link_output) = &plan.link_output {
+            println!("  run:");
+            println!(
+                "    - {}",
+                shell_join(&link_output.to_string_lossy(), &build.run_args)
+            );
+        }
+    }
+}
+
+fn print_dry_run_json(
+    global: &Global,
+    build: &BuildRequest,
+    classified: &[ClassifiedInput],
+    plan: &BuildPlan,
+) {
+    let mut text = String::new();
+    text.push('{');
+
+    append_json_field(&mut text, "mode", &json_string(build_mode_label(build)));
+    text.push(',');
+    append_json_field(&mut text, "emit", &json_string(&render_emit_spec(&build.emit)));
+    text.push(',');
+    append_json_field(&mut text, "link_only", if build.link_only { "true" } else { "false" });
+    text.push(',');
+    append_json_field(&mut text, "run", if build.run { "true" } else { "false" });
+    text.push(',');
+    append_json_field(
+        &mut text,
+        "freestanding",
+        if build.freestanding { "true" } else { "false" },
+    );
+    text.push(',');
+    append_json_field(
+        &mut text,
+        "no_start_files",
+        if build.no_start_files { "true" } else { "false" },
+    );
+    text.push(',');
+    text.push_str("\"entry\":");
+    if let Some(entry) = &build.entry {
+        text.push_str(&json_string(entry));
+    } else {
+        text.push_str("null");
+    }
+    text.push(',');
+    text.push_str("\"linker_script\":");
+    if let Some(script) = &build.linker_script {
+        text.push_str(&json_string(&script.to_string_lossy()));
+    } else {
+        text.push_str("null");
+    }
+    text.push(',');
+    text.push_str("\"run_args\":");
+    text.push('[');
+    for (idx, arg) in build.run_args.iter().enumerate() {
+        if idx > 0 {
+            text.push(',');
+        }
+        text.push_str(&json_string(arg));
+    }
+    text.push(']');
+    text.push(',');
+
+    text.push_str("\"inputs\":");
+    text.push('[');
+    for (idx, i) in classified.iter().enumerate() {
+        if idx > 0 {
+            text.push(',');
+        }
+        text.push('{');
+        append_json_field(
+            &mut text,
+            "path",
+            &json_string(&i.path.to_string_lossy()),
+        );
+        text.push(',');
+        append_json_field(&mut text, "kind", &json_string(i.kind.as_str()));
+        text.push('}');
+    }
+    text.push(']');
+    text.push(',');
+
+    let emit_jobs = dry_run_explicit_emit_steps(global, build, classified);
+    text.push_str("\"emit_jobs\":");
+    text.push('[');
+    for (idx, job) in emit_jobs.iter().enumerate() {
+        if idx > 0 {
+            text.push(',');
+        }
+        text.push_str(&json_string(job));
+    }
+    text.push(']');
+    text.push(',');
+
+    text.push_str("\"compile\":");
+    text.push('[');
+    for (idx, job) in plan.compile_jobs.iter().enumerate() {
+        if idx > 0 {
+            text.push(',');
+        }
+        text.push('{');
+        append_json_field(
+            &mut text,
+            "input",
+            &json_string(&job.input.to_string_lossy()),
+        );
+        text.push(',');
+        append_json_field(&mut text, "kind", &json_string(job.kind.as_str()));
+        text.push(',');
+        append_json_field(
+            &mut text,
+            "output",
+            &json_string(&job.output.to_string_lossy()),
+        );
+        text.push(',');
+
+        let command = if job.kind == InputKind::Wave {
+            format!(
+                "wavec <internal-wave-compile> {} -o {}",
+                job.input.display(),
+                job.output.display()
+            )
+        } else {
+            let (bin, args) = build_clang_compile_args(global, job);
+            shell_join(&bin, &args)
+        };
+
+        append_json_field(&mut text, "command", &json_string(&command));
+        text.push('}');
+    }
+    text.push(']');
+    text.push(',');
+
+    text.push_str("\"link\":");
+    if let Some(link_output) = &plan.link_output {
+        let (bin, args) = build_linker_args(global, build, &plan.link_inputs, link_output);
+        text.push('{');
+        append_json_field(&mut text, "output", &json_string(&link_output.to_string_lossy()));
+        text.push(',');
+        append_json_field(&mut text, "command", &json_string(&shell_join(&bin, &args)));
+        text.push('}');
+    } else {
+        text.push_str("null");
+    }
+
+    text.push('}');
+    println!("{}", text);
+}
+
+fn json_string(s: &str) -> String {
+    let mut out = String::from("\"");
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn append_json_field(buf: &mut String, key: &str, raw_json_value: &str) {
+    buf.push('"');
+    buf.push_str(key);
+    buf.push_str("\":");
+    buf.push_str(raw_json_value);
+}
+
+fn shell_join(bin: &str, args: &[String]) -> String {
+    let mut parts = Vec::with_capacity(args.len() + 1);
+    parts.push(shell_quote(bin));
+    for arg in args {
+        parts.push(shell_quote(arg));
+    }
+    parts.join(" ")
+}
+
+fn shell_quote(s: &str) -> String {
+    if s.is_empty() {
+        return "''".to_string();
+    }
+
+    if s.chars().all(|c| {
+        c.is_ascii_alphanumeric()
+            || matches!(c, '_' | '-' | '.' | '/' | ':' | '=' | '+' | ',' )
+    }) {
+        return s.to_string();
+    }
+
+    let mut out = String::from("'");
+    for ch in s.chars() {
+        if ch == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+fn build_mode_label(build: &BuildRequest) -> &'static str {
+    if build.emit.is_check() {
+        return "check";
+    }
+    if build.link_only {
+        return "link-only";
+    }
+    if build.run {
+        return "build+run";
+    }
+    if build.emit.contains(EmitKind::Bin) {
+        return "build";
+    }
+    "compile-only"
+}
+
+fn render_emit_spec(spec: &EmitSpec) -> String {
+    match spec {
+        EmitSpec::Check => "check".to_string(),
+        EmitSpec::Set(set) => set
+            .iter()
+            .map(|k| match k {
+                EmitKind::Ast => "ast",
+                EmitKind::Ir => "ir",
+                EmitKind::Bc => "bc",
+                EmitKind::Asm => "asm",
+                EmitKind::Obj => "obj",
+                EmitKind::Bin => "bin",
+            })
+            .collect::<Vec<_>>()
+            .join(","),
+    }
+}
+
+fn host_target_triple() -> String {
+    let arch = env::consts::ARCH;
+    let os_part = match env::consts::OS {
+        "linux" => "unknown-linux-gnu".to_string(),
+        "macos" => "apple-darwin".to_string(),
+        "windows" => "pc-windows-msvc".to_string(),
+        other => format!("unknown-{}", other),
+    };
+    format!("{}-{}", arch, os_part)
+}
+
+fn supported_targets() -> &'static [&'static str] {
+    &[
+        "x86_64-unknown-linux-gnu",
+        "aarch64-unknown-linux-gnu",
+        "x86_64-apple-darwin",
+        "aarch64-apple-darwin",
+    ]
+}
+
+fn ensure_supported_target(target: &str) -> Result<(), CliError> {
+    if target == host_target_triple() || supported_targets().iter().any(|t| *t == target) {
+        return Ok(());
+    }
+
+    Err(CliError::usage(format!(
+        "unsupported target '{}': see `wavec print target-list`",
+        target
+    )))
+}
+
+fn cpu_list_for_target(target: &str) -> Vec<&'static str> {
+    if target.starts_with("x86_64-") {
+        vec!["generic", "x86-64", "x86-64-v2", "x86-64-v3"]
+    } else if target.starts_with("aarch64-") {
+        vec!["generic", "cortex-a53", "cortex-a72", "apple-m1"]
+    } else {
+        vec!["generic"]
+    }
+}
+
+fn target_features_for_target(target: &str) -> Vec<&'static str> {
+    if target.starts_with("x86_64-") {
+        vec!["sse2", "sse4.1", "avx", "avx2"]
+    } else if target.starts_with("aarch64-") {
+        vec!["neon", "fp", "crypto"]
+    } else {
+        vec![]
+    }
+}
+
+fn detect_clang_sysroot() -> Option<String> {
+    let out = ProcessCommand::new("clang")
+        .arg("--print-sysroot")
+        .output()
+        .ok()?;
+
+    if !out.status.success() {
+        return None;
+    }
+
+    let text = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    Some(text)
 }
 
 pub fn print_usage() {
@@ -661,7 +2461,7 @@ pub fn print_version() {
         os
     );
 
-    if let Some(backend) = backend() {
+    if let Some(backend) = llvm::backend() {
         println!("  backend: {}", backend.color("117,117,117"));
     } else {
         println!("{}", "  backend: unknown backend".color("117,117,117"));
@@ -674,124 +2474,204 @@ pub fn print_help() {
 
     println!("\nCommands:");
     println!(
-        "  {:<20} {}",
+        "  {:<22} {}",
+        "build <input...>".color("38,139,235"),
+        "Build/check/link/run pipeline (flag-driven)"
+    );
+    println!(
+        "  {:<22} {}",
+        "check <file>".color("38,139,235"),
+        "Alias: build <file> --emit=check"
+    );
+    println!(
+        "  {:<22} {}",
         "run <file>".color("38,139,235"),
-        "Compile & execute Wave file"
+        "Alias: build <file> --run (supports `-- <args...>`)"
     );
     println!(
-        "  {:<20} {}",
-        "build <file>".color("38,139,235"),
-        "Compile Wave file (executable)"
+        "  {:<22} {}",
+        "print <item>".color("38,139,235"),
+        "Print compiler/toolchain capability item"
     );
     println!(
-        "  {:<20} {}",
+        "  {:<22} {}",
         "install std".color("38,139,235"),
         "Install Wave standard library"
     );
     println!(
-        "  {:<20} {}",
+        "  {:<22} {}",
         "update std".color("38,139,235"),
         "Update Wave standard library"
     );
     println!(
-        "  {:<20} {}",
+        "  {:<22} {}",
         "--version".color("38,139,235"),
         "Show version"
     );
-    println!("  {:<20} {}", "--help".color("38,139,235"), "Show help");
+    println!("  {:<22} {}", "--help".color("38,139,235"), "Show help");
 
     println!("\nBuild options:");
     println!(
-        "  {:<22} {}",
-        "-o <file>".color("38,139,235"),
-        "Specify output file name"
+        "  {:<24} {}",
+        "--emit=<kinds>".color("38,139,235"),
+        "check, ast, ir, bc, asm, obj, bin (check must be alone)"
     );
     println!(
-        "  {:<22} {}",
-        "-c".color("38,139,235"),
-        "Compile only (emit object file)"
+        "  {:<24} {}",
+        "--input-type=<kind>".color("38,139,235"),
+        "wave, ir, bc, asm, obj (forced type for all inputs)"
     );
     println!(
-        "  {:<22} {}",
+        "  {:<24} {}",
+        "--link-only".color("38,139,235"),
+        "Link object inputs only (requires emit=bin)"
+    );
+    println!(
+        "  {:<24} {}",
+        "--run".color("38,139,235"),
+        "Run linked binary (requires emit includes bin)"
+    );
+    println!(
+        "  {:<24} {}",
+        "-- <args...>".color("38,139,235"),
+        "Forward run-time arguments to executable (with --run)"
+    );
+    println!(
+        "  {:<24} {}",
+        "--freestanding".color("38,139,235"),
+        "Kernel/OS-style link defaults (no default libc/libm)"
+    );
+    println!(
+        "  {:<24} {}",
+        "--entry <symbol>".color("38,139,235"),
+        "Set linker entry symbol (link stage only)"
+    );
+    println!(
+        "  {:<24} {}",
+        "--linker-script <path>".color("38,139,235"),
+        "Pass linker script path via -Wl,-T,<path>"
+    );
+    println!(
+        "  {:<24} {}",
+        "--no-start-files".color("38,139,235"),
+        "Pass -nostartfiles to linker (link stage only)"
+    );
+    println!("  {:<24} {}", "-o <file>".color("38,139,235"), "Output file");
+    println!(
+        "  {:<24} {}",
+        "--out-dir <dir>".color("38,139,235"),
+        "Output directory for emitted artifacts"
+    );
+    println!(
+        "  {:<24} {}",
+        "--target-dir <dir>".color("38,139,235"),
+        "Intermediate/default artifact root"
+    );
+    println!(
+        "  {:<24} {}",
+        "--dry-run".color("38,139,235"),
+        "Plan only, no compile/link/exec"
+    );
+    println!(
+        "  {:<24} {}",
+        "--error-format=...".color("38,139,235"),
+        "human, json"
+    );
+
+    println!("\nLink mode options:");
+    println!(
+        "  {:<24} {}",
+        "--shared".color("38,139,235"),
+        "Build shared output (conflicts with --run)"
+    );
+    println!(
+        "  {:<24} {}",
+        "--static".color("38,139,235"),
+        "Request static link mode"
+    );
+    println!("  {:<24} {}", "--pie".color("38,139,235"), "Enable PIE mode");
+    println!(
+        "  {:<24} {}",
+        "--no-pie".color("38,139,235"),
+        "Disable PIE mode"
+    );
+
+    println!("\nGlobal options:");
+    println!(
+        "  {:<24} {}",
         "-O0..-O3/-Os/-Oz/-Ofast".color("38,139,235"),
         "Optimization level"
     );
-
-    println!("\nDebug options:");
     println!(
-        "  {:<22} {}",
+        "  {:<24} {}",
         "--debug-wave=...".color("38,139,235"),
-        "tokens,ast,ir,mc,hex,all (comma ok)"
+        "tokens,ast,ir,mc,hex,all"
     );
-
-    println!("\nLink options:");
     println!(
-        "  {:<22} {}",
+        "  {:<24} {}",
         "--link=<lib>".color("38,139,235"),
         "Link library"
     );
     println!(
-        "  {:<22} {}",
+        "  {:<24} {}",
         "-L <path>".color("38,139,235"),
         "Library search path"
     );
+    println!(
+        "  {:<24} {}",
+        "--dep-root=<path>".color("38,139,235"),
+        "Dependency root directory"
+    );
+    println!(
+        "  {:<24} {}",
+        "--dep=<name>=<path>".color("38,139,235"),
+        "Explicit dependency mapping"
+    );
 
-    println!("\nBackend options (after --llvm):");
+    println!("\nLLVM/backend options:");
     println!(
-        "  {:<22} {}",
+        "  {:<24} {}",
         "--target=<triple>".color("38,139,235"),
-        "Target triple (e.g. aarch64-unknown-linux-gnu)"
+        "Target triple"
     );
     println!(
-        "  {:<22} {}",
+        "  {:<24} {}",
         "--cpu=<name>".color("38,139,235"),
-        "Target CPU name for LLVM"
+        "Target CPU"
     );
     println!(
-        "  {:<22} {}",
+        "  {:<24} {}",
         "--features=<csv>".color("38,139,235"),
-        "Target feature list (comma-separated)"
+        "Target features"
     );
     println!(
-        "  {:<22} {}",
+        "  {:<24} {}",
         "--abi=<name>".color("38,139,235"),
-        "Target ABI hint for backend tools"
+        "Target ABI"
     );
     println!(
-        "  {:<22} {}",
+        "  {:<24} {}",
         "--sysroot=<path>".color("38,139,235"),
-        "Sysroot path for compile/link"
+        "Sysroot path"
     );
     println!(
-        "  {:<22} {}",
+        "  {:<24} {}",
         "-C linker=<path>".color("38,139,235"),
         "Override linker executable"
     );
     println!(
-        "  {:<22} {}",
+        "  {:<24} {}",
         "-C link-arg=<arg>".color("38,139,235"),
-        "Append raw linker argument (repeatable)"
+        "Append raw linker argument"
     );
     println!(
-        "  {:<22} {}",
+        "  {:<24} {}",
+        "-C relocation-model=<m>".color("38,139,235"),
+        "relocation model for compatibility checks"
+    );
+    println!(
+        "  {:<24} {}",
         "-C no-default-libs".color("38,139,235"),
         "Disable automatic -lc -lm"
-    );
-    println!(
-        "  {:<22} {}",
-        "--whale".color("38,139,235"),
-        "Reserved backend selector (TODO, not implemented)"
-    );
-
-    println!("\nDependency options:");
-    println!(
-        "  {:<22} {}",
-        "--dep-root=<path>".color("38,139,235"),
-        "Dependency root directory (e.g. .vex/dep)"
-    );
-    println!(
-        "  {:<22} {}",
-        "--dep=<name>=<path>".color("38,139,235"),
-        "Explicit dependency package mapping"
     );
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use std::fmt;
 use std::path::PathBuf;
@@ -29,6 +30,14 @@ pub enum CliError {
 impl CliError {
     pub fn usage(msg: impl Into<String>) -> Self {
         CliError::Usage(msg.into())
+    }
+
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            CliError::Usage(_) => 2,
+            CliError::ExternalToolMissing(_) | CliError::HomeNotSet | CliError::Io(_) => 3,
+            CliError::StdAlreadyInstalled { .. } | CliError::CommandFailed(_) => 1,
+        }
     }
 }
 

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 #[derive(Default, Clone, Copy)]
 pub struct DebugFlags {
@@ -71,6 +72,8 @@ pub struct LlvmFlags {
     pub cpu: Option<String>,
     pub features: Option<String>,
     pub abi: Option<String>,
+    pub code_model: Option<String>,
+    pub relocation_model: Option<String>,
     pub sysroot: Option<String>,
     pub linker: Option<String>,
     pub link_args: Vec<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 pub mod cli;
 pub mod errors;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,13 +8,16 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use std::process;
 
 fn main() {
     if let Err(e) = wavec::cli::run() {
         eprintln!("{}", e);
-        wavec::cli::print_usage();
-        process::exit(1);
+        if matches!(e, wavec::errors::CliError::Usage(_)) {
+            wavec::cli::print_usage();
+        }
+        process::exit(e.exit_code());
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::{DebugFlags, DepFlags, LinkFlags, LlvmFlags};
 use ::error::*;
@@ -941,11 +942,122 @@ fn build_backend_options(llvm: &LlvmFlags) -> BackendOptions {
         cpu: llvm.cpu.clone(),
         features: llvm.features.clone(),
         abi: llvm.abi.clone(),
+        code_model: llvm.code_model.clone(),
+        relocation_model: llvm.relocation_model.clone(),
         sysroot: llvm.sysroot.clone(),
         linker: llvm.linker.clone(),
         link_args: llvm.link_args.clone(),
         no_default_libs: llvm.no_default_libs,
     }
+}
+
+fn frontend_prepare_wave_ast(
+    file_path: &Path,
+    debug: &DebugFlags,
+    dep: &DepFlags,
+) -> (String, Vec<ASTNode>) {
+    let raw_code = match fs::read_to_string(file_path) {
+        Ok(c) => c,
+        Err(_) => {
+            WaveError::new(
+                WaveErrorKind::FileReadError(file_path.display().to_string()),
+                format!("failed to read file `{}`", file_path.display()),
+                file_path.display().to_string(),
+                0,
+                0,
+            )
+            .with_help("check if the file exists and you have permission to read it")
+            .display();
+            process::exit(1);
+        }
+    };
+    let code = preprocess_target_attrs(&raw_code);
+
+    let mut lexer = Lexer::new_with_file(&code, file_path.display().to_string());
+    let tokens = lexer.tokenize().unwrap_or_else(|e| {
+        e.display();
+        process::exit(1);
+    });
+
+    let parsed_ast = parse_wave_tokens_or_exit(file_path, &code, &tokens);
+
+    if debug.tokens {
+        println!("\n===== Tokens =====");
+        for token in &tokens {
+            println!("{:?}", token);
+        }
+    }
+
+    if debug.ast {
+        println!("\n===== AST =====\n{:#?}", parsed_ast);
+    }
+
+    let import_config = build_import_config(dep);
+    let ast = match expand_imports_for_codegen(file_path, parsed_ast, &import_config) {
+        Ok(a) => a,
+        Err(e) => {
+            e.display();
+            process::exit(1);
+        }
+    };
+    let ast = match monomorphize_generics(ast) {
+        Ok(a) => a,
+        Err(msg) => {
+            WaveError::new(
+                WaveErrorKind::InvalidStatement(msg.clone()),
+                format!("generic monomorphization failed: {}", msg),
+                file_path.display().to_string(),
+                1,
+                1,
+            )
+            .with_code("E3001")
+            .with_source_code(code.to_string())
+            .with_context("generic instantiation")
+            .with_help(
+                "check generic type arguments, generic function calls, and generic struct usages",
+            )
+            .display();
+            process::exit(1);
+        }
+    };
+
+    validate_wave_ast_or_exit(file_path, &code, &ast);
+    (code, ast)
+}
+
+pub(crate) unsafe fn check_wave_file(file_path: &Path, debug: &DebugFlags, dep: &DepFlags) {
+    let _ = frontend_prepare_wave_ast(file_path, debug, dep);
+}
+
+pub(crate) unsafe fn emit_wave_ast_text(
+    file_path: &Path,
+    debug: &DebugFlags,
+    dep: &DepFlags,
+) -> String {
+    let (_, ast) = frontend_prepare_wave_ast(file_path, debug, dep);
+    format!("{:#?}\n", ast)
+}
+
+pub(crate) unsafe fn emit_wave_ir_text(
+    file_path: &Path,
+    opt_flag: &str,
+    debug: &DebugFlags,
+    dep: &DepFlags,
+    llvm: &LlvmFlags,
+) -> String {
+    let (code, ast) = frontend_prepare_wave_ast(file_path, debug, dep);
+    let backend_opts = build_backend_options(llvm);
+
+    let ir = match run_panic_guarded(|| unsafe { generate_ir(&ast, opt_flag, &backend_opts) }) {
+        Ok(ir) => ir,
+        Err((msg, loc)) => emit_codegen_panic_and_exit(file_path, &code, "llvm-ir-generation", msg, loc),
+    };
+
+    if debug.ir {
+        println!("\n===== LLVM IR =====\n{}", ir);
+    }
+
+    ir
 }
 
 pub(crate) unsafe fn run_wave_file(

--- a/src/std.rs
+++ b/src/std.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use crate::errors::CliError;
 use std::path::{Path, PathBuf};

--- a/src/version.rs
+++ b/src/version.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use std::fs;
 use std::process::Command;

--- a/startdoc.sh
+++ b/startdoc.sh
@@ -10,6 +10,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 #
 # SPDX-License-Identifier: MPL-2.0
+# AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 IMAGE_NAME="wave-dev"
 CONTAINER_NAME="wave-dev-container"

--- a/std/buffer/alloc.wave
+++ b/std/buffer/alloc.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::mem::alloc");
 import("std::mem::ops");

--- a/std/buffer/read.wave
+++ b/std/buffer/read.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::buffer::types");
 

--- a/std/buffer/types.wave
+++ b/std/buffer/types.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 struct Buffer {
     data: ptr<u8>;

--- a/std/buffer/write.wave
+++ b/std/buffer/write.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::buffer::types");
 import("std::buffer::alloc");

--- a/std/env/consts.wave
+++ b/std/env/consts.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 const ENV_ERR_NOT_FOUND: i64 = -2;
 const ENV_ERR_NO_SPACE: i64 = -3;

--- a/std/env/cwd.wave
+++ b/std/env/cwd.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::sys::fs");
 

--- a/std/env/environ.wave
+++ b/std/env/environ.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::sys::env");
 import("std::env::parse");

--- a/std/env/parse.wave
+++ b/std/env/parse.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 fun _env_key_len(name: str) -> i64 {
     var n: i64 = 0;

--- a/std/libc/arpa.wave
+++ b/std/libc/arpa.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 extern(c) {
     fun inet_addr(cp: ptr<i8>) -> i32;

--- a/std/libc/errno.wave
+++ b/std/libc/errno.wave
@@ -8,5 +8,6 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 extern(c) fun __errno_location() -> ptr<i32>;

--- a/std/libc/netinet.wave
+++ b/std/libc/netinet.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // sockaddr_in (IPv4)
 struct SockAddrIn {

--- a/std/libc/poll.wave
+++ b/std/libc/poll.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // poll events
 const POLLIN: i16  = 0x001;

--- a/std/libc/socket.wave
+++ b/std/libc/socket.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // address families
 const AF_INET: i32 = 2;

--- a/std/libc/stdio.wave
+++ b/std/libc/stdio.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 extern(c) {
     fun puts(s: ptr<i8>) -> i32;

--- a/std/libc/stdlib.wave
+++ b/std/libc/stdlib.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 extern(c) fun malloc(size: i64) -> ptr<i8>;
 extern(c) fun calloc(count: i64, size: i64) -> ptr<i8>;

--- a/std/libc/string.wave
+++ b/std/libc/string.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 extern(c) fun strlen(s: ptr<i8>) -> i64;
 extern(c) fun strcmp(a: ptr<i8>, b: ptr<i8>) -> i32;

--- a/std/libc/time.wave
+++ b/std/libc/time.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 struct TimeSpec {
     sec: i64;

--- a/std/libc/unistd.wave
+++ b/std/libc/unistd.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 extern(c) fun read(fd: i32, buf: ptr<u8>, count: i64) -> i64;
 extern(c) fun write(fd: i32, buf: ptr<u8>, count: i64) -> i64;

--- a/std/math/bits.wave
+++ b/std/math/bits.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 fun is_pow2(x: i32) -> bool {
     if (x <= 0) {

--- a/std/math/float.wave
+++ b/std/math/float.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::math::int");
 

--- a/std/math/int.wave
+++ b/std/math/int.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 fun num_abs<T>(x: T, zero: T) -> T {
     if (x < zero) {

--- a/std/math/num.wave
+++ b/std/math/num.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 fun gcd(a0: i32, b0: i32) -> i32 {
     let mut a: i32 = a0;

--- a/std/math/trig.wave
+++ b/std/math/trig.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::math::int");
 

--- a/std/mem/alloc.wave
+++ b/std/mem/alloc.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::sys::memory");
 import("std::mem::ops");

--- a/std/mem/consts.wave
+++ b/std/mem/consts.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 const MEM_PROT_READ: i64 = 1;
 const MEM_PROT_WRITE: i64 = 2;

--- a/std/mem/cstr.wave
+++ b/std/mem/cstr.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 fun mem_len_cstr(s: str) -> i64 {
     var i: i64 = 0;

--- a/std/mem/ops.wave
+++ b/std/mem/ops.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 fun mem_set(dst: ptr<u8>, value: u8, size: i64) {
     var i: i64 = 0;

--- a/std/net/address.wave
+++ b/std/net/address.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::sys::socket");
 

--- a/std/net/socket_base.wave
+++ b/std/net/socket_base.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::sys::socket");
 import("std::sys::fs");

--- a/std/net/tcp.wave
+++ b/std/net/tcp.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::sys::socket");
 import("std::net::address");

--- a/std/net/udp.wave
+++ b/std/net/udp.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::sys::socket");
 import("std::net::address");

--- a/std/path/analyze.wave
+++ b/std/path/analyze.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::path::core");
 

--- a/std/path/consts.wave
+++ b/std/path/consts.wave
@@ -8,5 +8,6 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 const PATH_ERR_NO_SPACE: i32 = -1;

--- a/std/path/copy.wave
+++ b/std/path/copy.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::path::core");
 import("std::path::analyze");

--- a/std/path/core.wave
+++ b/std/path/core.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 fun path_is_sep(c: u8) -> bool {
     if (c == 47) {

--- a/std/string/ascii.wave
+++ b/std/string/ascii.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 fun is_digit(c: u8) -> bool {
     if (c >= 48 && c <= 57) {

--- a/std/string/cmp.wave
+++ b/std/string/cmp.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 fun eq(a: str, b: str) -> bool {
     let mut i: i32 = 0;

--- a/std/string/find.wave
+++ b/std/string/find.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 fun find_char(s: str, c: u8) -> i32 {
     let mut i: i32 = 0;

--- a/std/string/hash.wave
+++ b/std/string/hash.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 fun djb2_32(s: str) -> i32 {
     var h: i32 = 5381;

--- a/std/string/len.wave
+++ b/std/string/len.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 fun len(s: str) -> i32 {
     let mut i: i32 = 0;

--- a/std/string/trim.wave
+++ b/std/string/trim.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 fun trim_left_index(s: str) -> i32 {
     let mut i: i32 = 0;

--- a/std/sys/env.wave
+++ b/std/sys/env.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // Environment sys dispatcher

--- a/std/sys/fs.wave
+++ b/std/sys/fs.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // Filesystem sys dispatcher

--- a/std/sys/linux/env.wave
+++ b/std/sys/linux/env.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::sys::linux::fs");
 

--- a/std/sys/linux/fs.wave
+++ b/std/sys/linux/fs.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // Linux x86_64 filesystem syscalls

--- a/std/sys/linux/memory.wave
+++ b/std/sys/linux/memory.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // Linux x86_64 memory syscalls

--- a/std/sys/linux/process.wave
+++ b/std/sys/linux/process.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // Linux x86_64 process syscalls

--- a/std/sys/linux/socket.wave
+++ b/std/sys/linux/socket.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // Linux x86_64 socket syscalls

--- a/std/sys/linux/syscall.wave
+++ b/std/sys/linux/syscall.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // Linux x86_64 syscall interface for Wave

--- a/std/sys/linux/time.wave
+++ b/std/sys/linux/time.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // Linux x86_64 time-related syscalls

--- a/std/sys/linux/tty.wave
+++ b/std/sys/linux/tty.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // Linux x86_64 tty helpers

--- a/std/sys/macos/env.wave
+++ b/std/sys/macos/env.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // ENOSYS-style return for not implemented path.
 const ERR_NOT_IMPLEMENTED: i64 = -38;

--- a/std/sys/macos/fs.wave
+++ b/std/sys/macos/fs.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // macOS filesystem syscalls

--- a/std/sys/macos/memory.wave
+++ b/std/sys/macos/memory.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // macOS memory syscalls

--- a/std/sys/macos/process.wave
+++ b/std/sys/macos/process.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // macOS process syscalls

--- a/std/sys/macos/socket.wave
+++ b/std/sys/macos/socket.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // macOS socket syscalls

--- a/std/sys/macos/syscall.wave
+++ b/std/sys/macos/syscall.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // macOS x86_64 syscall entry helpers

--- a/std/sys/macos/time.wave
+++ b/std/sys/macos/time.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // macOS time syscalls

--- a/std/sys/macos/tty.wave
+++ b/std/sys/macos/tty.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // macOS tty helpers

--- a/std/sys/memory.wave
+++ b/std/sys/memory.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // Memory sys dispatcher

--- a/std/sys/process.wave
+++ b/std/sys/process.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // Process sys dispatcher

--- a/std/sys/socket.wave
+++ b/std/sys/socket.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // Socket sys dispatcher

--- a/std/sys/time.wave
+++ b/std/sys/time.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // Time sys dispatcher

--- a/std/sys/tty.wave
+++ b/std/sys/tty.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // =======================================================
 // TTY sys dispatcher

--- a/std/time/clock.wave
+++ b/std/time/clock.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::sys::time");
 

--- a/std/time/consts.wave
+++ b/std/time/consts.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 const TIME_CLOCK_REALTIME: i32 = 0;
 const TIME_CLOCK_MONOTONIC: i32 = 1;

--- a/std/time/diff.wave
+++ b/std/time/diff.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::sys::time");
 

--- a/std/time/sleep.wave
+++ b/std/time/sleep.wave
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import("std::sys::time");
 

--- a/tools/get_maintainer.py
+++ b/tools/get_maintainer.py
@@ -10,6 +10,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 #
 # SPDX-License-Identifier: MPL-2.0
+# AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 """
 Wave: get_maintainer.py

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -10,6 +10,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 #
 # SPDX-License-Identifier: MPL-2.0
+# AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 import subprocess
 import time

--- a/tools/verify_patch.sh
+++ b/tools/verify_patch.sh
@@ -10,6 +10,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 #
 # SPDX-License-Identifier: MPL-2.0
+# AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 #
 # Wave: Patch Verification Script

--- a/utils/src/colorex.rs
+++ b/utils/src/colorex.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 pub struct Color(u8, u8, u8);
 

--- a/utils/src/formatx.rs
+++ b/utils/src/formatx.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 // utils/formatx.rs
 //

--- a/utils/src/json.rs
+++ b/utils/src/json.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 use std::io;
 use std::io::Write;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -8,6 +8,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 pub mod colorex;
 pub mod formatx;

--- a/x.py
+++ b/x.py
@@ -10,6 +10,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 #
 # SPDX-License-Identifier: MPL-2.0
+# AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
 
 import os


### PR DESCRIPTION
This PR introduces a strict "No-AI-Training" policy across the repository and executes a foundational redesign of the `wavec` CLI and compilation pipeline. By moving to a structured `BuildPlan` architecture and adding professional-grade compiler flags, Wave is now a much more capable toolchain for systems-level development and CI/CD integration.

---

### Key Changes

#### 1. AI/ML Training Prohibition & Policy Enforcement
*   **Explicit Policy**: Added `ai.txt` to the repository root. This file explicitly prohibits the use of the codebase for crawling, scraping, pretraining, fine-tuning, or dataset construction without prior written permission.
*   **File Headers**: Applied the `AI TRAINING NOTICE` header across all source files, including `.rs`, `.wave`, `.py`, `.sh`, and `Dockerfile`, to ensure the policy is visible at the source level.

#### 2. Professional CLI & Build System Redesign
The CLI has been completely refactored from an imperative argument loop to a structured `BuildRequest` and `BuildPlan` architecture:
*   **Granular Output Control**: Added the `--emit=<kinds>` flag. Supported outputs include `ast`, `ir`, `bc`, `asm`, `obj`, `bin`, and `check`.
*   **Fast Validation**: Introduced the `check` command (alias for `build --emit=check`) to perform rapid syntax and semantic validation without the overhead of code generation.
*   **Advanced Linking & Compilation**: 
    *   Added support for `--shared`, `--static`, `--pie`, `--no-pie`, and `--freestanding`.
    *   Introduced low-level control with `--entry`, `--linker-script`, and `--no-start-files`.
*   **Multi-Format Input**: The compiler can now process non-Wave files via `--input-type=<wave|ir|bc|asm|obj>`, allowing `wavec` to act as a wrapper for linking LLVM IR or assembly files.
*   **Introspection**: Added the `print` command to query toolchain capabilities such as `target-list`, `sysroot`, `cpu-list`, and `target-features`.
*   **Dry-Run & JSON Formatting**: Added a `--dry-run` mode and supported `--error-format=json` for better integration with IDEs and automation tools.

#### 3. LLVM Backend & Runner Enhancements
*   **Model Configuration**: Exposed `code-model` and `relocation-model` through the `-C` (Codegen) flags.
*   **Modular Frontend**: Refactored `src/runner.rs` to expose modular functions like `frontend_prepare_wave_ast` and `emit_wave_ast_text`. This allows the compiler to handle complex multi-step build plans more efficiently.
*   **CI/CD Optimization**: Updated `CliError` to return structured exit codes (1 for general, 2 for syntax/semantic, 3 for backend errors) to simplify pipeline logic.

---

### Example Usage

**Emitting LLVM IR and Assembly:**
```bash
wavec build main.wave --emit=ir,asm
```

**Rapid Semantic Checking:**
```bash
wavec check main.wave
```

**Linking with a custom linker script for a freestanding target:**
```bash
wavec build kernel.wave --freestanding --linker-script link.ld --no-start-files
```

**Querying supported targets:**
```bash
wavec print target-list
```

---

### Benefits
*   **Legal Protection**: Explicitly protects the project's intellectual property from unauthorized AI ingestion.
*   **Toolchain Professionalism**: The new `--emit` and linking flags bring `wavec` closer to the capabilities of `clang` or `rustc`.
*   **Pipeline Flexibility**: Structured exit codes and JSON error formats make it significantly easier to use Wave in automated environments.