### PR TITLE
Stabilize Vex CLI contracts

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,6 +101,7 @@ enum InputKind {
     Bc,
     Asm,
     Obj,
+    Archive,
 }
 
 impl InputKind {
@@ -111,7 +112,12 @@ impl InputKind {
             InputKind::Bc => "bc",
             InputKind::Asm => "asm",
             InputKind::Obj => "obj",
+            InputKind::Archive => "archive",
         }
+    }
+
+    fn is_link_input(self) -> bool {
+        matches!(self, InputKind::Obj | InputKind::Archive)
     }
 }
 
@@ -211,20 +217,30 @@ where
     S: AsRef<str>,
 {
     let mut expect_value = false;
+    let mut wants_json = false;
     for arg in args {
         let arg = arg.as_ref();
+        if arg == "--" {
+            break;
+        }
         if expect_value {
-            return arg == "json";
+            if arg == "json" {
+                wants_json = true;
+            }
+            expect_value = false;
+            continue;
         }
         if arg == "--error-format" {
             expect_value = true;
             continue;
         }
         if let Some(value) = arg.strip_prefix("--error-format=") {
-            return value == "json";
+            if value == "json" {
+                wants_json = true;
+            }
         }
     }
-    false
+    wants_json
 }
 
 fn dispatch(global: Global, cmd: CliCommand) -> Result<(), CliError> {
@@ -307,7 +323,7 @@ fn dispatch_build(global: &Global, build: &BuildRequest) -> Result<(), CliError>
             InputKind::Ir | InputKind::Bc | InputKind::Asm => {
                 compile_non_wave_to_object(&effective_global, job)?;
             }
-            InputKind::Obj => {}
+            InputKind::Obj | InputKind::Archive => {}
         }
     }
 
@@ -1352,8 +1368,9 @@ fn parse_input_kind(v: &str) -> Result<InputKind, CliError> {
         "bc" => Ok(InputKind::Bc),
         "asm" => Ok(InputKind::Asm),
         "obj" => Ok(InputKind::Obj),
+        "archive" | "lib" => Ok(InputKind::Archive),
         _ => Err(CliError::usage(format!(
-            "invalid --input-type '{}': expected wave, ir, bc, asm, obj",
+            "invalid --input-type '{}': expected wave, ir, bc, asm, obj, archive",
             v
         ))),
     }
@@ -1493,7 +1510,7 @@ fn resolve_input_kind(path: &Path, forced: Option<InputKind>) -> Result<InputKin
 
     inferred.ok_or_else(|| {
         CliError::usage(format!(
-            "cannot infer input type for '{}': use --input-type=<wave,ir,bc,asm,obj>",
+            "cannot infer input type for '{}': use --input-type=<wave,ir,bc,asm,obj,archive>",
             path.display()
         ))
     })
@@ -1507,6 +1524,7 @@ fn infer_input_kind(path: &Path) -> Option<InputKind> {
         "bc" => Some(InputKind::Bc),
         "s" | "asm" => Some(InputKind::Asm),
         "o" | "obj" => Some(InputKind::Obj),
+        "a" => Some(InputKind::Archive),
         _ => None,
     }
 }
@@ -1588,11 +1606,20 @@ fn validate_build_request(
                 "--link-only supports only --emit=bin in v1",
             ));
         }
-        if classified.iter().any(|i| i.kind != InputKind::Obj) {
+        if classified.iter().any(|i| !i.kind.is_link_input()) {
             return Err(CliError::usage(
-                "--link-only requires object inputs only (.o/.obj)",
+                "--link-only requires link-ready inputs only (.o/.obj/.a)",
             ));
         }
+    }
+
+    if emit_set.len() == 1
+        && emit_set.contains(&EmitKind::Obj)
+        && classified.iter().all(|i| i.kind.is_link_input())
+    {
+        return Err(CliError::usage(
+            "--emit=obj requires at least one compilable input (wave, ir, bc, asm)",
+        ));
     }
 
     if build.run {
@@ -1632,7 +1659,7 @@ fn validate_build_request(
     if build.output.is_some() {
         let compile_count = classified
             .iter()
-            .filter(|i| i.kind != InputKind::Obj)
+            .filter(|i| !i.kind.is_link_input())
             .count();
         let has_bin = emit_set.contains(&EmitKind::Bin) || build.run;
 
@@ -1682,14 +1709,14 @@ fn create_build_plan(
 
     let compile_total = classified
         .iter()
-        .filter(|i| i.kind != InputKind::Obj)
+        .filter(|i| !i.kind.is_link_input())
         .count();
     let mut compile_index = 0usize;
 
     let mut plan = BuildPlan::default();
 
     for input in classified {
-        if input.kind == InputKind::Obj {
+        if input.kind.is_link_input() {
             plan.link_inputs
                 .push(input.path.to_string_lossy().to_string());
             continue;
@@ -1832,7 +1859,12 @@ fn supports_emit_for_input(kind: EmitKind, input: InputKind) -> bool {
         ),
         EmitKind::Bin => matches!(
             input,
-            InputKind::Wave | InputKind::Ir | InputKind::Bc | InputKind::Asm | InputKind::Obj
+            InputKind::Wave
+                | InputKind::Ir
+                | InputKind::Bc
+                | InputKind::Asm
+                | InputKind::Obj
+                | InputKind::Archive
         ),
     }
 }
@@ -3009,6 +3041,8 @@ fn print_dry_run_json(
     let mut text = String::new();
     text.push('{');
 
+    append_json_field(&mut text, "schema_version", "1");
+    text.push(',');
     append_json_field(&mut text, "mode", &json_string(build_mode_label(build)));
     text.push(',');
     append_json_field(
@@ -3022,6 +3056,23 @@ fn print_dry_run_json(
         "emit",
         &json_string(&render_emit_spec(&build.emit)),
     );
+    text.push(',');
+    text.push_str("\"emit_kinds\":");
+    text.push_str(&emit_spec_json_array(&build.emit));
+    text.push(',');
+    text.push_str("\"control_mode\":");
+    if build.emit.is_check() {
+        text.push_str(&json_string("check"));
+    } else {
+        text.push_str("null");
+    }
+    text.push(',');
+    text.push_str("\"forced_input_type\":");
+    if let Some(kind) = build.input_type {
+        text.push_str(&json_string(kind.as_str()));
+    } else {
+        text.push_str("null");
+    }
     text.push(',');
     append_json_field(
         &mut text,
@@ -3155,6 +3206,7 @@ fn print_dry_run_json(
 
     text.push_str("\"link\":");
     if let Some(link_output) = &plan.link_output {
+        let (program, args) = build_linker_args(global, build, &plan.link_inputs, link_output);
         text.push('{');
         append_json_field(
             &mut text,
@@ -3162,17 +3214,44 @@ fn print_dry_run_json(
             &json_string(&link_output.to_string_lossy()),
         );
         text.push(',');
+        text.push_str("\"inputs\":");
+        text.push_str(&json_owned_string_array(&plan.link_inputs));
+        text.push(',');
+        append_json_field(&mut text, "program", &json_string(&program));
+        text.push(',');
+        text.push_str("\"args\":");
+        text.push_str(&json_owned_string_array(&args));
+        text.push(',');
         append_json_field(
             &mut text,
             "command",
-            &json_string(&render_link_command(
-                global,
-                build,
-                &plan.link_inputs,
-                link_output,
-            )),
+            &json_string(&shell_join(&program, &args)),
         );
         text.push('}');
+    } else {
+        text.push_str("null");
+    }
+    text.push(',');
+
+    text.push_str("\"execute\":");
+    if build.run {
+        if let Some(link_output) = &plan.link_output {
+            let program = link_output.to_string_lossy().to_string();
+            text.push('{');
+            append_json_field(&mut text, "program", &json_string(&program));
+            text.push(',');
+            text.push_str("\"args\":");
+            text.push_str(&json_owned_string_array(&build.run_args));
+            text.push(',');
+            append_json_field(
+                &mut text,
+                "command",
+                &json_string(&shell_join(&program, &build.run_args)),
+            );
+            text.push('}');
+        } else {
+            text.push_str("null");
+        }
     } else {
         text.push_str("null");
     }
@@ -3227,6 +3306,19 @@ fn json_owned_string_array(values: &[String]) -> String {
     }
     out.push(']');
     out
+}
+
+fn emit_spec_json_array(spec: &EmitSpec) -> String {
+    match spec {
+        EmitSpec::Check => json_string_array(vec!["check"]),
+        EmitSpec::Set(set) => {
+            let values = set
+                .iter()
+                .map(|kind| emit_kind_name(*kind).to_string())
+                .collect::<Vec<_>>();
+            json_owned_string_array(&values)
+        }
+    }
 }
 
 fn append_json_field(buf: &mut String, key: &str, raw_json_value: &str) {
@@ -3351,7 +3443,7 @@ fn supported_targets() -> Vec<&'static str> {
 }
 
 fn supported_input_types() -> Vec<&'static str> {
-    vec!["wave", "ir", "bc", "asm", "obj"]
+    vec!["wave", "ir", "bc", "asm", "obj", "archive"]
 }
 
 fn supported_artifact_emit_kinds() -> Vec<&'static str> {
@@ -3681,7 +3773,7 @@ pub fn print_help() {
     println!(
         "  {:<24} {}",
         "--input-type=<kind>".color("38,139,235"),
-        "wave, ir, bc, asm, obj (forced type for all inputs)"
+        "wave, ir, bc, asm, obj, archive (forced type for all inputs)"
     );
     println!(
         "  {:<24} {}",

--- a/tests/codegen_regressions.rs
+++ b/tests/codegen_regressions.rs
@@ -158,10 +158,45 @@ fn vex_cli_print_json_contracts_are_machine_readable() {
             && input_json.contains("\"ir\"")
             && input_json.contains("\"bc\"")
             && input_json.contains("\"asm\"")
-            && input_json.contains("\"obj\""),
+            && input_json.contains("\"obj\"")
+            && input_json.contains("\"archive\""),
         "{}",
         input_json
     );
+
+    let (stdout, _) = run_wavec_capture([
+        OsStr::new("print"),
+        OsStr::new("supported-print-items"),
+        OsStr::new("--format=json"),
+    ]);
+    let print_items = stdout.trim();
+    assert!(
+        print_items.contains("\"cpu-list\"")
+            && print_items.contains("\"target-features\"")
+            && print_items.contains("\"default-linker\"")
+            && print_items.contains("\"supported-input-types\"")
+            && print_items.contains("\"supported-emit-kinds\""),
+        "{}",
+        print_items
+    );
+
+    let (stdout, _) = run_wavec_capture([
+        OsStr::new("print"),
+        OsStr::new("cpu-list"),
+        OsStr::new("--target"),
+        OsStr::new("x86_64-unknown-linux-gnu"),
+        OsStr::new("--format=json"),
+    ]);
+    assert!(stdout.trim().starts_with('['), "{}", stdout);
+
+    let (stdout, _) = run_wavec_capture([
+        OsStr::new("print"),
+        OsStr::new("target-features"),
+        OsStr::new("--target"),
+        OsStr::new("x86_64-unknown-linux-gnu"),
+        OsStr::new("--format=json"),
+    ]);
+    assert!(stdout.contains("\"sse2\""), "{}", stdout);
 }
 
 #[test]
@@ -209,15 +244,19 @@ fun main() -> i32 {
     assert!(stderr.trim().is_empty(), "unexpected stderr:\n{}", stderr);
     let plan = stdout.trim();
     assert!(plan.starts_with('{') && plan.ends_with('}'), "{}", plan);
+    assert!(plan.contains("\"schema_version\":1"), "{}", plan);
     assert!(
         plan.contains("\"target\":\"x86_64-unknown-none-elf\""),
         "{}",
         plan
     );
     assert!(plan.contains("\"mode\":\"compile-only\""), "{}", plan);
+    assert!(plan.contains("\"emit_kinds\":[\"obj\"]"), "{}", plan);
+    assert!(plan.contains("\"control_mode\":null"), "{}", plan);
     assert!(plan.contains("\"freestanding\":true"), "{}", plan);
     assert!(plan.contains("\"compile\""), "{}", plan);
     assert!(plan.contains("\"link\":null"), "{}", plan);
+    assert!(plan.contains("\"execute\":null"), "{}", plan);
 
     let syntax_src = write_wave(
         &dir,
@@ -244,6 +283,186 @@ fun main( {
     assert!(stderr.contains("\"kind\":\"syntax-error\""), "{}", stderr);
     assert!(stderr.contains("\"line\":"), "{}", stderr);
     assert!(stderr.contains("\"column\":"), "{}", stderr);
+
+    let ordered_format = run_wavec_raw([
+        OsStr::new("--error-format=human"),
+        OsStr::new("build"),
+        OsStr::new("--bad-option"),
+        OsStr::new("--error-format=json"),
+    ]);
+    assert_eq!(ordered_format.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&ordered_format.stderr);
+    assert!(
+        stderr.contains("\"kind\":\"usage\""),
+        "later build-level json format must control parser errors:\n{}",
+        stderr
+    );
+}
+
+#[test]
+fn vex_cli_mixed_inputs_and_mode_conflicts_are_stable() {
+    let dir = temp_case_dir("vex-cli-mixed-inputs");
+    let src = write_wave(
+        &dir,
+        "main.wave",
+        r#"
+fun main() -> i32 {
+    return 0;
+}
+"#,
+    );
+    let obj = dir.join("native.o");
+    let archive = dir.join("libnative.a");
+    fs::write(&obj, b"not-a-real-object").unwrap();
+    fs::write(&archive, b"not-a-real-archive").unwrap();
+
+    let out_dir = dir.join("artifacts");
+    let target_dir = dir.join("intermediate");
+    let binary = dir.join("app");
+    let (stdout, stderr) = run_wavec_capture([
+        OsStr::new("--error-format=json"),
+        OsStr::new("build"),
+        src.as_os_str(),
+        obj.as_os_str(),
+        archive.as_os_str(),
+        OsStr::new("--emit=obj,bin"),
+        OsStr::new("--dry-run"),
+        OsStr::new("--out-dir"),
+        out_dir.as_os_str(),
+        OsStr::new("--target-dir"),
+        target_dir.as_os_str(),
+        OsStr::new("-o"),
+        binary.as_os_str(),
+    ]);
+    assert!(stderr.trim().is_empty(), "unexpected stderr:\n{}", stderr);
+    let plan = stdout.trim();
+    assert!(plan.contains("\"kind\":\"wave\""), "{}", plan);
+    assert!(plan.contains("\"kind\":\"obj\""), "{}", plan);
+    assert!(plan.contains("\"kind\":\"archive\""), "{}", plan);
+    assert!(
+        plan.contains("\"emit_kinds\":[\"obj\",\"bin\"]"),
+        "{}",
+        plan
+    );
+    assert!(
+        plan.contains(&format!("\"output\":\"{}\"", binary.to_string_lossy())),
+        "-o must apply to final linked binary only:\n{}",
+        plan
+    );
+    assert!(
+        plan.contains(&format!(
+            "\"output\":\"{}\"",
+            out_dir.join("main.o").to_string_lossy()
+        )),
+        "obj artifact must follow --out-dir, not -o:\n{}",
+        plan
+    );
+    assert!(
+        plan.contains(&format!("\"{}\"", archive.to_string_lossy())),
+        "archive input must be forwarded to the link plan:\n{}",
+        plan
+    );
+
+    let run_plan = run_wavec_raw([
+        OsStr::new("--error-format=json"),
+        OsStr::new("build"),
+        src.as_os_str(),
+        OsStr::new("--run"),
+        OsStr::new("--dry-run"),
+        OsStr::new("--"),
+        OsStr::new("arg one"),
+        OsStr::new("--flag"),
+    ]);
+    assert!(
+        run_plan.status.success(),
+        "run dry-run failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run_plan.stdout),
+        String::from_utf8_lossy(&run_plan.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&run_plan.stdout);
+    assert!(stdout.contains("\"mode\":\"build+run\""), "{}", stdout);
+    assert!(stdout.contains("\"execute\":{"), "{}", stdout);
+    assert!(
+        stdout.contains("\"args\":[\"arg one\",\"--flag\"]"),
+        "{}",
+        stdout
+    );
+
+    let cases: &[(&str, &[&str], &[&str])] = &[
+        (
+            "check cannot be combined",
+            &["build", "main.wave", "--emit=check,ast"],
+            &["--emit=check", "alone"],
+        ),
+        (
+            "link-only obj emit conflict",
+            &["build", "native.o", "--link-only", "--emit=obj"],
+            &["--link-only", "--emit=bin"],
+        ),
+        (
+            "shared static conflict",
+            &["build", "main.wave", "--shared", "--static", "--dry-run"],
+            &["--shared", "--static"],
+        ),
+        (
+            "run shared conflict",
+            &["build", "main.wave", "--shared", "--run", "--dry-run"],
+            &["--run", "--shared"],
+        ),
+        (
+            "no-pie relocation conflict",
+            &[
+                "-C",
+                "relocation-model=pie",
+                "build",
+                "main.wave",
+                "--no-pie",
+                "--dry-run",
+            ],
+            &["--no-pie", "relocation-model=pie"],
+        ),
+        (
+            "forced input conflict",
+            &["build", "native.o", "--input-type=wave", "--dry-run"],
+            &["--input-type=wave", "conflicts"],
+        ),
+        (
+            "unknown input inference",
+            &["build", "unknown.blob", "--dry-run"],
+            &["cannot infer input type", "--input-type"],
+        ),
+    ];
+
+    for (name, args, needles) in cases {
+        let full_args = std::iter::once("--error-format=json")
+            .chain(args.iter().copied())
+            .map(OsStr::new);
+        let out = run_wavec_raw(full_args);
+        assert!(
+            !out.status.success(),
+            "{} unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
+            name,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert_eq!(out.status.code(), Some(2), "{}", name);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("\"kind\":\"usage\""),
+            "{}: {}",
+            name,
+            stderr
+        );
+        for needle in *needles {
+            assert!(
+                stderr.contains(needle),
+                "{} missing '{}': {}",
+                name,
+                needle,
+                stderr
+            );
+        }
+    }
 }
 
 #[test]

--- a/tests/codegen_regressions.rs
+++ b/tests/codegen_regressions.rs
@@ -105,6 +105,23 @@ fn bytes_contains(haystack: &[u8], needle: &[u8]) -> bool {
         .any(|window| window == needle)
 }
 
+fn json_string_for_test(value: &str) -> String {
+    let mut out = String::from("\"");
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
 fn run_link_tests_enabled() -> bool {
     std::env::var_os("WAVE_RUN_LINK_TESTS").is_some()
 }
@@ -345,20 +362,23 @@ fun main() -> i32 {
         plan
     );
     assert!(
-        plan.contains(&format!("\"output\":\"{}\"", binary.to_string_lossy())),
+        plan.contains(&format!(
+            "\"output\":{}",
+            json_string_for_test(&binary.to_string_lossy())
+        )),
         "-o must apply to final linked binary only:\n{}",
         plan
     );
     assert!(
         plan.contains(&format!(
-            "\"output\":\"{}\"",
-            out_dir.join("main.o").to_string_lossy()
+            "\"output\":{}",
+            json_string_for_test(&out_dir.join("main.o").to_string_lossy())
         )),
         "obj artifact must follow --out-dir, not -o:\n{}",
         plan
     );
     assert!(
-        plan.contains(&format!("\"{}\"", archive.to_string_lossy())),
+        plan.contains(&json_string_for_test(&archive.to_string_lossy())),
         "archive input must be forwarded to the link plan:\n{}",
         plan
     );


### PR DESCRIPTION
## Summary

Stabilizes the wavec CLI contract used by Vex and other build tooling.

## Changes

- Adds `.a` static archive input inference as a link-ready `archive` input kind.
- Extends `--dry-run --error-format=json` with versioned and structured fields for emit kinds, control mode, forced input type, link command parts, and run execution arguments.
- Tightens CLI validation around link-only inputs, object-only builds, and JSON error-format detection.
- Adds regression coverage for machine-readable print output, mixed input dry-run plans, run argument forwarding, and invalid flag combinations.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked --all-targets`
- `python3 -m py_compile x.py tools/run_tests.py`
- `python3 tools/run_tests.py`
