### PR TITLE
Relicense the Wave standard library under Apache 2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,9 +184,13 @@ Small, focused PRs are preferred.
 
 ## 11. License
 
-By contributing to Wave, you agree that your contributions are licensed under:
+By contributing to Wave, you agree that your contributions are licensed under
+the license governing the part of the repository you modify:
 
-[Mozilla Public License 2.0](LICENSE)
+- Contributions outside [`std/`](std/) are licensed under the
+  [Mozilla Public License 2.0](LICENSE).
+- Contributions to the Wave standard library under [`std/`](std/) are licensed
+  under the [Apache License 2.0](std/LICENSE).
 
 ---
 

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -12,5 +12,6 @@ Contributors:
 Copyright ownership of individual source files
 is indicated in the file headers.
 
-Unless otherwise noted, all contributions to this project
-are licensed under the Mozilla Public License v2.0 (MPL-2.0).
+Unless otherwise noted, contributions outside std/ are licensed under the
+Mozilla Public License v2.0 (MPL-2.0). Contributions to the Wave standard
+library under std/ are licensed under the Apache License 2.0 (Apache-2.0).

--- a/NOTICE
+++ b/NOTICE
@@ -7,10 +7,16 @@ maintained by the Wave Foundation.
 Copyright (c) 2024–2026 Wave Foundation
 Copyright (c) 2024–2026 LunaStev and contributors
 
-This project is licensed under the Mozilla Public License v2.0 (MPL-2.0).
+The Wave compiler and repository components outside std/ are licensed under
+the Mozilla Public License v2.0 (MPL-2.0).
+
+The Wave standard library under std/ is a separate work licensed under the
+Apache License 2.0 (Apache-2.0). See std/LICENSE.
 
 Re-implementations of the Wave language specification are permitted.
-However, reuse of Wave source files must comply with the terms of the MPL-2.0.
+However, reuse of Wave compiler source files must comply with the terms of the
+MPL-2.0, while reuse of standard library source files must comply with the
+Apache-2.0 license.
 
 The names "Wave", "Wave Language", "Wave Compiler", and related project names
 may be considered trademarks of the Wave Foundation.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Created by <a href="https://github.com/LunaStev" style="color: #777; text-decora
 <a href="https://discord.gg/3nev5nHqq9">
 <img src="https://img.shields.io/badge/Discord-Join%20Us-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" />
 </a>
-<a href="https://github.com/wavefnd/Wave/blob/master/LICENSE">
-<img src="https://img.shields.io/badge/License-MPL%202.0-blue?style=for-the-badge" alt="License"/>
+<a href="#license">
+<img src="https://img.shields.io/badge/License-MPL%202.0%20%7C%20Apache%202.0-blue?style=for-the-badge" alt="Licenses"/>
 </a>
 </div>
 </div>
@@ -121,6 +121,16 @@ Contributions are welcome! Please read the [contributing guidelines](CONTRIBUTIN
 
 ---
 
+## License
+
+- The Wave compiler and repository components outside [`std/`](std/) are
+  licensed under the [Mozilla Public License 2.0](LICENSE).
+- The Wave standard library under [`std/`](std/) is licensed separately under
+  the [Apache License 2.0](std/LICENSE), allowing it to be modified,
+  redistributed, and embedded in other products under that license.
+
+---
+
 ## What can do?
 
 Check https://github.com/wavefnd/Wave/issues/328 to see useful programs created with Wave.
@@ -135,4 +145,4 @@ Check https://github.com/wavefnd/Wave/issues/328 to see useful programs created 
 
 ---
 
-<p align="center"> <strong>Built with ❤️ by the Wave community</strong><br/> <sub>© 2025 Wave Programming Language • LunaStev • <a href="LICENSE">Mozilla Public License 2.0</a></sub> </p>
+<p align="center"> <strong>Built with ❤️ by the Wave community</strong><br/> <sub>© 2025 Wave Programming Language • LunaStev • Compiler: <a href="LICENSE">MPL-2.0</a> • Standard library: <a href="std/LICENSE">Apache-2.0</a></sub> </p>

--- a/std/LICENSE
+++ b/std/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/std/README.md
+++ b/std/README.md
@@ -2,6 +2,15 @@
 
 This is Wave's standard library. This standard library operates independently of Wave's compiler and is not part of the compiler itself.
 
+## License
+
+The Wave standard library in this directory is licensed under the
+[Apache License 2.0](LICENSE). It may be modified, redistributed, and embedded
+in other products under the terms of that license.
+
+The Wave compiler and other repository components outside `std/` remain
+licensed under the repository's [Mozilla Public License 2.0](../LICENSE).
+
 ## Dependency Policy
 
 - `std/libc/*` is the only place where `extern(c)` bindings are allowed.

--- a/std/buffer/alloc.wave
+++ b/std/buffer/alloc.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::mem::alloc");
 import("std::mem::ops");

--- a/std/buffer/read.wave
+++ b/std/buffer/read.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::buffer::types");
 

--- a/std/buffer/types.wave
+++ b/std/buffer/types.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 struct Buffer {
     data: ptr<u8>;

--- a/std/buffer/write.wave
+++ b/std/buffer/write.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::buffer::types");
 import("std::buffer::alloc");

--- a/std/bytes/endian.wave
+++ b/std/bytes/endian.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 fun bytes_swap16(x: i16) -> i16 {
     let v: i32 = x as i32;

--- a/std/env/consts.wave
+++ b/std/env/consts.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 const ENV_ERR_NOT_FOUND: i64 = -2;
 const ENV_ERR_NO_SPACE: i64 = -3;

--- a/std/env/cwd.wave
+++ b/std/env/cwd.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::sys::fs");
 

--- a/std/env/environ.wave
+++ b/std/env/environ.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::sys::env");
 import("std::env::parse");

--- a/std/env/parse.wave
+++ b/std/env/parse.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 fun _env_key_len(name: str) -> i64 {
     let mut n: i64 = 0;

--- a/std/fs/consts.wave
+++ b/std/fs/consts.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // unix-style file modes
 const FS_MODE_USER_RW: i32 = 384;      // 0600

--- a/std/fs/file.wave
+++ b/std/fs/file.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::io::consts");
 import("std::io::fd");

--- a/std/io/consts.wave
+++ b/std/io/consts.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 const IO_STDIN_FD: i64 = 0;
 const IO_STDOUT_FD: i64 = 1;

--- a/std/io/fd.wave
+++ b/std/io/fd.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::io::consts");
 import("std::sys::fs");

--- a/std/libc/arpa.wave
+++ b/std/libc/arpa.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 extern(c) {
     fun inet_addr(cp: ptr<i8>) -> i32;

--- a/std/libc/errno.wave
+++ b/std/libc/errno.wave
@@ -2,12 +2,18 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 extern(c) fun __errno_location() -> ptr<i32>;

--- a/std/libc/netinet.wave
+++ b/std/libc/netinet.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // sockaddr_in (IPv4)
 struct SockAddrIn {

--- a/std/libc/poll.wave
+++ b/std/libc/poll.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // poll events
 const POLLIN: i16  = 0x001;

--- a/std/libc/socket.wave
+++ b/std/libc/socket.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // address families
 const AF_INET: i32 = 2;

--- a/std/libc/stdio.wave
+++ b/std/libc/stdio.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 extern(c) {
     fun puts(s: ptr<i8>) -> i32;

--- a/std/libc/stdlib.wave
+++ b/std/libc/stdlib.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 extern(c) fun malloc(size: i64) -> ptr<i8>;
 extern(c) fun calloc(count: i64, size: i64) -> ptr<i8>;

--- a/std/libc/string.wave
+++ b/std/libc/string.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 extern(c) fun strlen(s: ptr<i8>) -> i64;
 extern(c) fun strcmp(a: ptr<i8>, b: ptr<i8>) -> i32;

--- a/std/libc/time.wave
+++ b/std/libc/time.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 struct TimeSpec {
     sec: i64;

--- a/std/libc/unistd.wave
+++ b/std/libc/unistd.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 extern(c) fun read(fd: i32, buf: ptr<u8>, count: i64) -> i64;
 extern(c) fun write(fd: i32, buf: ptr<u8>, count: i64) -> i64;

--- a/std/manifest.json
+++ b/std/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "std",
   "format": 1,
+  "license": "Apache-2.0",
   "modules": ["string", "math", "sys", "net", "libc", "time", "env", "path", "mem", "buffer", "io", "fs", "bytes", "process"]
 }

--- a/std/math/bits.wave
+++ b/std/math/bits.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 fun is_pow2(x: i32) -> bool {
     if (x <= 0) {

--- a/std/math/float.wave
+++ b/std/math/float.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::math::int");
 

--- a/std/math/int.wave
+++ b/std/math/int.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 fun num_abs<T>(x: T, zero: T) -> T {
     if (x < zero) {

--- a/std/math/num.wave
+++ b/std/math/num.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 fun gcd(a0: i32, b0: i32) -> i32 {
     let mut a: i32 = a0;

--- a/std/math/trig.wave
+++ b/std/math/trig.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::math::int");
 

--- a/std/mem/alloc.wave
+++ b/std/mem/alloc.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::sys::memory");
 import("std::mem::consts");

--- a/std/mem/consts.wave
+++ b/std/mem/consts.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 const MEM_PROT_READ: i64 = 1;
 const MEM_PROT_WRITE: i64 = 2;

--- a/std/mem/cstr.wave
+++ b/std/mem/cstr.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 fun mem_len_cstr(s: str) -> i64 {
     let mut i: i64 = 0;

--- a/std/mem/ops.wave
+++ b/std/mem/ops.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::mem::consts");
 

--- a/std/net/address.wave
+++ b/std/net/address.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::sys::socket");
 

--- a/std/net/poll.wave
+++ b/std/net/poll.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::sys::socket");
 

--- a/std/net/socket_base.wave
+++ b/std/net/socket_base.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::sys::socket");
 import("std::sys::fs");

--- a/std/net/socketopt.wave
+++ b/std/net/socketopt.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::sys::fs");
 import("std::sys::socket");

--- a/std/net/tcp.wave
+++ b/std/net/tcp.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::sys::socket");
 import("std::net::address");

--- a/std/net/udp.wave
+++ b/std/net/udp.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::sys::socket");
 import("std::net::address");

--- a/std/path/analyze.wave
+++ b/std/path/analyze.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::path::core");
 

--- a/std/path/consts.wave
+++ b/std/path/consts.wave
@@ -2,12 +2,18 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 const PATH_ERR_NO_SPACE: i32 = -1;

--- a/std/path/copy.wave
+++ b/std/path/copy.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::path::core");
 import("std::path::analyze");

--- a/std/path/core.wave
+++ b/std/path/core.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 fun path_is_sep(c: u8) -> bool {
     if (c == 47) {

--- a/std/process/consts.wave
+++ b/std/process/consts.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 const PROC_ERR_INTR: i64 = -4;
 

--- a/std/process/core.wave
+++ b/std/process/core.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::process::consts");
 import("std::sys::process");

--- a/std/process/spawn.wave
+++ b/std/process/spawn.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::io::consts");
 import("std::io::fd");

--- a/std/process/wait.wave
+++ b/std/process/wait.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::process::consts");
 import("std::process::core");

--- a/std/string/ascii.wave
+++ b/std/string/ascii.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 fun is_digit(c: u8) -> bool {
     if (c >= 48 && c <= 57) {

--- a/std/string/cmp.wave
+++ b/std/string/cmp.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 fun eq(a: str, b: str) -> bool {
     let mut i: i32 = 0;

--- a/std/string/find.wave
+++ b/std/string/find.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 fun find_char(s: str, c: u8) -> i32 {
     let mut i: i32 = 0;

--- a/std/string/hash.wave
+++ b/std/string/hash.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 fun djb2_32(s: str) -> i32 {
     let mut h: i32 = 5381;

--- a/std/string/len.wave
+++ b/std/string/len.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 fun len(s: str) -> i32 {
     let mut i: i32 = 0;

--- a/std/string/trim.wave
+++ b/std/string/trim.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 fun trim_left_index(s: str) -> i32 {
     let mut i: i32 = 0;

--- a/std/sys/env.wave
+++ b/std/sys/env.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // Environment sys dispatcher

--- a/std/sys/fs.wave
+++ b/std/sys/fs.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // Filesystem sys dispatcher

--- a/std/sys/linux/env.wave
+++ b/std/sys/linux/env.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::sys::linux::fs");
 

--- a/std/sys/linux/fs.wave
+++ b/std/sys/linux/fs.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // Linux x86_64 filesystem syscalls

--- a/std/sys/linux/memory.wave
+++ b/std/sys/linux/memory.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // Linux x86_64 memory syscalls

--- a/std/sys/linux/process.wave
+++ b/std/sys/linux/process.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // Linux x86_64 process syscalls

--- a/std/sys/linux/socket.wave
+++ b/std/sys/linux/socket.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // Linux x86_64 socket syscalls

--- a/std/sys/linux/syscall.wave
+++ b/std/sys/linux/syscall.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // Linux x86_64 syscall interface for Wave

--- a/std/sys/linux/time.wave
+++ b/std/sys/linux/time.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // Linux x86_64 time-related syscalls

--- a/std/sys/linux/tty.wave
+++ b/std/sys/linux/tty.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // Linux x86_64 tty helpers

--- a/std/sys/macos/env.wave
+++ b/std/sys/macos/env.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // ENOSYS-style return for not implemented path.
 const ERR_NOT_IMPLEMENTED: i64 = -38;

--- a/std/sys/macos/fs.wave
+++ b/std/sys/macos/fs.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // macOS filesystem syscalls

--- a/std/sys/macos/memory.wave
+++ b/std/sys/macos/memory.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // macOS memory syscalls

--- a/std/sys/macos/process.wave
+++ b/std/sys/macos/process.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // macOS process syscalls

--- a/std/sys/macos/socket.wave
+++ b/std/sys/macos/socket.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // macOS socket syscalls

--- a/std/sys/macos/syscall.wave
+++ b/std/sys/macos/syscall.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // macOS x86_64 syscall entry helpers

--- a/std/sys/macos/time.wave
+++ b/std/sys/macos/time.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // macOS time syscalls

--- a/std/sys/macos/tty.wave
+++ b/std/sys/macos/tty.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // macOS tty helpers

--- a/std/sys/memory.wave
+++ b/std/sys/memory.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // Memory sys dispatcher

--- a/std/sys/process.wave
+++ b/std/sys/process.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // Process sys dispatcher

--- a/std/sys/socket.wave
+++ b/std/sys/socket.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // Socket sys dispatcher

--- a/std/sys/time.wave
+++ b/std/sys/time.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // Time sys dispatcher

--- a/std/sys/tty.wave
+++ b/std/sys/tty.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // =======================================================
 // TTY sys dispatcher

--- a/std/time/clock.wave
+++ b/std/time/clock.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::sys::time");
 

--- a/std/time/consts.wave
+++ b/std/time/consts.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 const TIME_CLOCK_REALTIME: i32 = 0;
 const TIME_CLOCK_MONOTONIC: i32 = 1;

--- a/std/time/diff.wave
+++ b/std/time/diff.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::sys::time");
 

--- a/std/time/sleep.wave
+++ b/std/time/sleep.wave
@@ -2,13 +2,19 @@
 // Copyright (c) 2024-2026 Wave Foundation
 // Copyright (c) 2024-2026 LunaStev and contributors
 //
-// This Source Code Form is subject to the terms of the
-// Mozilla Public License, v. 2.0.
-// If a copy of the MPL was not distributed with this file,
-// You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// SPDX-License-Identifier: MPL-2.0
-// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import("std::sys::time");
 


### PR DESCRIPTION
## Summary

- license the Wave standard library under Apache License 2.0
- keep the Wave compiler and all repository components outside `std/` under MPL-2.0
- add the canonical Apache 2.0 license text at `std/LICENSE`
- replace the license headers in all 79 standard library Wave source files with `Apache-2.0` SPDX headers
- declare `Apache-2.0` in `std/manifest.json`
- document the repository license boundary in README, NOTICE, COPYRIGHT, and contribution terms

## Motivation

The standard library is maintained in the same repository for distribution and update purposes, but it is independent from the compiler implementation. Apache 2.0 allows companies and other downstream users to modify, redistribute, and embed the standard library in their products under a widely used permissive license, while the compiler remains protected by MPL-2.0.

## License scope

- `std/`: Apache License 2.0
- compiler and all other repository components: Mozilla Public License 2.0

## Validation

- matched `std/LICENSE` byte-for-byte with the Apache Software Foundation license text
- verified all 79 `std/**/*.wave` files use `SPDX-License-Identifier: Apache-2.0`
- verified no MPL or additional use-restriction header remains in standard library source files
- `./tools/check_std_policy.sh`
- `jq empty std/manifest.json`
- `cargo fmt --all -- --check`
- `cargo test --locked`: 22 passed
- `python3 tools/run_tests.py`: 96 passed, 12 skipped, 0 failed, 0 timed out
