### PR TITLE
feat(cli): add -C link-sysroot option and custom linker validation

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -739,11 +739,12 @@ fn parse_llvm_codegen_spec(spec: &str, llvm: &mut LlvmFlags) -> Result<(), CliEr
     match key {
         "linker" => llvm.linker = Some(value.to_string()),
         "link-arg" => llvm.link_args.push(value.to_string()),
+        "link-sysroot" => set_link_sysroot_arg(&mut llvm.link_args, value),
         "code-model" => llvm.code_model = Some(value.to_string()),
         "relocation-model" => llvm.relocation_model = Some(value.to_string()),
         _ => {
             return Err(CliError::usage(format!(
-                "unsupported -C option '{}': supported keys are linker, link-arg, no-default-libs, code-model, relocation-model",
+                "unsupported -C option '{}': supported keys are linker, link-arg, link-sysroot, no-default-libs, code-model, relocation-model",
                 key
             )));
         }
@@ -1413,6 +1414,18 @@ fn validate_build_request(
         ));
     }
 
+    if need_link
+        && global.llvm.linker.is_some()
+        && global.llvm.sysroot.is_some()
+        && !has_explicit_link_sysroot_arg(&global.llvm.link_args)
+    {
+        return Err(CliError::usage(
+            "when using -C linker=..., --sysroot=<path> is compile-stage only; \
+             pass linker sysroot explicitly with -C link-sysroot=<path> \
+             (or -C link-arg=--sysroot=<path>)",
+        ));
+    }
+
     if build.output.is_some() {
         let compile_count = classified
             .iter()
@@ -1431,6 +1444,19 @@ fn validate_build_request(
     }
 
     Ok(())
+}
+
+fn is_link_sysroot_arg(arg: &str) -> bool {
+    arg == "--sysroot" || arg.starts_with("--sysroot=") || arg.contains("--sysroot=")
+}
+
+fn has_explicit_link_sysroot_arg(args: &[String]) -> bool {
+    args.iter().any(|arg| is_link_sysroot_arg(arg))
+}
+
+fn set_link_sysroot_arg(link_args: &mut Vec<String>, value: &str) {
+    link_args.retain(|arg| !is_link_sysroot_arg(arg));
+    link_args.push(format!("--sysroot={}", value));
 }
 
 fn create_build_plan(
@@ -2715,6 +2741,11 @@ pub fn print_help() {
         "  {:<24} {}",
         "-C link-arg=<arg>".color("38,139,235"),
         "Append raw linker argument"
+    );
+    println!(
+        "  {:<24} {}",
+        "-C link-sysroot=<path>".color("38,139,235"),
+        "Set linker sysroot as --sysroot=<path>"
     );
     println!(
         "  {:<24} {}",


### PR DESCRIPTION
This PR enhances the Wave compiler's CLI by introducing fine-grained control over the sysroot during the linking stage. It adds the `-C link-sysroot=<path>` option and implements a safety validation check to prevent common configuration errors when using custom linkers alongside general sysroots.

### Key Changes

#### 1. New Linker Option: `-C link-sysroot`
*   Added `-C link-sysroot=<path>` to the codegen specification parser.
*   This allows developers to explicitly specify which sysroot the linker should use, which may differ from the compiler's general sysroot in complex cross-compilation environments.

#### 2. Custom Linker Safety Validation
*   **Problem**: Previously, specifying a general `--sysroot` would apply to the compilation stage, but might be ignored by a custom linker specified via `-C linker`. This led to confusing "file not found" or "incompatible library" errors during the final link phase.
*   **Solution**: Updated `validate_build_request` to enforce a new safety rule: if both a **custom linker** and a **general sysroot** are provided, the user must now explicitly provide a `-C link-sysroot`. This ensures the developer is consciously aware of where the linker is searching for libraries.

#### 3. Argument Management Helpers
*   Introduced a suite of helper functions to manage internal linker arguments safely:
    *   `is_link_sysroot_arg`: Identifies sysroot-related strings.
    *   `has_explicit_link_sysroot_arg`: Checks if the sysroot has already been set in the build plan.
    *   `set_link_sysroot_arg`: Safely updates or appends the sysroot argument while avoiding duplication.

#### 4. Documentation
*   Updated the CLI help output (`wavec --help`) to include and describe the new `-C link-sysroot` option.

### Rationale
In systems programming and OS development, the compiler's view of the "system" (headers/core logic) and the linker's view (standard libraries/start files) can sometimes diverge. By requiring explicit link sysroots when a custom linker is involved, Wave prevents "silent" linking failures where the compiler assumes the linker inherited the general sysroot.

### Example Usage

**Explicitly providing a link sysroot for a custom cross-linker:**
```bash
wavec build main.wave \
    --sysroot /path/to/compiled/headers \
    -C linker=aarch64-linux-gnu-ld \
    -C link-sysroot=/path/to/target/libs
```