### PR TITLE
Remove let syntax and integrate v0.2.1 CI gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,12 +147,20 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all --check
 
+      - name: Check standard library policy
+        run: ./tools/check_std_policy.sh
+
       - name: Run Clippy
         run: cargo clippy --locked --all-targets -- -D warnings
 
+      - name: Build warning-free Rust documentation
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --locked --no-deps --jobs 2
+
       - name: Validate Python tooling
         run: |
-          python3 -m py_compile x.py tools/run_tests.py tools/test_contracts.py tools/test_test_contracts.py
+          python3 -m py_compile x.py tools/check_wave_corpus.py tools/run_tests.py tools/test_contracts.py tools/test_test_contracts.py
           python3 -m unittest tools.test_test_contracts
 
       - name: Run Rust tests
@@ -175,12 +183,123 @@ jobs:
           set -euo pipefail
           target/release/wavec -V
 
+      - name: Check examples and standard library corpus
+        run: python3 tools/check_wave_corpus.py --wavec target/release/wavec
+
       - name: Run Wave end-to-end tests
-        run: python3 tools/run_tests.py
+        run: python3 tools/run_tests.py --report-json wave-e2e-report.json
+
+      - name: Upload Wave end-to-end report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-validation-e2e
+          path: wave-e2e-report.json
+          if-no-files-found: warn
+          retention-days: 7
+
+  validate-riscv64:
+    name: Validate Linux RISC-V 64 release path
+    needs: validate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@1.89.0
+
+      - name: Install LLVM 21 and RISC-V runtime tools
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update
+          sudo apt-get install -y wget software-properties-common
+          wget -q https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh "$LLVM_VERSION"
+          sudo apt-get install -y \
+            binutils-riscv64-linux-gnu \
+            gcc-riscv64-linux-gnu \
+            libc6-dev-riscv64-cross \
+            lld-"$LLVM_VERSION" \
+            qemu-user
+
+          echo "LLVM_SYS_211_PREFIX=$LLVM_PREFIX_LINUX" >> "$GITHUB_ENV"
+          echo "LLVM_CONFIG_PATH=$LLVM_PREFIX_LINUX/bin/llvm-config" >> "$GITHUB_ENV"
+          echo "$LLVM_PREFIX_LINUX/bin" >> "$GITHUB_PATH"
+
+      - name: Verify RISC-V toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          llvm-config --version
+          ld.lld --version
+          riscv64-linux-gnu-gcc --version
+          riscv64-linux-gnu-readelf --version
+          qemu-riscv64 --version
+
+      - name: Install Wave stdlib
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.wave/lib/wave"
+          rm -rf "$HOME/.wave/lib/wave/std"
+          cp -R std "$HOME/.wave/lib/wave/std"
+
+      - name: Build release compiler
+        run: cargo build --locked --release --jobs 2
+
+      - name: Build RISC-V-only LLVM feature set
+        run: >-
+          cargo build --locked --no-default-features
+          --features llvm-target-riscv --jobs 2
+
+      - name: Build core 64-bit LLVM feature set
+        run: >-
+          cargo build --locked --no-default-features
+          --features llvm-target-core64 --jobs 2
+
+      - name: Run RISC-V contract tests
+        env:
+          WAVE_RUN_RISCV64_INTEROP_TESTS: "1"
+        run: >-
+          cargo test --locked --test codegen_regressions
+          riscv64_ --jobs 2 --verbose
+
+      - name: Link and run Linux riscv64 Hello World
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          riscv_sysroot=/usr/riscv64-linux-gnu
+          output_dir="$RUNNER_TEMP/wave-linux-riscv64"
+          binary="$output_dir/test2"
+          mkdir -p "$output_dir"
+
+          target/release/wavec build tests/cases/test2.wave \
+            --target riscv64-unknown-linux-gnu \
+            --sysroot "$riscv_sysroot" \
+            --out-dir "$output_dir"
+
+          test -x "$binary"
+          riscv64-linux-gnu-readelf -h "$binary" \
+            | grep -Eq 'Machine:[[:space:]]+RISC-V'
+          riscv64-linux-gnu-readelf -h "$binary" \
+            | grep -Eq 'Flags:[[:space:]]+0x5.*double-float ABI'
+          riscv64-linux-gnu-readelf -l "$binary" \
+            | grep -Fq '/lib/ld-linux-riscv64-lp64d.so.1'
+
+          runtime_output="$(timeout --signal=TERM --kill-after=5s 30s \
+            qemu-riscv64 -L "$riscv_sysroot" "$binary")"
+          printf '%s\n' "$runtime_output"
+          test "$runtime_output" = 'Hello World'
 
   package-linux:
     name: Package Linux x86_64
-    needs: validate
+    needs: [validate, validate-riscv64]
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -288,7 +407,7 @@ jobs:
 
   package-macos:
     name: Package macOS
-    needs: validate
+    needs: [validate, validate-riscv64]
     runs-on: macos-latest
     timeout-minutes: 60
 
@@ -396,7 +515,7 @@ jobs:
 
   package-windows:
     name: Package Windows x86_64
-    needs: validate
+    needs: [validate, validate-riscv64]
     runs-on: windows-latest
     timeout-minutes: 90
 
@@ -561,7 +680,7 @@ jobs:
 
   publish:
     name: Create GitHub release
-    needs: [validate, package-linux, package-macos, package-windows]
+    needs: [validate, validate-riscv64, package-linux, package-macos, package-windows]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,12 +55,20 @@ jobs:
       - name: Check Rust formatting
         run: cargo fmt --all --check
 
+      - name: Check standard library policy
+        run: ./tools/check_std_policy.sh
+
+      - name: Build warning-free Rust documentation
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --locked --no-deps --jobs 2
+
       - name: Run Clippy
         run: cargo clippy --locked --all-targets -- -D warnings
 
       - name: Validate Python tooling
         run: |
-          python3 -m py_compile x.py tools/run_tests.py tools/test_contracts.py tools/test_test_contracts.py
+          python3 -m py_compile x.py tools/check_wave_corpus.py tools/run_tests.py tools/test_contracts.py tools/test_test_contracts.py
           python3 -m unittest tools.test_test_contracts
 
       - name: Build release compiler
@@ -68,6 +76,9 @@ jobs:
 
       - name: Run Rust tests
         run: cargo test --locked --all-targets --verbose
+
+      - name: Check examples and standard library corpus
+        run: python3 tools/check_wave_corpus.py --wavec target/release/wavec
 
       - name: Run x86_64 SysV ABI contract tests
         if: ${{ always() }}
@@ -78,7 +89,15 @@ jobs:
           x86_64_c_abi_interoperates_with_c --verbose
 
       - name: Run Wave end-to-end tests
-        run: python3 tools/run_tests.py
+        run: python3 tools/run_tests.py --report-json wave-e2e-report.json
+
+      - name: Upload Wave end-to-end report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: wave-e2e-${{ github.job }}
+          path: wave-e2e-report.json
+          if-no-files-found: warn
 
   build-linux-arm64:
     name: Build Linux arm64
@@ -122,7 +141,7 @@ jobs:
 
       - name: Validate Python tooling
         run: |
-          python3 -m py_compile x.py tools/run_tests.py tools/test_contracts.py tools/test_test_contracts.py
+          python3 -m py_compile x.py tools/check_wave_corpus.py tools/run_tests.py tools/test_contracts.py tools/test_test_contracts.py
           python3 -m unittest tools.test_test_contracts
 
       - name: Build release compiler
@@ -141,7 +160,15 @@ jobs:
 
       - name: Run Wave end-to-end tests
         if: ${{ always() }}
-        run: python3 tools/run_tests.py
+        run: python3 tools/run_tests.py --report-json wave-e2e-report.json
+
+      - name: Upload Wave end-to-end report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: wave-e2e-${{ github.job }}
+          path: wave-e2e-report.json
+          if-no-files-found: warn
 
   build-linux-riscv64:
     name: Build Linux riscv64
@@ -204,7 +231,7 @@ jobs:
 
       - name: Validate Python tooling
         run: |
-          python3 -m py_compile x.py tools/run_tests.py tools/test_contracts.py tools/test_test_contracts.py
+          python3 -m py_compile x.py tools/check_wave_corpus.py tools/run_tests.py tools/test_contracts.py tools/test_test_contracts.py
           python3 -m unittest tools.test_test_contracts
 
       - name: Build release compiler
@@ -212,6 +239,16 @@ jobs:
 
       - name: Run Rust tests
         run: cargo test --locked --all-targets --verbose
+
+      - name: Build with the RISC-V-only LLVM feature
+        run: >-
+          cargo build --locked --no-default-features
+          --features llvm-target-riscv --jobs 2
+
+      - name: Build with the core 64-bit LLVM feature set
+        run: >-
+          cargo build --locked --no-default-features
+          --features llvm-target-core64 --jobs 2
 
       - name: Verify bundled Linux CRT matrix
         if: ${{ always() }}
@@ -244,7 +281,15 @@ jobs:
 
       - name: Run Wave end-to-end tests
         if: ${{ always() }}
-        run: python3 tools/run_tests.py
+        run: python3 tools/run_tests.py --report-json wave-e2e-report.json
+
+      - name: Upload Wave end-to-end report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: wave-e2e-${{ github.job }}
+          path: wave-e2e-report.json
+          if-no-files-found: warn
 
       - name: Run RISC-V contract tests
         if: ${{ always() }}
@@ -332,7 +377,7 @@ jobs:
 
       - name: Validate Python tooling
         run: |
-          python3 -m py_compile x.py tools/run_tests.py tools/test_contracts.py tools/test_test_contracts.py
+          python3 -m py_compile x.py tools/check_wave_corpus.py tools/run_tests.py tools/test_contracts.py tools/test_test_contracts.py
           python3 -m unittest tools.test_test_contracts
 
       - name: Build release compiler
@@ -342,12 +387,19 @@ jobs:
         run: cargo test --locked --all-targets --verbose
 
       - name: Run Wave end-to-end tests
-        run: python3 tools/run_tests.py
+        run: python3 tools/run_tests.py --report-json wave-e2e-report.json
+
+      - name: Upload Wave end-to-end report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: wave-e2e-${{ github.job }}
+          path: wave-e2e-report.json
+          if-no-files-found: warn
 
   build-macos-amd64:
     name: Build macOS amd64
     runs-on: macos-15-intel
-    continue-on-error: true
     timeout-minutes: 45
 
     steps:
@@ -396,7 +448,7 @@ jobs:
 
       - name: Validate Python tooling
         run: |
-          python3 -m py_compile x.py tools/run_tests.py tools/test_contracts.py tools/test_test_contracts.py
+          python3 -m py_compile x.py tools/check_wave_corpus.py tools/run_tests.py tools/test_contracts.py tools/test_test_contracts.py
           python3 -m unittest tools.test_test_contracts
 
       - name: Build release compiler
@@ -406,7 +458,15 @@ jobs:
         run: cargo test --locked --all-targets --verbose
 
       - name: Run Wave end-to-end tests
-        run: python3 tools/run_tests.py
+        run: python3 tools/run_tests.py --report-json wave-e2e-report.json
+
+      - name: Upload Wave end-to-end report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: wave-e2e-${{ github.job }}
+          path: wave-e2e-report.json
+          if-no-files-found: warn
 
   build-windows-amd64:
     name: Build Windows GNU amd64
@@ -519,7 +579,7 @@ jobs:
           PYTHONUTF8: "1"
           PYTHONIOENCODING: "utf-8"
         run: |
-          python -m py_compile x.py tools/run_tests.py tools/test_contracts.py tools/test_test_contracts.py
+          python -m py_compile x.py tools/check_wave_corpus.py tools/run_tests.py tools/test_contracts.py tools/test_test_contracts.py
           python -m unittest tools.test_test_contracts
 
       - name: Build release compiler
@@ -535,4 +595,12 @@ jobs:
         env:
           PYTHONUTF8: "1"
           PYTHONIOENCODING: "utf-8"
-        run: python tools/run_tests.py
+        run: python tools/run_tests.py --report-json wave-e2e-report.json
+
+      - name: Upload Wave end-to-end report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: wave-e2e-${{ github.job }}
+          path: wave-e2e-report.json
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Wave is built for software where the machine matters. It combines familiar struc
 
 - **Native by design.** Compile to executables, objects, assembly, LLVM IR, or bitcode.
 - **Low-level when needed.** Use pointers, C ABI boundaries, inline assembly, and freestanding targets when system contracts must stay visible.
-- **Structured language features.** Build with functions, generics, structs, enums, `proto`, arrays, and explicit mutable or immutable bindings.
+- **Structured language features.** Build with functions, generics, structs, enums, `proto`, arrays, and explicit `var` declarations.
 - **Cross-target compilation.** Generate code for x86-64, AArch64, and RISC-V 64 from supported compiler hosts.
 - **Tool-friendly interfaces.** Query targets and compiler capabilities in human-readable or JSON form for build tools and editors.
 
@@ -39,7 +39,7 @@ Wave is under active pre-beta development. Syntax and toolchain contracts are be
 
 ```wave
 fun main() {
-    let language: str = "Wave";
+    var language: str = "Wave";
     var count: i32 = 1;
 
     println("Hello from {} #{}", language, count);

--- a/examples/struct_proto_semantics.wave
+++ b/examples/struct_proto_semantics.wave
@@ -175,23 +175,23 @@ fun test_mutability() {
     a = 20;
     println("var a = {}", a);
 
-    let b: i32 = 30;
-    println("let b = {}", b);
+    var b: i32 = 30;
+    println("var b = {}", b);
 
-    let mut c: Data = Data { value: 5 };
+    var c: Data = Data { value: 5 };
     c.value = 77;
-    println("let mut c.value = {}", c.value);
+    println("var c.value = {}", c.value);
 
-    let mut t: Transform = Transform {
+    var t: Transform = Transform {
         pos: Vec2 { x: 3.0, y: 4.0 },
         scale: 1.0
     };
     t.pos.x = 10.0;
     t.scale = 5.0;
-    println("let mut Transform({}, {}, {})", t.pos.x, t.pos.y, t.scale);
+    println("var Transform({}, {}, {})", t.pos.x, t.pos.y, t.scale);
 
-    let p: Stats = Stats { hp: 50, mp: 25 };
-    println("let p.hp = {}", p.hp);
+    var p: Stats = Stats { hp: 50, mp: 25 };
+    println("var p.hp = {}", p.hp);
 }
 
 fun main() {

--- a/examples/tcp.wave
+++ b/examples/tcp.wave
@@ -4,7 +4,7 @@
 // =========================
 
 fun len(s: str) -> i32 {
-    let mut i: i32 = 0;
+    var i: i32 = 0;
     while (s[i] != 0) {
         i += 1;
     }
@@ -144,7 +144,7 @@ fun _socket_create_tcp() -> i64 {
 }
 
 fun _socket_bind_any(sockfd: i64, port: i16) -> i64 {
-    let mut addr: SockAddrIn = SockAddrIn {
+    var addr: SockAddrIn = SockAddrIn {
         sin_family: 2,
         sin_port: htons(port),
         sin_addr: 0,

--- a/examples/udp.wave
+++ b/examples/udp.wave
@@ -19,7 +19,7 @@ const MAP_PRIVATE: i32 = 2;
 const MAP_ANONYMOUS: i32 = 32;
 
 fun syscall_write(fd: i32, buf: ptr<i8>, len: i32) {
-    let r: i32;
+    var r: i32;
     asm {
         "mov rax, 1"
         "syscall"
@@ -31,7 +31,7 @@ fun syscall_write(fd: i32, buf: ptr<i8>, len: i32) {
 }
 
 fun syscall_read(fd: i32, buf: ptr<i8>, len:i32) -> i32 {
-    let r: i32;
+    var r: i32;
     asm {
         "mov rax, 0"
         "syscall"
@@ -44,7 +44,7 @@ fun syscall_read(fd: i32, buf: ptr<i8>, len:i32) -> i32 {
 }
 
 fun syscall_close(fd: i32) -> i32 {
-    let r: i32;
+    var r: i32;
     asm {
         "mov rax, 3"
         "syscall"
@@ -55,7 +55,7 @@ fun syscall_close(fd: i32) -> i32 {
 }
 
 fun syscall_mmap(addr: ptr<u8>, length: i32, prot: i32, flags: i32, fd: i32, offset: i32) -> ptr<u8> {
-    let r: ptr<u8>;
+    var r: ptr<u8>;
     asm {
         "mov rax, 9"
         "syscall"
@@ -71,7 +71,7 @@ fun syscall_mmap(addr: ptr<u8>, length: i32, prot: i32, flags: i32, fd: i32, off
 }
 
 fun syscall_munmap(addr: ptr<u8>, length: i32) -> i32 {
-    let r: i32;
+    var r: i32;
     asm {
         "mov rax, 11"
         "syscall"
@@ -83,7 +83,7 @@ fun syscall_munmap(addr: ptr<u8>, length: i32) -> i32 {
 }
 
 fun main() {
-    let length: i32 = 4096;
+    var length: i32 = 4096;
     var mem: ptr<u8> = syscall_mmap(
         null, length,
         PROT_READ | PROT_WRITE,

--- a/front/parser/src/ast.rs
+++ b/front/parser/src/ast.rs
@@ -325,8 +325,6 @@ pub enum StatementNode {
 pub enum Mutability {
     Static,
     Var,
-    Let,
-    LetMut,
     Const,
 }
 

--- a/front/parser/src/parser/control.rs
+++ b/front/parser/src/parser/control.rs
@@ -233,17 +233,6 @@ fn parse_for_initializer(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> 
             tokens.next(); // consume `var`
             parse_typed_for_initializer(tokens, Mutability::Var)
         }
-        Some(TokenType::Let) => {
-            tokens.next(); // consume `let`
-            let mutability = if matches!(tokens.peek().map(|t| &t.token_type), Some(TokenType::Mut))
-            {
-                tokens.next(); // consume `mut`
-                Mutability::LetMut
-            } else {
-                Mutability::Let
-            };
-            parse_typed_for_initializer(tokens, mutability)
-        }
         Some(TokenType::Const) => {
             println!("Error: `const` is not allowed in local for-loop initializer");
             None

--- a/front/parser/src/parser/decl.rs
+++ b/front/parser/src/parser/decl.rs
@@ -83,28 +83,8 @@ where
     None
 }
 
-pub fn parse_variable_decl(
-    tokens: &mut Peekable<Iter<'_, Token>>,
-    is_const: bool,
-) -> Option<ASTNode> {
-    let mut mutability = if is_const {
-        Mutability::Const
-    } else {
-        Mutability::Let
-    };
-
-    skip_ws(tokens);
-    if !is_const {
-        if let Some(Token {
-            token_type: TokenType::Mut,
-            ..
-        }) = tokens.peek()
-        {
-            tokens.next(); // consume `mut`
-            mutability = Mutability::LetMut;
-        }
-    }
-
+pub fn parse_const_decl(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
+    let mutability = Mutability::Const;
     skip_ws(tokens);
     let name = match tokens.next() {
         Some(Token {
@@ -112,10 +92,7 @@ pub fn parse_variable_decl(
             ..
         }) => name.clone(),
         _ => {
-            println!(
-                "Expected identifier after `{}`",
-                if is_const { "const" } else { "let" }
-            );
+            println!("Expected identifier after `const`");
             return None;
         }
     };
@@ -219,7 +196,7 @@ pub fn parse_variable_decl(
 }
 
 pub fn parse_const(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
-    parse_variable_decl(tokens, true)
+    parse_const_decl(tokens)
 }
 
 pub fn parse_static(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
@@ -229,10 +206,6 @@ pub fn parse_static(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
     };
     v.mutability = Mutability::Static;
     Some(ASTNode::Variable(v))
-}
-
-pub fn parse_let(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
-    parse_variable_decl(tokens, false)
 }
 
 // VAR parsing

--- a/front/parser/src/parser/functions.rs
+++ b/front/parser/src/parser/functions.rs
@@ -366,9 +366,9 @@ pub fn extract_body(tokens: &mut Peekable<Iter<Token>>) -> Option<Vec<ASTNode>> 
                 tokens.next(); // consume 'var'
                 body.push(parse_var(tokens)?);
             }
-            TokenType::Let => {
-                tokens.next(); // consume 'let'
-                body.push(parse_let(tokens)?);
+            TokenType::Let | TokenType::Mut => {
+                println!("Error: `let` and `let mut` declarations were removed; use `var`");
+                return None;
             }
             TokenType::Const => {
                 println!("Error: `const` is only allowed at top level");

--- a/front/parser/src/parser/stmt.rs
+++ b/front/parser/src/parser/stmt.rs
@@ -19,7 +19,7 @@
 use crate::ast::{ASTNode, AssignOperator, Expression, StatementNode};
 use crate::expr::{is_assignable, parse_expression, parse_expression_from_token};
 use crate::parser::control::{parse_for, parse_if, parse_match, parse_while};
-use crate::parser::decl::{parse_let, parse_var};
+use crate::parser::decl::parse_var;
 use crate::parser::io::*;
 use crate::parser::types::is_expression_start;
 use lexer::token::TokenType;
@@ -176,9 +176,9 @@ pub fn parse_statement(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
             tokens.next();
             parse_var(tokens)
         }
-        TokenType::Let => {
-            tokens.next();
-            parse_let(tokens)
+        TokenType::Let | TokenType::Mut => {
+            println!("Error: `let` and `let mut` declarations were removed; use `var`");
+            None
         }
         TokenType::Const => {
             println!("Error: `const` is only allowed at top level");

--- a/front/parser/src/verification.rs
+++ b/front/parser/src/verification.rs
@@ -1939,7 +1939,7 @@ impl<'a> Validator<'a> {
         binding: &Binding,
         operation: &str,
     ) -> Result<(), String> {
-        if matches!(binding.mutability, Mutability::Let | Mutability::Const) {
+        if matches!(binding.mutability, Mutability::Const) {
             return Err(format!(
                 "cannot {} immutable binding `{}` ({:?})",
                 operation, name, binding.mutability

--- a/llvm/src/codegen/ir.rs
+++ b/llvm/src/codegen/ir.rs
@@ -937,7 +937,7 @@ fn build_module(
                 param.name.clone(),
                 VariableInfo {
                     ptr: alloca,
-                    mutability: Mutability::Let,
+                    mutability: Mutability::Var,
                     ty: param.param_type.clone(),
                 },
             );

--- a/llvm/src/statement/assign.rs
+++ b/llvm/src/statement/assign.rs
@@ -14,7 +14,7 @@
 //!
 //! General lvalue assignment is represented as an expression and handled by
 //! `expression::rvalue::assign`. This path accepts only a named mutable variable
-//! and rejects constants and immutable bindings.
+//! and rejects constants.
 
 use crate::codegen::abi_c::ExternCInfo;
 use crate::codegen::types::TypeFlavor;
@@ -54,7 +54,7 @@ pub(super) fn gen_assign_ir<'ctx>(
         (info.ptr, info.mutability.clone(), info.ty.clone())
     };
 
-    if matches!(dst_mutability, Mutability::Let | Mutability::Const) {
+    if matches!(dst_mutability, Mutability::Const) {
         panic!("Cannot assign to immutable variable '{}'", variable);
     }
 

--- a/llvm/src/statement/variable.rs
+++ b/llvm/src/statement/variable.rs
@@ -26,7 +26,7 @@ use inkwell::targets::TargetData;
 use inkwell::types::{BasicType, BasicTypeEnum, StructType};
 use inkwell::values::{BasicValue, BasicValueEnum, PointerValue};
 
-use parser::ast::{Expression, Mutability, VariableNode, WaveType};
+use parser::ast::{Expression, VariableNode, WaveType};
 
 use std::collections::HashMap;
 
@@ -284,11 +284,6 @@ pub(super) fn gen_variable_ir<'ctx>(
         );
 
         builder.build_store(alloca, casted).unwrap();
-    }
-
-    // mutability check is done elsewhere, but keep for sanity if you want:
-    if matches!(mutability, Mutability::Let) {
-        // nothing to do here
     }
 }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -240,7 +240,7 @@ fn is_declaration_occurrence(source: &str, offset: usize, name: &str) -> bool {
     let line_start = source[..offset].rfind('\n').map_or(0, |index| index + 1);
     let prefix = source[line_start..offset].trim_start();
     [
-        "fun ", "struct ", "proto ", "enum ", "type ", "let ", "var ", "const ", "static ",
+        "fun ", "struct ", "proto ", "enum ", "type ", "var ", "const ", "static ",
     ]
     .iter()
     .any(|keyword| prefix.ends_with(keyword))
@@ -548,12 +548,7 @@ fn find_function_decl(source: &str, fn_name: &str) -> Option<usize> {
 }
 
 fn find_variable_decl(source: &str, var_name: &str) -> Option<usize> {
-    let patterns = [
-        format!("let mut {}", var_name),
-        format!("let {}", var_name),
-        format!("var {}", var_name),
-        format!("const {}", var_name),
-    ];
+    let patterns = [format!("var {}", var_name), format!("const {}", var_name)];
 
     for p in patterns {
         if let Some(idx) = source.find(&p) {

--- a/std/POLICY.md
+++ b/std/POLICY.md
@@ -10,9 +10,9 @@ This document defines non-negotiable rules for the Wave standard library (`std/`
 
 ## 2) Syntax Rules
 
-- `var` declarations are banned in `std/**`.
-- Use `let` for immutable values.
-- Use `let mut` for mutable values.
+- `var` is the only local variable declaration syntax.
+- The retired `let` and `let mut` declaration forms are forbidden.
+- Use top-level `const` declarations for immutable constants.
 
 ## 3) Runtime Contract Rules
 
@@ -21,7 +21,7 @@ This document defines non-negotiable rules for the Wave standard library (`std/`
 
 ## 4) Compatibility Rules
 
-- All `std/` code must remain compatible with the `v0.1.8-pre-beta` compiler baseline.
+- All `std/` code must remain compatible with the compiler version shipped in this repository.
 - Avoid patterns known to break older codegen paths (for example, complex index expressions in single brackets).
 
 ## 5) Automated Check
@@ -36,4 +36,4 @@ The checker validates:
 
 - `extern(c)` appears only under `std/libc/**`
 - no `std::libc::*` import outside `std/libc/**`
-- no `var` usage in `std/**`
+- no retired `let` or `let mut` declarations in Wave sources

--- a/std/buffer/alloc.wave
+++ b/std/buffer/alloc.wave
@@ -21,12 +21,12 @@ import("std::mem::ops");
 import("std::buffer::types");
 
 fun buffer_new(capacity: i64) -> Buffer {
-    let mut cap: i64 = capacity;
+    var cap: i64 = capacity;
     if (cap <= 0) {
         cap = 64;
     }
 
-    let mut data: ptr<u8> = mem_alloc(cap);
+    var data: ptr<u8> = mem_alloc(cap);
     if (data == null) {
         return Buffer {
             data: null,
@@ -47,7 +47,7 @@ fun buffer_new_default() -> Buffer {
 }
 
 fun buffer_free(buf: ptr<Buffer>) -> i64 {
-    let mut ret: i64 = 0;
+    var ret: i64 = 0;
 
     if (deref buf.cap > 0) {
         ret = mem_free(deref buf.data, deref buf.cap);
@@ -68,7 +68,7 @@ fun buffer_reserve(buf: ptr<Buffer>, required_cap: i64) -> i64 {
         return 0;
     }
 
-    let mut new_cap: i64 = deref buf.cap;
+    var new_cap: i64 = deref buf.cap;
     if (new_cap <= 0) {
         new_cap = 64;
     }
@@ -77,7 +77,7 @@ fun buffer_reserve(buf: ptr<Buffer>, required_cap: i64) -> i64 {
         new_cap = new_cap * 2;
     }
 
-    let mut new_data: ptr<u8> = mem_alloc(new_cap);
+    var new_data: ptr<u8> = mem_alloc(new_cap);
     if (new_data == null) {
         return -1;
     }
@@ -98,7 +98,7 @@ fun buffer_reserve(buf: ptr<Buffer>, required_cap: i64) -> i64 {
 
 fun tbuffer_new<T>(elem_size: i64, initial_cap: i64) -> TypedBuffer<T> {
     if (elem_size <= 0) {
-        let mut empty: TypedBuffer<T>;
+        var empty: TypedBuffer<T>;
         empty.data = null;
         empty.len = 0;
         empty.cap_bytes = 0;
@@ -106,16 +106,16 @@ fun tbuffer_new<T>(elem_size: i64, initial_cap: i64) -> TypedBuffer<T> {
         return empty;
     }
 
-    let mut cap_elems: i64 = initial_cap;
+    var cap_elems: i64 = initial_cap;
     if (cap_elems <= 0) {
         cap_elems = 16;
     }
 
-    let mut cap_bytes: i64 = cap_elems * elem_size;
-    let mut data: ptr<u8> = mem_alloc(cap_bytes);
+    var cap_bytes: i64 = cap_elems * elem_size;
+    var data: ptr<u8> = mem_alloc(cap_bytes);
 
     if (data == null) {
-        let mut failed: TypedBuffer<T>;
+        var failed: TypedBuffer<T>;
         failed.data = null;
         failed.len = 0;
         failed.cap_bytes = 0;
@@ -123,7 +123,7 @@ fun tbuffer_new<T>(elem_size: i64, initial_cap: i64) -> TypedBuffer<T> {
         return failed;
     }
 
-    let mut created: TypedBuffer<T>;
+    var created: TypedBuffer<T>;
     created.data = data;
     created.len = 0;
     created.cap_bytes = cap_bytes;
@@ -132,7 +132,7 @@ fun tbuffer_new<T>(elem_size: i64, initial_cap: i64) -> TypedBuffer<T> {
 }
 
 fun tbuffer_free<T>(buf: ptr<TypedBuffer<T>>) -> i64 {
-    let mut ret: i64 = 0;
+    var ret: i64 = 0;
 
     if (deref buf.cap_bytes > 0) {
         ret = mem_free(deref buf.data, deref buf.cap_bytes);
@@ -158,12 +158,12 @@ fun tbuffer_reserve<T>(buf: ptr<TypedBuffer<T>>, required_len: i64) -> i64 {
         return 0;
     }
 
-    let mut required_bytes: i64 = required_len * deref buf.elem_size;
+    var required_bytes: i64 = required_len * deref buf.elem_size;
     if (required_bytes <= deref buf.cap_bytes) {
         return 0;
     }
 
-    let mut new_cap_bytes: i64 = deref buf.cap_bytes;
+    var new_cap_bytes: i64 = deref buf.cap_bytes;
     if (new_cap_bytes <= 0) {
         new_cap_bytes = deref buf.elem_size * 16;
     }
@@ -172,12 +172,12 @@ fun tbuffer_reserve<T>(buf: ptr<TypedBuffer<T>>, required_len: i64) -> i64 {
         new_cap_bytes = new_cap_bytes * 2;
     }
 
-    let mut new_data: ptr<u8> = mem_alloc(new_cap_bytes);
+    var new_data: ptr<u8> = mem_alloc(new_cap_bytes);
     if (new_data == null) {
         return -1;
     }
 
-    let mut used_bytes: i64 = deref buf.len * deref buf.elem_size;
+    var used_bytes: i64 = deref buf.len * deref buf.elem_size;
     if (used_bytes > 0) {
         mem_copy(new_data, deref buf.data, used_bytes);
     }

--- a/std/buffer/read.wave
+++ b/std/buffer/read.wave
@@ -39,8 +39,8 @@ fun tbuffer_at<T>(buf: TypedBuffer<T>, index: i64, out_value: ptr<T>) -> bool {
         return false;
     }
 
-    let mut offset_bytes: i64 = index * buf.elem_size;
-    let mut slot: ptr<T> = (buf.data + offset_bytes) as ptr<T>;
+    var offset_bytes: i64 = index * buf.elem_size;
+    var slot: ptr<T> = (buf.data + offset_bytes) as ptr<T>;
     deref out_value = deref slot;
 
     return true;

--- a/std/buffer/write.wave
+++ b/std/buffer/write.wave
@@ -20,14 +20,14 @@ import("std::buffer::types");
 import("std::buffer::alloc");
 
 fun buffer_push(buf: ptr<Buffer>, value: u8) -> i64 {
-    let mut needed: i64 = deref buf.len + 1;
-    let mut ret: i64 = buffer_reserve(buf, needed);
+    var needed: i64 = deref buf.len + 1;
+    var ret: i64 = buffer_reserve(buf, needed);
 
     if (ret < 0) {
         return ret;
     }
 
-    let mut p: ptr<u8> = deref buf.data;
+    var p: ptr<u8> = deref buf.data;
     deref p[deref buf.len] = value;
     deref buf.len = needed;
 
@@ -39,17 +39,17 @@ fun buffer_append(buf: ptr<Buffer>, src: ptr<u8>, size: i64) -> i64 {
         return 0;
     }
 
-    let mut base: i64 = deref buf.len;
-    let mut needed: i64 = base + size;
-    let mut ret: i64 = buffer_reserve(buf, needed);
+    var base: i64 = deref buf.len;
+    var needed: i64 = base + size;
+    var ret: i64 = buffer_reserve(buf, needed);
 
     if (ret < 0) {
         return ret;
     }
 
-    let mut dst: ptr<u8> = deref buf.data;
-    let mut src_idx: i64 = 0;
-    let mut dst_idx: i64 = base;
+    var dst: ptr<u8> = deref buf.data;
+    var src_idx: i64 = 0;
+    var dst_idx: i64 = base;
 
     while (src_idx < size) {
         deref dst[dst_idx] = src[src_idx];
@@ -62,10 +62,10 @@ fun buffer_append(buf: ptr<Buffer>, src: ptr<u8>, size: i64) -> i64 {
 }
 
 fun buffer_append_str(buf: ptr<Buffer>, s: str) -> i64 {
-    let mut i: i64 = 0;
+    var i: i64 = 0;
 
     while (s[i] != 0) {
-        let mut ret: i64 = buffer_push(buf, s[i]);
+        var ret: i64 = buffer_push(buf, s[i]);
         if (ret < 0) {
             return ret;
         }
@@ -80,21 +80,21 @@ fun buffer_set(buf: ptr<Buffer>, index: i64, value: u8) -> bool {
         return false;
     }
 
-    let mut p: ptr<u8> = deref buf.data;
+    var p: ptr<u8> = deref buf.data;
     deref p[index] = value;
     return true;
 }
 
 fun tbuffer_push<T>(buf: ptr<TypedBuffer<T>>, value: T) -> i64 {
-    let mut needed_len: i64 = deref buf.len + 1;
-    let mut ret: i64 = tbuffer_reserve<T>(buf, needed_len);
+    var needed_len: i64 = deref buf.len + 1;
+    var ret: i64 = tbuffer_reserve<T>(buf, needed_len);
 
     if (ret < 0) {
         return ret;
     }
 
-    let mut offset_bytes: i64 = deref buf.len * deref buf.elem_size;
-    let mut slot: ptr<T> = (deref buf.data + offset_bytes) as ptr<T>;
+    var offset_bytes: i64 = deref buf.len * deref buf.elem_size;
+    var slot: ptr<T> = (deref buf.data + offset_bytes) as ptr<T>;
 
     deref slot = value;
     deref buf.len = needed_len;
@@ -107,8 +107,8 @@ fun tbuffer_set<T>(buf: ptr<TypedBuffer<T>>, index: i64, value: T) -> bool {
         return false;
     }
 
-    let mut offset_bytes: i64 = index * deref buf.elem_size;
-    let mut slot: ptr<T> = (deref buf.data + offset_bytes) as ptr<T>;
+    var offset_bytes: i64 = index * deref buf.elem_size;
+    var slot: ptr<T> = (deref buf.data + offset_bytes) as ptr<T>;
     deref slot = value;
 
     return true;

--- a/std/bytes/endian.wave
+++ b/std/bytes/endian.wave
@@ -17,7 +17,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fun bytes_swap16(x: i16) -> i16 {
-    let v: i32 = x as i32;
+    var v: i32 = x as i32;
     return (((v & 255) << 8) | ((v >> 8) & 255)) as i16;
 }
 
@@ -40,42 +40,42 @@ fun bytes_swap64(x: i64) -> i64 {
 }
 
 fun bytes_load_be_i16(src: ptr<u8>) -> i16 {
-    let b0: i16 = src[0] as i16;
-    let b1: i16 = src[1] as i16;
+    var b0: i16 = src[0] as i16;
+    var b1: i16 = src[1] as i16;
     return (b0 << 8) | b1;
 }
 
 fun bytes_load_le_i16(src: ptr<u8>) -> i16 {
-    let b0: i16 = src[0] as i16;
-    let b1: i16 = src[1] as i16;
+    var b0: i16 = src[0] as i16;
+    var b1: i16 = src[1] as i16;
     return b0 | (b1 << 8);
 }
 
 fun bytes_store_be_i16(dst: ptr<u8>, value: i16) {
-    let v: i32 = value as i32;
+    var v: i32 = value as i32;
     deref dst[0] = ((v >> 8) & 255) as u8;
     deref dst[1] = (v & 255) as u8;
 }
 
 fun bytes_store_le_i16(dst: ptr<u8>, value: i16) {
-    let v: i32 = value as i32;
+    var v: i32 = value as i32;
     deref dst[0] = (v & 255) as u8;
     deref dst[1] = ((v >> 8) & 255) as u8;
 }
 
 fun bytes_load_be_i32(src: ptr<u8>) -> i32 {
-    let b0: i32 = src[0] as i32;
-    let b1: i32 = src[1] as i32;
-    let b2: i32 = src[2] as i32;
-    let b3: i32 = src[3] as i32;
+    var b0: i32 = src[0] as i32;
+    var b1: i32 = src[1] as i32;
+    var b2: i32 = src[2] as i32;
+    var b3: i32 = src[3] as i32;
     return (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
 }
 
 fun bytes_load_le_i32(src: ptr<u8>) -> i32 {
-    let b0: i32 = src[0] as i32;
-    let b1: i32 = src[1] as i32;
-    let b2: i32 = src[2] as i32;
-    let b3: i32 = src[3] as i32;
+    var b0: i32 = src[0] as i32;
+    var b1: i32 = src[1] as i32;
+    var b2: i32 = src[2] as i32;
+    var b3: i32 = src[3] as i32;
     return b0 | (b1 << 8) | (b2 << 16) | (b3 << 24);
 }
 
@@ -94,14 +94,14 @@ fun bytes_store_le_i32(dst: ptr<u8>, value: i32) {
 }
 
 fun bytes_load_be_i64(src: ptr<u8>) -> i64 {
-    let b0: i64 = src[0] as i64;
-    let b1: i64 = src[1] as i64;
-    let b2: i64 = src[2] as i64;
-    let b3: i64 = src[3] as i64;
-    let b4: i64 = src[4] as i64;
-    let b5: i64 = src[5] as i64;
-    let b6: i64 = src[6] as i64;
-    let b7: i64 = src[7] as i64;
+    var b0: i64 = src[0] as i64;
+    var b1: i64 = src[1] as i64;
+    var b2: i64 = src[2] as i64;
+    var b3: i64 = src[3] as i64;
+    var b4: i64 = src[4] as i64;
+    var b5: i64 = src[5] as i64;
+    var b6: i64 = src[6] as i64;
+    var b7: i64 = src[7] as i64;
 
     return (b0 << 56)
          | (b1 << 48)
@@ -114,14 +114,14 @@ fun bytes_load_be_i64(src: ptr<u8>) -> i64 {
 }
 
 fun bytes_load_le_i64(src: ptr<u8>) -> i64 {
-    let b0: i64 = src[0] as i64;
-    let b1: i64 = src[1] as i64;
-    let b2: i64 = src[2] as i64;
-    let b3: i64 = src[3] as i64;
-    let b4: i64 = src[4] as i64;
-    let b5: i64 = src[5] as i64;
-    let b6: i64 = src[6] as i64;
-    let b7: i64 = src[7] as i64;
+    var b0: i64 = src[0] as i64;
+    var b1: i64 = src[1] as i64;
+    var b2: i64 = src[2] as i64;
+    var b3: i64 = src[3] as i64;
+    var b4: i64 = src[4] as i64;
+    var b5: i64 = src[5] as i64;
+    var b6: i64 = src[6] as i64;
+    var b7: i64 = src[7] as i64;
 
     return b0
          | (b1 << 8)

--- a/std/env/cwd.wave
+++ b/std/env/cwd.wave
@@ -19,12 +19,12 @@
 import("std::sys::fs");
 
 fun env_getcwd(dst: ptr<u8>, cap: i64) -> i64 {
-    let mut r: i64 = getcwd(dst, cap);
+    var r: i64 = getcwd(dst, cap);
     if (r <= 0) {
         return -1;
     }
 
-    let mut n: i64 = 0;
+    var n: i64 = 0;
     while (dst[n] != 0) {
         n += 1;
     }

--- a/std/env/environ.wave
+++ b/std/env/environ.wave
@@ -25,14 +25,14 @@ struct EnvResult<T> {
 }
 
 fun env_result_ok<T>(value: T) -> EnvResult<T> {
-    let mut result: EnvResult<T>;
+    var result: EnvResult<T>;
     result.ok = true;
     result.value = value;
     return result;
 }
 
 fun env_result_err<T>(fallback: T) -> EnvResult<T> {
-    let mut result: EnvResult<T>;
+    var result: EnvResult<T>;
     result.ok = false;
     result.value = fallback;
     return result;
@@ -47,7 +47,7 @@ fun env_unwrap_or<T>(result: EnvResult<T>, default_value: T) -> T {
 }
 
 fun env_get(name: str, dst: ptr<u8>, dst_cap: i64) -> i64 {
-    let mut key_len: i64 = _env_key_len(name);
+    var key_len: i64 = _env_key_len(name);
 
     if (key_len <= 0) {
         return -4;
@@ -57,17 +57,17 @@ fun env_get(name: str, dst: ptr<u8>, dst_cap: i64) -> i64 {
         return -3;
     }
 
-    let mut raw: array<u8, 32768>;
-    let mut n: i64 = env_read(&raw[0], 32768);
+    var raw: array<u8, 32768>;
+    var n: i64 = env_read(&raw[0], 32768);
 
     if (n <= 0) {
         return -2;
     }
 
-    let mut i: i64 = 0;
+    var i: i64 = 0;
     while (i < n) {
-        let mut entry_start: i64 = i;
-        let mut eq_pos: i64 = -1;
+        var entry_start: i64 = i;
+        var eq_pos: i64 = -1;
 
         while (i < n && raw[i] != 0) {
             if (raw[i] == 61 && eq_pos < 0) {
@@ -76,7 +76,7 @@ fun env_get(name: str, dst: ptr<u8>, dst_cap: i64) -> i64 {
             i += 1;
         }
 
-        let mut entry_end: i64 = i;
+        var entry_end: i64 = i;
 
         if (i < n) {
             i += 1;
@@ -101,8 +101,8 @@ fun env_get(name: str, dst: ptr<u8>, dst_cap: i64) -> i64 {
 }
 
 fun env_exists(name: str) -> bool {
-    let mut tmp: array<u8, 2>;
-    let mut r: i64 = env_get(name, &tmp[0], 2);
+    var tmp: array<u8, 2>;
+    var r: i64 = env_get(name, &tmp[0], 2);
 
     if (r >= 0) {
         return true;
@@ -112,14 +112,14 @@ fun env_exists(name: str) -> bool {
 }
 
 fun env_get_i64(name: str) -> EnvResult<i64> {
-    let mut raw: array<u8, 64>;
-    let mut n: i64 = env_get(name, &raw[0], 64);
+    var raw: array<u8, 64>;
+    var n: i64 = env_get(name, &raw[0], 64);
 
     if (n <= 0) {
         return env_result_err<i64>(0);
     }
 
-    let mut parsed: i64 = 0;
+    var parsed: i64 = 0;
     if (!_env_parse_i64(&raw[0], &parsed)) {
         return env_result_err<i64>(0);
     }
@@ -128,14 +128,14 @@ fun env_get_i64(name: str) -> EnvResult<i64> {
 }
 
 fun env_get_i32(name: str) -> EnvResult<i32> {
-    let mut raw: array<u8, 64>;
-    let mut n: i64 = env_get(name, &raw[0], 64);
+    var raw: array<u8, 64>;
+    var n: i64 = env_get(name, &raw[0], 64);
 
     if (n <= 0) {
         return env_result_err<i32>(0);
     }
 
-    let mut parsed_i64: i64 = 0;
+    var parsed_i64: i64 = 0;
     if (!_env_parse_i64(&raw[0], &parsed_i64)) {
         return env_result_err<i32>(0);
     }

--- a/std/env/parse.wave
+++ b/std/env/parse.wave
@@ -17,7 +17,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fun _env_key_len(name: str) -> i64 {
-    let mut n: i64 = 0;
+    var n: i64 = 0;
 
     while (name[n] != 0) {
         if (name[n] == 61) {
@@ -30,8 +30,8 @@ fun _env_key_len(name: str) -> i64 {
 }
 
 fun _env_match_key(blob: ptr<u8>, start: i64, name: str, key_len: i64) -> bool {
-    let mut blob_idx: i64 = start;
-    let mut name_idx: i64 = 0;
+    var blob_idx: i64 = start;
+    var name_idx: i64 = 0;
 
     while (name_idx < key_len) {
         if (blob[blob_idx] != name[name_idx]) {
@@ -51,14 +51,14 @@ fun _env_copy_value(
     dst: ptr<u8>,
     dst_cap: i64
 ) -> i64 {
-    let mut value_len: i64 = end - begin;
+    var value_len: i64 = end - begin;
 
     if (value_len + 1 > dst_cap) {
         return -3;
     }
 
-    let mut src_idx: i64 = begin;
-    let mut dst_idx: i64 = 0;
+    var src_idx: i64 = begin;
+    var dst_idx: i64 = 0;
     while (dst_idx < value_len) {
         deref dst[dst_idx] = blob[src_idx];
         src_idx += 1;
@@ -70,8 +70,8 @@ fun _env_copy_value(
 }
 
 fun _env_parse_i64(raw: ptr<u8>, out_value: ptr<i64>) -> bool {
-    let mut i: i64 = 0;
-    let mut sign: i64 = 1;
+    var i: i64 = 0;
+    var sign: i64 = 1;
 
     if (raw[0] == 45) {
         sign = -1;
@@ -84,14 +84,14 @@ fun _env_parse_i64(raw: ptr<u8>, out_value: ptr<i64>) -> bool {
         return false;
     }
 
-    let mut value: i64 = 0;
+    var value: i64 = 0;
     while (raw[i] != 0) {
-        let mut c: u8 = raw[i];
+        var c: u8 = raw[i];
         if (c < 48 || c > 57) {
             return false;
         }
 
-        let mut digit: i64 = c - 48;
+        var digit: i64 = c - 48;
         value = (value * 10) + digit;
         i += 1;
     }

--- a/std/fs/file.wave
+++ b/std/fs/file.wave
@@ -53,13 +53,13 @@ fun fs_close(fd: i64) -> i64 {
 }
 
 fun fs_file_size(path: str) -> i64 {
-    let fd: i64 = fs_open_read(path);
+    var fd: i64 = fs_open_read(path);
     if (fd < 0) {
         return fd;
     }
 
-    let sz: i64 = fs_file_size_fd(fd);
-    let cr: i64 = io_close(fd);
+    var sz: i64 = fs_file_size_fd(fd);
+    var cr: i64 = io_close(fd);
 
     if (sz < 0) {
         return sz;
@@ -73,18 +73,18 @@ fun fs_file_size(path: str) -> i64 {
 }
 
 fun fs_file_size_fd(fd: i64) -> i64 {
-    let cur: i64 = lseek(fd, 0, FS_SEEK_CUR);
+    var cur: i64 = lseek(fd, 0, FS_SEEK_CUR);
     if (cur < 0) {
         return cur;
     }
 
-    let end: i64 = lseek(fd, 0, FS_SEEK_END);
+    var end: i64 = lseek(fd, 0, FS_SEEK_END);
     if (end < 0) {
         lseek(fd, cur, FS_SEEK_SET);
         return end;
     }
 
-    let restore: i64 = lseek(fd, cur, FS_SEEK_SET);
+    var restore: i64 = lseek(fd, cur, FS_SEEK_SET);
     if (restore < 0) {
         return restore;
     }
@@ -109,12 +109,12 @@ fun fs_read_all(path: str, dst: ptr<u8>, dst_cap: i64) -> i64 {
         return IO_ERR_INVALID;
     }
 
-    let fd: i64 = fs_open_read(path);
+    var fd: i64 = fs_open_read(path);
     if (fd < 0) {
         return fd;
     }
 
-    let sz: i64 = fs_file_size_fd(fd);
+    var sz: i64 = fs_file_size_fd(fd);
     if (sz < 0) {
         io_close(fd);
         return sz;
@@ -125,8 +125,8 @@ fun fs_read_all(path: str, dst: ptr<u8>, dst_cap: i64) -> i64 {
         return IO_ERR_NO_SPACE;
     }
 
-    let n: i64 = io_read_exact(fd, dst, sz);
-    let cr: i64 = io_close(fd);
+    var n: i64 = io_read_exact(fd, dst, sz);
+    var cr: i64 = io_close(fd);
 
     if (n < 0) {
         return n;
@@ -144,13 +144,13 @@ fun fs_write_all(path: str, src: ptr<u8>, len: i64, mode: i32) -> i64 {
         return IO_ERR_INVALID;
     }
 
-    let fd: i64 = fs_open_write(path, mode);
+    var fd: i64 = fs_open_write(path, mode);
     if (fd < 0) {
         return fd;
     }
 
-    let n: i64 = io_write_all(fd, src, len);
-    let cr: i64 = io_close(fd);
+    var n: i64 = io_write_all(fd, src, len);
+    var cr: i64 = io_close(fd);
 
     if (n < 0) {
         return n;
@@ -168,13 +168,13 @@ fun fs_append_all(path: str, src: ptr<u8>, len: i64, mode: i32) -> i64 {
         return IO_ERR_INVALID;
     }
 
-    let fd: i64 = fs_open_append(path, mode);
+    var fd: i64 = fs_open_append(path, mode);
     if (fd < 0) {
         return fd;
     }
 
-    let n: i64 = io_write_all(fd, src, len);
-    let cr: i64 = io_close(fd);
+    var n: i64 = io_write_all(fd, src, len);
+    var cr: i64 = io_close(fd);
 
     if (n < 0) {
         return n;
@@ -198,21 +198,21 @@ fun fs_copy(
         return IO_ERR_INVALID;
     }
 
-    let src_fd: i64 = fs_open_read(src_path);
+    var src_fd: i64 = fs_open_read(src_path);
     if (src_fd < 0) {
         return src_fd;
     }
 
-    let dst_fd: i64 = fs_open_write(dst_path, mode);
+    var dst_fd: i64 = fs_open_write(dst_path, mode);
     if (dst_fd < 0) {
         io_close(src_fd);
         return dst_fd;
     }
 
-    let copied: i64 = io_copy(src_fd, dst_fd, scratch, scratch_cap);
+    var copied: i64 = io_copy(src_fd, dst_fd, scratch, scratch_cap);
 
-    let src_cr: i64 = io_close(src_fd);
-    let dst_cr: i64 = io_close(dst_fd);
+    var src_cr: i64 = io_close(src_fd);
+    var dst_cr: i64 = io_close(dst_fd);
 
     if (copied < 0) {
         return copied;

--- a/std/io/fd.wave
+++ b/std/io/fd.wave
@@ -33,7 +33,7 @@ fun io_read(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
     }
 
     while (true) {
-        let n: i64 = read(fd, buf, len);
+        var n: i64 = read(fd, buf, len);
         if (n == IO_ERR_INTR) {
             continue;
         }
@@ -49,7 +49,7 @@ fun io_write(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
     }
 
     while (true) {
-        let n: i64 = write(fd, buf, len);
+        var n: i64 = write(fd, buf, len);
         if (n == IO_ERR_INTR) {
             continue;
         }
@@ -68,9 +68,9 @@ fun io_write_all(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
         return 0;
     }
 
-    let mut written: i64 = 0;
+    var written: i64 = 0;
     while (written < len) {
-        let n: i64 = io_write(fd, buf + written, len - written);
+        var n: i64 = io_write(fd, buf + written, len - written);
         if (n < 0) {
             return n;
         }
@@ -94,9 +94,9 @@ fun io_read_exact(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
         return 0;
     }
 
-    let mut total: i64 = 0;
+    var total: i64 = 0;
     while (total < len) {
-        let n: i64 = io_read(fd, buf + total, len - total);
+        var n: i64 = io_read(fd, buf + total, len - total);
         if (n < 0) {
             return n;
         }
@@ -120,9 +120,9 @@ fun io_read_at_most(fd: i64, dst: ptr<u8>, dst_cap: i64) -> i64 {
         return 0;
     }
 
-    let mut total: i64 = 0;
+    var total: i64 = 0;
     while (total < dst_cap) {
-        let n: i64 = io_read(fd, dst + total, dst_cap - total);
+        var n: i64 = io_read(fd, dst + total, dst_cap - total);
         if (n < 0) {
             return n;
         }
@@ -142,9 +142,9 @@ fun io_copy(src_fd: i64, dst_fd: i64, scratch: ptr<u8>, scratch_cap: i64) -> i64
         return IO_ERR_INVALID;
     }
 
-    let mut total: i64 = 0;
+    var total: i64 = 0;
     while (true) {
-        let n: i64 = io_read(src_fd, scratch, scratch_cap);
+        var n: i64 = io_read(src_fd, scratch, scratch_cap);
         if (n < 0) {
             return n;
         }
@@ -153,7 +153,7 @@ fun io_copy(src_fd: i64, dst_fd: i64, scratch: ptr<u8>, scratch_cap: i64) -> i64
             return total;
         }
 
-        let wn: i64 = io_write_all(dst_fd, scratch, n);
+        var wn: i64 = io_write_all(dst_fd, scratch, n);
         if (wn < 0) {
             return wn;
         }

--- a/std/math/bits.wave
+++ b/std/math/bits.wave
@@ -49,8 +49,8 @@ fun low_bit(x: i32) -> i32 {
 }
 
 fun popcount(x0: i32) -> i32 {
-    let mut x: i32 = x0;
-    let mut c: i32 = 0;
+    var x: i32 = x0;
+    var c: i32 = 0;
 
     while (x != 0) {
         x = x & (x - 1);
@@ -65,7 +65,7 @@ fun ctz32(x: i32) -> i32 {
         return 32;
     }
 
-    let lb: i32 = low_bit(x);
+    var lb: i32 = low_bit(x);
     return popcount(lb - 1);
 }
 
@@ -74,8 +74,8 @@ fun bit_length(x0: i32) -> i32 {
         return 0;
     }
 
-    let mut x: i32 = x0;
-    let mut n: i32 = 0;
+    var x: i32 = x0;
+    var n: i32 = 0;
 
     while (x > 0) {
         x = x >> 1;
@@ -134,8 +134,8 @@ fun low_bit_i64(x: i64) -> i64 {
 }
 
 fun popcount64(x0: i64) -> i32 {
-    let mut x: i64 = x0;
-    let mut c: i32 = 0;
+    var x: i64 = x0;
+    var c: i32 = 0;
 
     while (x != 0) {
         x = x & (x - 1);
@@ -150,7 +150,7 @@ fun ctz64(x: i64) -> i32 {
         return 64;
     }
 
-    let lb: i64 = low_bit_i64(x);
+    var lb: i64 = low_bit_i64(x);
     return popcount64(lb - 1);
 }
 
@@ -159,8 +159,8 @@ fun bit_length64(x0: i64) -> i32 {
         return 0;
     }
 
-    let mut x: i64 = x0;
-    let mut n: i32 = 0;
+    var x: i64 = x0;
+    var n: i32 = 0;
 
     while (x > 0) {
         x = x >> 1;

--- a/std/math/int.wave
+++ b/std/math/int.wave
@@ -53,7 +53,7 @@ fun num_clamp<T>(x: T, lo: T, hi: T) -> T {
 }
 
 fun ptr_swap<T>(a: ptr<T>, b: ptr<T>) {
-    let t: T = deref a;
+    var t: T = deref a;
 
     deref a = deref b;
     deref b = t;

--- a/std/math/num.wave
+++ b/std/math/num.wave
@@ -17,8 +17,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fun gcd(a0: i32, b0: i32) -> i32 {
-    let mut a: i32 = a0;
-    let mut b: i32 = b0;
+    var a: i32 = a0;
+    var b: i32 = b0;
 
     if (a < 0) {
         a = -a;
@@ -29,7 +29,7 @@ fun gcd(a0: i32, b0: i32) -> i32 {
     }
 
     while (b != 0) {
-        let t: i32 = a % b;
+        var t: i32 = a % b;
         a = b;
         b = t;
     }
@@ -42,9 +42,9 @@ fun lcm(a: i32, b: i32) -> i32 {
         return 0;
     }
 
-    let g: i32 = gcd(a, b);
-    let x: i32 = a / g;
-    let mut r: i32 = x * b;
+    var g: i32 = gcd(a, b);
+    var x: i32 = a / g;
+    var r: i32 = x * b;
 
     if (r < 0) {
         r = -r;
@@ -54,9 +54,9 @@ fun lcm(a: i32, b: i32) -> i32 {
 }
 
 fun pow_i32(base0: i32, exp0: i32) -> i32 {
-    let mut base: i32 = base0;
-    let mut exp: i32 = exp0;
-    let mut result: i32 = 1;
+    var base: i32 = base0;
+    var exp: i32 = exp0;
+    var result: i32 = 1;
 
     while (exp > 0) {
         if ((exp & 1) == 1) {

--- a/std/math/trig.wave
+++ b/std/math/trig.wave
@@ -26,8 +26,8 @@ fun abs_f64(x: f64) -> f64 {
 }
 
 fun wrap_angle_pi_f64(x: f64) -> f64 {
-    let mut k: i64 = (x / MATH_TWO_PI_F64) as i64;
-    let mut y: f64 = x - (k as f64) * MATH_TWO_PI_F64;
+    var k: i64 = (x / MATH_TWO_PI_F64) as i64;
+    var y: f64 = x - (k as f64) * MATH_TWO_PI_F64;
 
     if (y > MATH_PI_F64) {
         y -= MATH_TWO_PI_F64;
@@ -41,12 +41,12 @@ fun wrap_angle_pi_f64(x: f64) -> f64 {
 }
 
 fun sin_f64(x0: f64) -> f64 {
-    let mut x: f64 = wrap_angle_pi_f64(x0);
-    let mut x2: f64 = x * x;
-    let mut x3: f64 = x * x2;
-    let mut x5: f64 = x3 * x2;
-    let mut x7: f64 = x5 * x2;
-    let mut x9: f64 = x7 * x2;
+    var x: f64 = wrap_angle_pi_f64(x0);
+    var x2: f64 = x * x;
+    var x3: f64 = x * x2;
+    var x5: f64 = x3 * x2;
+    var x7: f64 = x5 * x2;
+    var x9: f64 = x7 * x2;
 
     return x
          - (x3 / 6.0)
@@ -56,11 +56,11 @@ fun sin_f64(x0: f64) -> f64 {
 }
 
 fun cos_f64(x0: f64) -> f64 {
-    let mut x: f64 = wrap_angle_pi_f64(x0);
-    let mut x2: f64 = x * x;
-    let mut x4: f64 = x2 * x2;
-    let mut x6: f64 = x4 * x2;
-    let mut x8: f64 = x6 * x2;
+    var x: f64 = wrap_angle_pi_f64(x0);
+    var x2: f64 = x * x;
+    var x4: f64 = x2 * x2;
+    var x6: f64 = x4 * x2;
+    var x8: f64 = x6 * x2;
 
     return 1.0
          - (x2 / 2.0)
@@ -74,12 +74,12 @@ fun sqrt_f64(x: f64) -> f64 {
         return 0.0;
     }
 
-    let mut g: f64 = x;
+    var g: f64 = x;
     if (g < 1.0) {
         g = 1.0;
     }
 
-    let mut i: i32 = 0;
+    var i: i32 = 0;
     while (i < 16) {
         g = 0.5 * (g + (x / g));
         i += 1;

--- a/std/mem/alloc.wave
+++ b/std/mem/alloc.wave
@@ -25,12 +25,12 @@ fun mem_alloc(size: i64) -> ptr<u8> {
 }
 
 fun mem_alloc_zeroed(size: i64) -> ptr<u8> {
-    let mut p: ptr<u8> = mem_alloc(size);
+    var p: ptr<u8> = mem_alloc(size);
     if (p == null) {
         return null;
     }
 
-    let mut i: i64 = 0;
+    var i: i64 = 0;
     while (i < size) {
         deref p[i] = 0;
         i += 1;
@@ -54,12 +54,12 @@ fun mem_realloc(old_ptr: ptr<u8>, old_size: i64, new_size: i64) -> ptr<u8> {
         return mem_alloc(new_size);
     }
 
-    let mut new_ptr: ptr<u8> = mem_alloc(new_size);
+    var new_ptr: ptr<u8> = mem_alloc(new_size);
     if (new_ptr == null) {
         return null;
     }
 
-    let mut copy_size: i64 = old_size;
+    var copy_size: i64 = old_size;
     if (new_size < copy_size) {
         copy_size = new_size;
     }
@@ -95,12 +95,12 @@ fun mem_realloc_items<T>(
         return null;
     }
 
-    let mut old_size: i64 = 0;
+    var old_size: i64 = 0;
     if (old_count > 0) {
         old_size = old_count * elem_size;
     }
 
-    let mut new_size: i64 = 0;
+    var new_size: i64 = 0;
     if (new_count > 0) {
         new_size = new_count * elem_size;
     }
@@ -177,24 +177,24 @@ fun mem_alloc_aligned(size: i64, align: i64) -> ptr<u8> {
         return null;
     }
 
-    let mut real_align: i64 = align;
+    var real_align: i64 = align;
     if (real_align < 8) {
         real_align = 8;
     }
 
-    let meta_size: i64 = 16;
-    let total_size: i64 = size + real_align + meta_size;
-    let raw: ptr<u8> = mem_alloc(total_size);
+    var meta_size: i64 = 16;
+    var total_size: i64 = size + real_align + meta_size;
+    var raw: ptr<u8> = mem_alloc(total_size);
     if (raw == null) {
         return null;
     }
 
-    let raw_addr: i64 = raw as i64;
-    let base_addr: i64 = raw_addr + meta_size;
-    let aligned_addr: i64 = (base_addr + (real_align - 1)) & ~(real_align - 1);
+    var raw_addr: i64 = raw as i64;
+    var base_addr: i64 = raw_addr + meta_size;
+    var aligned_addr: i64 = (base_addr + (real_align - 1)) & ~(real_align - 1);
 
-    let meta_raw: ptr<i64> = (aligned_addr - 16) as ptr<i64>;
-    let meta_total: ptr<i64> = (aligned_addr - 8) as ptr<i64>;
+    var meta_raw: ptr<i64> = (aligned_addr - 16) as ptr<i64>;
+    var meta_total: ptr<i64> = (aligned_addr - 8) as ptr<i64>;
     deref meta_raw = raw_addr;
     deref meta_total = total_size;
 
@@ -206,11 +206,11 @@ fun mem_free_aligned(p: ptr<u8>) -> i64 {
         return 0;
     }
 
-    let addr: i64 = p as i64;
-    let meta_raw: ptr<i64> = (addr - 16) as ptr<i64>;
-    let meta_total: ptr<i64> = (addr - 8) as ptr<i64>;
+    var addr: i64 = p as i64;
+    var meta_raw: ptr<i64> = (addr - 16) as ptr<i64>;
+    var meta_total: ptr<i64> = (addr - 8) as ptr<i64>;
 
-    let raw_addr: i64 = deref meta_raw;
-    let total_size: i64 = deref meta_total;
+    var raw_addr: i64 = deref meta_raw;
+    var total_size: i64 = deref meta_total;
     return mem_free(raw_addr as ptr<u8>, total_size);
 }

--- a/std/mem/cstr.wave
+++ b/std/mem/cstr.wave
@@ -17,7 +17,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fun mem_len_cstr(s: str) -> i64 {
-    let mut i: i64 = 0;
+    var i: i64 = 0;
 
     while (s[i] != 0) {
         i += 1;
@@ -27,7 +27,7 @@ fun mem_len_cstr(s: str) -> i64 {
 }
 
 fun mem_copy_cstr(dst: ptr<u8>, s: str) -> i64 {
-    let mut i: i64 = 0;
+    var i: i64 = 0;
 
     while (s[i] != 0) {
         deref dst[i] = s[i];
@@ -43,8 +43,8 @@ fun mem_copy_cstr_n(dst: ptr<u8>, dst_cap: i64, s: str) -> i64 {
         return -1;
     }
 
-    let mut i: i64 = 0;
-    let mut max_copy: i64 = dst_cap - 1;
+    var i: i64 = 0;
+    var max_copy: i64 = dst_cap - 1;
 
     while (s[i] != 0 && i < max_copy) {
         deref dst[i] = s[i];
@@ -56,7 +56,7 @@ fun mem_copy_cstr_n(dst: ptr<u8>, dst_cap: i64, s: str) -> i64 {
 }
 
 fun mem_eq_cstr(a: str, b: str) -> bool {
-    let mut i: i64 = 0;
+    var i: i64 = 0;
     while (true) {
         if (a[i] != b[i]) {
             return false;
@@ -71,7 +71,7 @@ fun mem_eq_cstr(a: str, b: str) -> bool {
 }
 
 fun mem_starts_with_cstr(s: str, prefix: str) -> bool {
-    let mut i: i64 = 0;
+    var i: i64 = 0;
     while (prefix[i] != 0) {
         if (s[i] != prefix[i]) {
             return false;
@@ -82,7 +82,7 @@ fun mem_starts_with_cstr(s: str, prefix: str) -> bool {
 }
 
 fun mem_find_cstr_char(s: str, c: u8) -> i64 {
-    let mut i: i64 = 0;
+    var i: i64 = 0;
     while (s[i] != 0) {
         if (s[i] == c) {
             return i;

--- a/std/mem/ops.wave
+++ b/std/mem/ops.wave
@@ -19,7 +19,7 @@
 import("std::mem::consts");
 
 fun mem_set(dst: ptr<u8>, value: u8, size: i64) {
-    let mut i: i64 = 0;
+    var i: i64 = 0;
     while (i < size) {
         deref dst[i] = value;
         i += 1;
@@ -31,7 +31,7 @@ fun mem_zero(dst: ptr<u8>, size: i64) {
 }
 
 fun mem_copy(dst: ptr<u8>, src: ptr<u8>, size: i64) {
-    let mut i: i64 = 0;
+    var i: i64 = 0;
     while (i < size) {
         deref dst[i] = src[i];
         i += 1;
@@ -48,7 +48,7 @@ fun mem_move(dst: ptr<u8>, src: ptr<u8>, size: i64) {
     }
 
     if ((dst as i64) < (src as i64)) {
-        let mut i: i64 = 0;
+        var i: i64 = 0;
         while (i < size) {
             deref dst[i] = src[i];
             i += 1;
@@ -56,7 +56,7 @@ fun mem_move(dst: ptr<u8>, src: ptr<u8>, size: i64) {
         return;
     }
 
-    let mut i: i64 = size;
+    var i: i64 = size;
     while (i > 0) {
         i -= 1;
         deref dst[i] = src[i];
@@ -64,11 +64,11 @@ fun mem_move(dst: ptr<u8>, src: ptr<u8>, size: i64) {
 }
 
 fun mem_cmp(a: ptr<u8>, b: ptr<u8>, size: i64) -> i32 {
-    let mut i: i64 = 0;
+    var i: i64 = 0;
 
     while (i < size) {
-        let mut av: u8 = a[i];
-        let mut bv: u8 = b[i];
+        var av: u8 = a[i];
+        var bv: u8 = b[i];
 
         if (av < bv) {
             return -1;
@@ -93,7 +93,7 @@ fun mem_eq(a: ptr<u8>, b: ptr<u8>, size: i64) -> bool {
 }
 
 fun mem_find_byte(src: ptr<u8>, size: i64, value: u8) -> i64 {
-    let mut i: i64 = 0;
+    var i: i64 = 0;
     while (i < size) {
         if (src[i] == value) {
             return i;
@@ -104,7 +104,7 @@ fun mem_find_byte(src: ptr<u8>, size: i64, value: u8) -> i64 {
 }
 
 fun mem_swap<T>(a: ptr<T>, b: ptr<T>) {
-    let mut tmp: T = deref a;
+    var tmp: T = deref a;
     deref a = deref b;
     deref b = tmp;
 }
@@ -122,7 +122,7 @@ fun mem_set_items<T>(dst: ptr<T>, value: T, count: i64, elem_size: i64) {
         return;
     }
 
-    let mut i: i64 = 0;
+    var i: i64 = 0;
     while (i < count) {
         deref dst[i] = value;
         i += 1;

--- a/std/net/address.wave
+++ b/std/net/address.wave
@@ -50,7 +50,7 @@ fun net_ntohl(x: i32) -> i32 {
 }
 
 fun net_addr_v4(ip_host_order: i32, port_host_order: i16) -> NetAddrV4 {
-    let mut addr_value: NetAddrV4;
+    var addr_value: NetAddrV4;
     addr_value.ip = net_htonl(ip_host_order);
     addr_value.port = net_htons(port_host_order);
     return addr_value;

--- a/std/net/poll.wave
+++ b/std/net/poll.wave
@@ -29,13 +29,13 @@ fun net_poll(fds: ptr<PollFd>, nfds: i64, timeout_ms: i32) -> i64 {
 }
 
 fun net_wait_readable(fd: i64, timeout_ms: i32) -> i64 {
-    let mut pfd: PollFd = PollFd {
+    var pfd: PollFd = PollFd {
         fd: fd as i32,
         events: NET_POLLIN,
         revents: 0
     };
 
-    let r: i64 = net_poll(&pfd, 1, timeout_ms);
+    var r: i64 = net_poll(&pfd, 1, timeout_ms);
     if (r <= 0) {
         return r;
     }
@@ -52,13 +52,13 @@ fun net_wait_readable(fd: i64, timeout_ms: i32) -> i64 {
 }
 
 fun net_wait_writable(fd: i64, timeout_ms: i32) -> i64 {
-    let mut pfd: PollFd = PollFd {
+    var pfd: PollFd = PollFd {
         fd: fd as i32,
         events: NET_POLLOUT,
         revents: 0
     };
 
-    let r: i64 = net_poll(&pfd, 1, timeout_ms);
+    var r: i64 = net_poll(&pfd, 1, timeout_ms);
     if (r <= 0) {
         return r;
     }

--- a/std/net/socket_base.wave
+++ b/std/net/socket_base.wave
@@ -28,7 +28,7 @@ fun net_fd_valid(fd: i64) -> bool {
 }
 
 fun net_set_reuseaddr(fd: i64) -> i64 {
-    let mut one: i32 = 1;
+    var one: i32 = 1;
     return setsockopt(
         fd,
         SOL_SOCKET,
@@ -47,20 +47,20 @@ fun net_socket_udp_v4() -> i64 {
 }
 
 fun net_bind_v4(fd: i64, addr: NetAddrV4) -> i64 {
-    let mut sa: NetSockAddrIn = net_to_sockaddr_v4(addr);
+    var sa: NetSockAddrIn = net_to_sockaddr_v4(addr);
     return bind(fd, &sa, 16);
 }
 
 fun net_connect_v4(fd: i64, addr: NetAddrV4) -> i64 {
-    let mut sa: NetSockAddrIn = net_to_sockaddr_v4(addr);
+    var sa: NetSockAddrIn = net_to_sockaddr_v4(addr);
     return connect(fd, &sa, 16);
 }
 
 fun net_accept_v4(fd: i64, out_addr: ptr<NetAddrV4>) -> i64 {
-    let mut sa: NetSockAddrIn;
-    let mut salen: i32 = 16;
+    var sa: NetSockAddrIn;
+    var salen: i32 = 16;
 
-    let mut cfd: i64 = accept(fd, &sa, &salen);
+    var cfd: i64 = accept(fd, &sa, &salen);
     if (cfd >= 0 && out_addr != null) {
         deref out_addr = net_from_sockaddr_v4(sa);
     }
@@ -73,9 +73,9 @@ fun net_send_all(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
         return 0;
     }
 
-    let mut sent_total: i64 = 0;
+    var sent_total: i64 = 0;
     while (sent_total < len) {
-        let mut n: i64 = send(fd, buf + sent_total, len - sent_total, flags);
+        var n: i64 = send(fd, buf + sent_total, len - sent_total, flags);
         if (n <= 0) {
             if (sent_total == 0) {
                 return n;
@@ -92,9 +92,9 @@ fun net_recv_exact(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
         return 0;
     }
 
-    let mut read_total: i64 = 0;
+    var read_total: i64 = 0;
     while (read_total < len) {
-        let mut n: i64 = recv(fd, buf + read_total, len - read_total, flags);
+        var n: i64 = recv(fd, buf + read_total, len - read_total, flags);
         if (n <= 0) {
             if (read_total == 0) {
                 return n;
@@ -113,7 +113,7 @@ fun net_sendto_v4(
     len: i64,
     flags: i32
 ) -> i64 {
-    let mut sa: NetSockAddrIn = net_to_sockaddr_v4(addr);
+    var sa: NetSockAddrIn = net_to_sockaddr_v4(addr);
     return sendto(fd, buf, len, flags, &sa, 16);
 }
 
@@ -124,10 +124,10 @@ fun net_recvfrom_v4(
     flags: i32,
     out_addr: ptr<NetAddrV4>
 ) -> i64 {
-    let mut sa: NetSockAddrIn;
-    let mut salen: i32 = 16;
+    var sa: NetSockAddrIn;
+    var salen: i32 = 16;
 
-    let mut n: i64 = recvfrom(fd, buf, len, flags, &sa, &salen);
+    var n: i64 = recvfrom(fd, buf, len, flags, &sa, &salen);
     if (n >= 0 && out_addr != null) {
         deref out_addr = net_from_sockaddr_v4(sa);
     }

--- a/std/net/socketopt.wave
+++ b/std/net/socketopt.wave
@@ -20,12 +20,12 @@ import("std::sys::fs");
 import("std::sys::socket");
 
 fun net_set_nonblock(fd: i64, enabled: i32) -> i64 {
-    let flags_raw: i64 = fcntl(fd, FS_F_GETFL, 0);
+    var flags_raw: i64 = fcntl(fd, FS_F_GETFL, 0);
     if (flags_raw < 0) {
         return flags_raw;
     }
 
-    let mut flags: i32 = flags_raw as i32;
+    var flags: i32 = flags_raw as i32;
     if (enabled != 0) {
         flags = flags | FS_O_NONBLOCK;
     } else {
@@ -36,12 +36,12 @@ fun net_set_nonblock(fd: i64, enabled: i32) -> i64 {
 }
 
 fun net_get_nonblock(fd: i64) -> i64 {
-    let flags_raw: i64 = fcntl(fd, FS_F_GETFL, 0);
+    var flags_raw: i64 = fcntl(fd, FS_F_GETFL, 0);
     if (flags_raw < 0) {
         return flags_raw;
     }
 
-    let flags: i32 = flags_raw as i32;
+    var flags: i32 = flags_raw as i32;
     if ((flags & FS_O_NONBLOCK) != 0) {
         return 1;
     }
@@ -50,7 +50,7 @@ fun net_get_nonblock(fd: i64) -> i64 {
 }
 
 fun net_set_reuseaddr_flag(fd: i64, enabled: i32) -> i64 {
-    let mut value: i32 = 0;
+    var value: i32 = 0;
     if (enabled != 0) {
         value = 1;
     }
@@ -65,10 +65,10 @@ fun net_set_reuseaddr_flag(fd: i64, enabled: i32) -> i64 {
 }
 
 fun net_get_reuseaddr_flag(fd: i64) -> i64 {
-    let mut value: i32 = 0;
-    let mut size: i32 = 4;
+    var value: i32 = 0;
+    var size: i32 = 4;
 
-    let r: i64 = getsockopt(
+    var r: i64 = getsockopt(
         fd,
         SOL_SOCKET,
         SO_REUSEADDR,
@@ -87,7 +87,7 @@ fun net_get_reuseaddr_flag(fd: i64) -> i64 {
 }
 
 fun net_set_reuseport_flag(fd: i64, enabled: i32) -> i64 {
-    let mut value: i32 = 0;
+    var value: i32 = 0;
     if (enabled != 0) {
         value = 1;
     }

--- a/std/net/tcp.wave
+++ b/std/net/tcp.wave
@@ -36,14 +36,14 @@ struct TcpStream {
 }
 
 fun _tcp_to_net_addr(addr: TcpAddr) -> NetAddrV4 {
-    let mut value: NetAddrV4;
+    var value: NetAddrV4;
     value.ip = addr.ip;
     value.port = addr.port;
     return value;
 }
 
 fun _tcp_from_net_addr(addr: NetAddrV4) -> TcpAddr {
-    let mut value: TcpAddr;
+    var value: TcpAddr;
     value.ip = addr.ip;
     value.port = addr.port;
     return value;
@@ -78,12 +78,12 @@ fun tcp_bind(port: i16) -> TcpListener {
 }
 
 fun tcp_bind_with_backlog(port: i16, backlog: i32) -> TcpListener {
-    let mut addr: TcpAddr = tcp_addr_any(port);
+    var addr: TcpAddr = tcp_addr_any(port);
     return tcp_bind_addr(addr, backlog);
 }
 
 fun tcp_bind_addr(addr: TcpAddr, backlog: i32) -> TcpListener {
-    let mut fd: i64 = net_socket_tcp_v4();
+    var fd: i64 = net_socket_tcp_v4();
     net_set_reuseaddr(fd);
 
     net_bind_v4(fd, _tcp_to_net_addr(addr));
@@ -93,13 +93,13 @@ fun tcp_bind_addr(addr: TcpAddr, backlog: i32) -> TcpListener {
 }
 
 fun tcp_accept(listener: TcpListener) -> TcpStream {
-    let mut cfd: i64 = net_accept_v4(listener.fd, null);
+    var cfd: i64 = net_accept_v4(listener.fd, null);
     return TcpStream { fd: cfd };
 }
 
 fun tcp_accept_addr(listener: TcpListener, src: ptr<TcpAddr>) -> TcpStream {
-    let mut peer: NetAddrV4;
-    let mut cfd: i64 = net_accept_v4(listener.fd, &peer);
+    var peer: NetAddrV4;
+    var cfd: i64 = net_accept_v4(listener.fd, &peer);
     if (cfd >= 0) {
         deref src = _tcp_from_net_addr(peer);
     }
@@ -111,14 +111,14 @@ fun tcp_close_listener(listener: TcpListener) {
 }
 
 fun tcp_connect(addr: TcpAddr) -> TcpStream {
-    let mut fd: i64 = net_socket_tcp_v4();
+    var fd: i64 = net_socket_tcp_v4();
     net_connect_v4(fd, _tcp_to_net_addr(addr));
     return TcpStream { fd: fd };
 }
 
 fun tcp_try_connect(addr: TcpAddr) -> i64 {
-    let mut fd: i64 = net_socket_tcp_v4();
-    let mut r: i64 = net_connect_v4(fd, _tcp_to_net_addr(addr));
+    var fd: i64 = net_socket_tcp_v4();
+    var r: i64 = net_connect_v4(fd, _tcp_to_net_addr(addr));
     if (r < 0) {
         close(fd);
         return r;
@@ -143,7 +143,7 @@ fun tcp_read_exact(stream: TcpStream, buf: ptr<u8>, len: i64) -> i64 {
 }
 
 fun tcp_write_str(stream: TcpStream, s: str) -> i64 {
-    let mut n: i64 = len(s) as i64;
+    var n: i64 = len(s) as i64;
     if (n <= 0) {
         return 0;
     }

--- a/std/net/udp.wave
+++ b/std/net/udp.wave
@@ -32,14 +32,14 @@ struct UdpSocket {
 }
 
 fun _udp_to_net_addr(addr: UdpAddr) -> NetAddrV4 {
-    let mut value: NetAddrV4;
+    var value: NetAddrV4;
     value.ip = addr.ip;
     value.port = addr.port;
     return value;
 }
 
 fun _udp_from_net_addr(addr: NetAddrV4) -> UdpAddr {
-    let mut value: UdpAddr;
+    var value: UdpAddr;
     value.ip = addr.ip;
     value.port = addr.port;
     return value;
@@ -74,7 +74,7 @@ fun udp_bind(port: i16) -> UdpSocket {
 }
 
 fun udp_bind_addr(addr: UdpAddr) -> UdpSocket {
-    let mut fd: i64 = net_socket_udp_v4();
+    var fd: i64 = net_socket_udp_v4();
     net_set_reuseaddr(fd);
     net_bind_v4(fd, _udp_to_net_addr(addr));
     return UdpSocket { fd: fd };
@@ -94,7 +94,7 @@ fun udp_send_to(
 }
 
 fun udp_send_str_to(sock: UdpSocket, addr: UdpAddr, s: str) -> i64 {
-    let mut n: i64 = len(s) as i64;
+    var n: i64 = len(s) as i64;
     if (n <= 0) {
         return 0;
     }
@@ -111,8 +111,8 @@ fun udp_recv_from(
     len: i64,
     src: ptr<UdpAddr>
 ) -> i64 {
-    let mut peer: NetAddrV4;
-    let mut n: i64 = net_recvfrom_v4(sock.fd, buf, len, 0, &peer);
+    var peer: NetAddrV4;
+    var n: i64 = net_recvfrom_v4(sock.fd, buf, len, 0, &peer);
     if (n >= 0) {
         deref src = _udp_from_net_addr(peer);
     }

--- a/std/path/analyze.wave
+++ b/std/path/analyze.wave
@@ -19,8 +19,8 @@
 import("std::path::core");
 
 fun path_basename_start(path: str) -> i32 {
-    let mut i: i32 = 0;
-    let mut base: i32 = 0;
+    var i: i32 = 0;
+    var base: i32 = 0;
 
     while (path[i] != 0) {
         if (path_is_sep(path[i])) {
@@ -33,20 +33,20 @@ fun path_basename_start(path: str) -> i32 {
 }
 
 fun path_basename_len(path: str) -> i32 {
-    let mut base: i32 = path_basename_start(path);
-    let mut end: i32 = path_len(path);
+    var base: i32 = path_basename_start(path);
+    var end: i32 = path_len(path);
 
     return end - base;
 }
 
 fun path_dirname_len(path: str) -> i32 {
-    let mut base: i32 = path_basename_start(path);
+    var base: i32 = path_basename_start(path);
 
     if (base <= 0) {
         return 0;
     }
 
-    let mut i: i32 = base - 1;
+    var i: i32 = base - 1;
 
     while (i > 0 && path_is_sep(path[i])) {
         i -= 1;
@@ -60,9 +60,9 @@ fun path_dirname_len(path: str) -> i32 {
 }
 
 fun path_ext_start(path: str) -> i32 {
-    let mut base: i32 = path_basename_start(path);
-    let mut i: i32 = base;
-    let mut dot: i32 = -1;
+    var base: i32 = path_basename_start(path);
+    var i: i32 = base;
+    var dot: i32 = -1;
 
     while (path[i] != 0) {
         if (path[i] == 46) {

--- a/std/path/copy.wave
+++ b/std/path/copy.wave
@@ -20,28 +20,28 @@ import("std::path::core");
 import("std::path::analyze");
 
 fun path_join2(dst: ptr<u8>, dst_cap: i32, left: str, right: str) -> i32 {
-    let mut ll: i32 = path_len(left);
-    let mut rl: i32 = path_len(right);
+    var ll: i32 = path_len(left);
+    var rl: i32 = path_len(right);
 
-    let mut need_sep: i32 = 0;
+    var need_sep: i32 = 0;
     if (ll > 0 && rl > 0) {
-        let mut last_left_idx: i32 = ll;
+        var last_left_idx: i32 = ll;
         last_left_idx -= 1;
-        let mut lc: u8 = left[last_left_idx];
-        let mut rc: u8 = right[0];
+        var lc: u8 = left[last_left_idx];
+        var rc: u8 = right[0];
 
         if (!path_is_sep(lc) && !path_is_sep(rc)) {
             need_sep = 1;
         }
     }
 
-    let mut total: i32 = ll + rl + need_sep;
+    var total: i32 = ll + rl + need_sep;
 
     if (total + 1 > dst_cap) {
         return -1;
     }
 
-    let mut k: i32 = 0;
+    var k: i32 = 0;
     while (k < ll) {
         deref dst[k] = left[k];
         k += 1;
@@ -52,8 +52,8 @@ fun path_join2(dst: ptr<u8>, dst_cap: i32, left: str, right: str) -> i32 {
         k += 1;
     }
 
-    let mut src_idx: i32 = 0;
-    let mut dst_idx: i32 = k;
+    var src_idx: i32 = 0;
+    var dst_idx: i32 = k;
     while (src_idx < rl) {
         deref dst[dst_idx] = right[src_idx];
         src_idx += 1;
@@ -65,15 +65,15 @@ fun path_join2(dst: ptr<u8>, dst_cap: i32, left: str, right: str) -> i32 {
 }
 
 fun path_basename_copy(dst: ptr<u8>, dst_cap: i32, path: str) -> i32 {
-    let mut start: i32 = path_basename_start(path);
-    let mut n: i32 = path_basename_len(path);
+    var start: i32 = path_basename_start(path);
+    var n: i32 = path_basename_len(path);
 
     if (n + 1 > dst_cap) {
         return -1;
     }
 
-    let mut src_idx: i32 = start;
-    let mut dst_idx: i32 = 0;
+    var src_idx: i32 = start;
+    var dst_idx: i32 = 0;
     while (dst_idx < n) {
         deref dst[dst_idx] = path[src_idx];
         src_idx += 1;
@@ -85,7 +85,7 @@ fun path_basename_copy(dst: ptr<u8>, dst_cap: i32, path: str) -> i32 {
 }
 
 fun path_dirname_copy(dst: ptr<u8>, dst_cap: i32, path: str) -> i32 {
-    let mut n: i32 = path_dirname_len(path);
+    var n: i32 = path_dirname_len(path);
 
     if (n + 1 > dst_cap) {
         return -1;
@@ -97,7 +97,7 @@ fun path_dirname_copy(dst: ptr<u8>, dst_cap: i32, path: str) -> i32 {
         return 1;
     }
 
-    let mut i: i32 = 0;
+    var i: i32 = 0;
     while (i < n) {
         deref dst[i] = path[i];
         i += 1;

--- a/std/path/core.wave
+++ b/std/path/core.wave
@@ -29,7 +29,7 @@ fun path_is_sep(c: u8) -> bool {
 }
 
 fun path_len(path: str) -> i32 {
-    let mut i: i32 = 0;
+    var i: i32 = 0;
 
     while (path[i] != 0) {
         i += 1;

--- a/std/process/core.wave
+++ b/std/process/core.wave
@@ -41,7 +41,7 @@ fun proc_execve(path: str, argv: ptr<ptr<i8>>, envp: ptr<ptr<i8>>) -> i64 {
 
 fun proc_waitpid_raw(pid: i64, status: ptr<i32>, options: i32) -> i64 {
     while (true) {
-        let r: i64 = waitpid(pid, status, options);
+        var r: i64 = waitpid(pid, status, options);
         if (r == PROC_ERR_INTR) {
             continue;
         }

--- a/std/process/spawn.wave
+++ b/std/process/spawn.wave
@@ -42,7 +42,7 @@ fun _proc_dup_child_fd(src_fd: i64, dst_fd: i64) -> i64 {
         return 0;
     }
 
-    let r: i64 = io_dup2(src_fd, dst_fd);
+    var r: i64 = io_dup2(src_fd, dst_fd);
     if (r < 0) {
         return r;
     }
@@ -59,7 +59,7 @@ fun proc_spawn_exec_raw(
     stdout_fd: i64,
     stderr_fd: i64
 ) -> i64 {
-    let pid: i64 = proc_fork();
+    var pid: i64 = proc_fork();
     if (pid < 0) {
         return pid;
     }
@@ -77,7 +77,7 @@ fun proc_spawn_exec_raw(
             proc_exit(PROC_EXIT_DUP_FAIL);
         }
 
-        let er: i64 = proc_execve(path, argv, envp);
+        var er: i64 = proc_execve(path, argv, envp);
         if (er < 0) {
             proc_exit(PROC_EXIT_EXEC_FAIL);
         }
@@ -93,8 +93,8 @@ fun proc_spawn(path: str, argv: ptr<ptr<i8>>, envp: ptr<ptr<i8>>) -> i64 {
 }
 
 fun proc_make_pipe() -> ProcPipeResult {
-    let mut fds: array<i32, 2>;
-    let r: i64 = io_pipe(&fds[0]);
+    var fds: array<i32, 2>;
+    var r: i64 = io_pipe(&fds[0]);
     if (r < 0) {
         return ProcPipeResult {
             status: r,
@@ -115,7 +115,7 @@ fun proc_spawn_capture_stdout(
     argv: ptr<ptr<i8>>,
     envp: ptr<ptr<i8>>
 ) -> ProcSpawnStdoutResult {
-    let pipe_r: ProcPipeResult = proc_make_pipe();
+    var pipe_r: ProcPipeResult = proc_make_pipe();
     if (pipe_r.status < 0) {
         return ProcSpawnStdoutResult {
             status: pipe_r.status,
@@ -124,7 +124,7 @@ fun proc_spawn_capture_stdout(
         };
     }
 
-    let pid: i64 = proc_spawn_exec_raw(path, argv, envp, -1, pipe_r.write_fd, -1);
+    var pid: i64 = proc_spawn_exec_raw(path, argv, envp, -1, pipe_r.write_fd, -1);
     io_close(pipe_r.write_fd);
     if (pid < 0) {
         io_close(pipe_r.read_fd);

--- a/std/process/wait.wave
+++ b/std/process/wait.wave
@@ -40,7 +40,7 @@ fun proc_status_exit_code(status: i32) -> i32 {
 }
 
 fun proc_status_signaled(status: i32) -> bool {
-    let sig: i32 = status & 127;
+    var sig: i32 = status & 127;
     if (sig != 0 && sig != 127) {
         return true;
     }

--- a/std/string/cmp.wave
+++ b/std/string/cmp.wave
@@ -17,11 +17,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fun eq(a: str, b: str) -> bool {
-    let mut i: i32 = 0;
+    var i: i32 = 0;
 
     while (true) {
-        let ca: u8 = a[i];
-        let cb: u8 = b[i];
+        var ca: u8 = a[i];
+        var cb: u8 = b[i];
 
         if (ca != cb) {
             return false;
@@ -38,11 +38,11 @@ fun eq(a: str, b: str) -> bool {
 }
 
 fun cmp(a: str, b: str) -> i32 {
-    let mut i: i32 = 0;
+    var i: i32 = 0;
 
     while (true) {
-        let ca: u8 = a[i];
-        let cb: u8 = b[i];
+        var ca: u8 = a[i];
+        var cb: u8 = b[i];
 
         if (ca < cb) {
             return -1;
@@ -63,7 +63,7 @@ fun cmp(a: str, b: str) -> i32 {
 }
 
 fun starts_with(s: str, prefix: str) -> bool {
-    let mut i: i32 = 0;
+    var i: i32 = 0;
 
     while (prefix[i] != 0) {
         if (s[i] != prefix[i]) {
@@ -77,12 +77,12 @@ fun starts_with(s: str, prefix: str) -> bool {
 }
 
 fun ends_with(s: str, suffix: str) -> bool {
-    let mut sl: i32 = 0;
+    var sl: i32 = 0;
     while (s[sl] != 0) {
         sl += 1;
     }
 
-    let mut tl: i32 = 0;
+    var tl: i32 = 0;
     while (suffix[tl] != 0) {
         tl += 1;
     }
@@ -91,9 +91,9 @@ fun ends_with(s: str, suffix: str) -> bool {
         return false;
     }
 
-    let mut i: i32 = 0;
+    var i: i32 = 0;
     while (i < tl) {
-        let idx: i32 = (sl - tl) + i;
+        var idx: i32 = (sl - tl) + i;
         if (s[idx] != suffix[i]) {
             return false;
         }

--- a/std/string/find.wave
+++ b/std/string/find.wave
@@ -17,7 +17,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fun find_char(s: str, c: u8) -> i32 {
-    let mut i: i32 = 0;
+    var i: i32 = 0;
 
     while (s[i] != 0) {
         if (s[i] == c) {
@@ -31,8 +31,8 @@ fun find_char(s: str, c: u8) -> i32 {
 }
 
 fun rfind_char(s: str, c: u8) -> i32 {
-    let mut last: i32 = -1;
-    let mut i: i32 = 0;
+    var last: i32 = -1;
+    var i: i32 = 0;
 
     while (s[i] != 0) {
         if (s[i] == c) {
@@ -54,8 +54,8 @@ fun contains_char(s: str, c: u8) -> bool {
 }
 
 fun count_char(s: str, c: u8) -> i32 {
-    let mut i: i32 = 0;
-    let mut count: i32 = 0;
+    var i: i32 = 0;
+    var count: i32 = 0;
 
     while (s[i] != 0) {
         if (s[i] == c) {
@@ -73,12 +73,12 @@ fun find(s: str, needle: str) -> i32 {
         return 0;
     }
 
-    let mut nl: i32 = 0;
+    var nl: i32 = 0;
     while (needle[nl] != 0) {
         nl += 1;
     }
 
-    let mut sl: i32 = 0;
+    var sl: i32 = 0;
     while (s[sl] != 0) {
         sl += 1;
     }
@@ -87,13 +87,13 @@ fun find(s: str, needle: str) -> i32 {
         return -1;
     }
 
-    let mut i: i32 = 0;
+    var i: i32 = 0;
     while (i <= (sl - nl)) {
-        let mut j: i32 = 0;
-        let mut ok: bool = true;
+        var j: i32 = 0;
+        var ok: bool = true;
 
         while (j < nl) {
-            let idx: i32 = i + j;
+            var idx: i32 = i + j;
             if (s[idx] != needle[j]) {
                 ok = false;
                 j = nl;
@@ -125,12 +125,12 @@ fun count(s: str, needle: str) -> i32 {
         return 0;
     }
 
-    let mut nl: i32 = 0;
+    var nl: i32 = 0;
     while (needle[nl] != 0) {
         nl += 1;
     }
 
-    let mut sl: i32 = 0;
+    var sl: i32 = 0;
     while (s[sl] != 0) {
         sl += 1;
     }
@@ -139,15 +139,15 @@ fun count(s: str, needle: str) -> i32 {
         return 0;
     }
 
-    let mut i: i32 = 0;
-    let mut total: i32 = 0;
+    var i: i32 = 0;
+    var total: i32 = 0;
 
     while (i <= (sl - nl)) {
-        let mut j: i32 = 0;
-        let mut ok: bool = true;
+        var j: i32 = 0;
+        var ok: bool = true;
 
         while (j < nl) {
-            let idx: i32 = i + j;
+            var idx: i32 = i + j;
             if (s[idx] != needle[j]) {
                 ok = false;
                 j = nl;

--- a/std/string/hash.wave
+++ b/std/string/hash.wave
@@ -17,11 +17,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fun djb2_32(s: str) -> i32 {
-    let mut h: i32 = 5381;
-    let mut i: i32 = 0;
+    var h: i32 = 5381;
+    var i: i32 = 0;
 
     while (s[i] != 0) {
-        let mut c: i32 = s[i];
+        var c: i32 = s[i];
         h = ((h << 5) + h) ^ c;
         i += 1;
     }
@@ -30,11 +30,11 @@ fun djb2_32(s: str) -> i32 {
 }
 
 fun fnv1a_64(s: str) -> i64 {
-    let mut h: i64 = 1469598103934665603;
-    let mut i: i32 = 0;
+    var h: i64 = 1469598103934665603;
+    var i: i32 = 0;
 
     while (s[i] != 0) {
-        let mut c: i64 = s[i];
+        var c: i64 = s[i];
         h = h ^ c;
         h = h * 1099511628211;
         i += 1;

--- a/std/string/len.wave
+++ b/std/string/len.wave
@@ -17,7 +17,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fun len(s: str) -> i32 {
-    let mut i: i32 = 0;
+    var i: i32 = 0;
     while (s[i] != 0) {
         i += 1;
     }

--- a/std/string/trim.wave
+++ b/std/string/trim.wave
@@ -17,10 +17,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fun trim_left_index(s: str) -> i32 {
-    let mut i: i32 = 0;
+    var i: i32 = 0;
 
     while (s[i] != 0) {
-        let c: u8 = s[i];
+        var c: u8 = s[i];
 
         if (c == 32 || c == 9 || c == 10 || c == 13) {
             i += 1;
@@ -33,7 +33,7 @@ fun trim_left_index(s: str) -> i32 {
 }
 
 fun trim_right_index(s: str) -> i32 {
-    let mut sl: i32 = 0;
+    var sl: i32 = 0;
 
     while (s[sl] != 0) {
         sl += 1;
@@ -43,10 +43,10 @@ fun trim_right_index(s: str) -> i32 {
         return 0;
     }
 
-    let mut i: i32 = sl - 1;
+    var i: i32 = sl - 1;
 
     while (i >= 0) {
-        let c: u8 = s[i];
+        var c: u8 = s[i];
 
         if (c == 32 || c == 9 || c == 10 || c == 13) {
             i -= 1;
@@ -59,8 +59,8 @@ fun trim_right_index(s: str) -> i32 {
 }
 
 fun trim_range(s: str, out_start: ptr<i32>, out_end: ptr<i32>) {
-    let start: i32 = trim_left_index(s);
-    let end: i32 = trim_right_index(s);
+    var start: i32 = trim_left_index(s);
+    var end: i32 = trim_right_index(s);
 
     deref out_start = start;
     deref out_end = end;

--- a/std/sys/linux/env.wave
+++ b/std/sys/linux/env.wave
@@ -23,12 +23,12 @@ fun env_read(buf: ptr<u8>, cap: i64) -> i64 {
         return -22;
     }
 
-    let mut fd: i64 = open("/proc/self/environ", 0, 0);
+    var fd: i64 = open("/proc/self/environ", 0, 0);
     if (fd < 0) {
         return fd;
     }
 
-    let mut n: i64 = read(fd, buf, cap);
+    var n: i64 = read(fd, buf, cap);
     close(fd);
     return n;
 }

--- a/std/sys/linux/memory.wave
+++ b/std/sys/linux/memory.wave
@@ -77,7 +77,7 @@ fun sys_alloc(size: i64) -> ptr<u8> {
         return null;
     }
 
-    let mut p: ptr<i8> = mmap(
+    var p: ptr<i8> = mmap(
         null,
         size,
         PROT_READ | PROT_WRITE,

--- a/std/sys/linux/syscall.wave
+++ b/std/sys/linux/syscall.wave
@@ -33,7 +33,7 @@
 // syscall with 0 args
 // -----------------------
 fun syscall0(id: i64) -> i64 {
-    let mut ret: i64;
+    var ret: i64;
     asm {
         "syscall"
         in("rax") id
@@ -47,7 +47,7 @@ fun syscall0(id: i64) -> i64 {
 // syscall with 1 arg
 // -----------------------
 fun syscall1(id: i64, a1: i64) -> i64 {
-    let mut ret: i64;
+    var ret: i64;
     asm {
         "syscall"
         in("rax") id
@@ -62,7 +62,7 @@ fun syscall1(id: i64, a1: i64) -> i64 {
 // syscall with 2 args
 // -----------------------
 fun syscall2(id: i64, a1: i64, a2: i64) -> i64 {
-    let mut ret: i64;
+    var ret: i64;
     asm {
         "syscall"
         in("rax") id
@@ -78,7 +78,7 @@ fun syscall2(id: i64, a1: i64, a2: i64) -> i64 {
 // syscall with 3 args
 // -----------------------
 fun syscall3(id: i64, a1: i64, a2: i64, a3: i64) -> i64 {
-    let mut ret: i64;
+    var ret: i64;
     asm {
         "syscall"
         in("rax") id
@@ -95,7 +95,7 @@ fun syscall3(id: i64, a1: i64, a2: i64, a3: i64) -> i64 {
 // syscall with 4 args
 // -----------------------
 fun syscall4(id: i64, a1: i64, a2: i64, a3: i64, a4: i64) -> i64 {
-    let mut ret: i64;
+    var ret: i64;
     asm {
         "syscall"
         in("rax") id
@@ -113,7 +113,7 @@ fun syscall4(id: i64, a1: i64, a2: i64, a3: i64, a4: i64) -> i64 {
 // syscall with 5 args
 // -----------------------
 fun syscall5(id: i64, a1: i64, a2: i64, a3: i64, a4: i64, a5: i64) -> i64 {
-    let mut ret: i64;
+    var ret: i64;
     asm {
         "syscall"
         in("rax") id
@@ -140,7 +140,7 @@ fun syscall6(
     a5: i64,
     a6: i64
 ) -> i64 {
-    let mut ret: i64;
+    var ret: i64;
     asm {
         "syscall"
         in("rax") id

--- a/std/sys/linux/tty.wave
+++ b/std/sys/linux/tty.wave
@@ -69,7 +69,7 @@ fun tty_getattr(fd: i32, t: ptr<Termios>) -> i64 {
 }
 
 fun tty_setattr(fd: i32, action: i32, t: ptr<Termios>) -> i64 {
-    let mut req: i64 = TTY_TCSETS;
+    var req: i64 = TTY_TCSETS;
 
     if (action == TTY_TCSADRAIN) {
         req = TTY_TCSETSW;
@@ -91,12 +91,12 @@ fun tty_setfl(fd: i32, flags: i32) -> i64 {
 fun tty_enable_raw_nonblock(fd: i32, st: ptr<TtyRawState>) -> i64 {
     deref st.active = 0;
 
-    let mut orig: Termios;
+    var orig: Termios;
     if (tty_getattr(fd, &orig) < 0) {
         return -1;
     }
 
-    let mut raw: Termios = orig;
+    var raw: Termios = orig;
     raw.c_lflag = raw.c_lflag & ~(TTY_ICANON | TTY_ECHO);
     raw.c_cc[6] = 0;
     raw.c_cc[5] = 0;
@@ -105,13 +105,13 @@ fun tty_enable_raw_nonblock(fd: i32, st: ptr<TtyRawState>) -> i64 {
         return -1;
     }
 
-    let mut flags_raw: i64 = tty_getfl(fd);
+    var flags_raw: i64 = tty_getfl(fd);
     if (flags_raw < 0) {
         tty_setattr(fd, TTY_TCSANOW, &orig);
         return -1;
     }
 
-    let mut old_flags: i32 = flags_raw as i32;
+    var old_flags: i32 = flags_raw as i32;
     if (tty_setfl(fd, old_flags | TTY_O_NONBLOCK) < 0) {
         tty_setattr(fd, TTY_TCSANOW, &orig);
         return -1;
@@ -128,7 +128,7 @@ fun tty_restore(fd: i32, st: ptr<TtyRawState>) {
         return;
     }
 
-    let mut orig: Termios = deref st.term;
+    var orig: Termios = deref st.term;
     tty_setattr(fd, TTY_TCSANOW, &orig);
     tty_setfl(fd, deref st.flags);
 }

--- a/std/sys/macos/memory.wave
+++ b/std/sys/macos/memory.wave
@@ -59,7 +59,7 @@ fun sys_alloc(size: i64) -> ptr<u8> {
         return null;
     }
 
-    let mut p: ptr<i8> = mmap(
+    var p: ptr<i8> = mmap(
         null,
         size,
         PROT_READ | PROT_WRITE,

--- a/std/sys/macos/syscall.wave
+++ b/std/sys/macos/syscall.wave
@@ -28,8 +28,8 @@
 const MACOS_SYSCALL_BASE: i64 = 0x2000000;
 
 fun syscall0(id: i64) -> i64 {
-    let mut ret: i64;
-    let mut sysno: i64 = MACOS_SYSCALL_BASE + id;
+    var ret: i64;
+    var sysno: i64 = MACOS_SYSCALL_BASE + id;
     asm {
         "syscall"
         in("rax") sysno
@@ -39,8 +39,8 @@ fun syscall0(id: i64) -> i64 {
 }
 
 fun syscall1(id: i64, a1: i64) -> i64 {
-    let mut ret: i64;
-    let mut sysno: i64 = MACOS_SYSCALL_BASE + id;
+    var ret: i64;
+    var sysno: i64 = MACOS_SYSCALL_BASE + id;
     asm {
         "syscall"
         in("rax") sysno
@@ -51,8 +51,8 @@ fun syscall1(id: i64, a1: i64) -> i64 {
 }
 
 fun syscall2(id: i64, a1: i64, a2: i64) -> i64 {
-    let mut ret: i64;
-    let mut sysno: i64 = MACOS_SYSCALL_BASE + id;
+    var ret: i64;
+    var sysno: i64 = MACOS_SYSCALL_BASE + id;
     asm {
         "syscall"
         in("rax") sysno
@@ -64,8 +64,8 @@ fun syscall2(id: i64, a1: i64, a2: i64) -> i64 {
 }
 
 fun syscall3(id: i64, a1: i64, a2: i64, a3: i64) -> i64 {
-    let mut ret: i64;
-    let mut sysno: i64 = MACOS_SYSCALL_BASE + id;
+    var ret: i64;
+    var sysno: i64 = MACOS_SYSCALL_BASE + id;
     asm {
         "syscall"
         in("rax") sysno
@@ -78,8 +78,8 @@ fun syscall3(id: i64, a1: i64, a2: i64, a3: i64) -> i64 {
 }
 
 fun syscall4(id: i64, a1: i64, a2: i64, a3: i64, a4: i64) -> i64 {
-    let mut ret: i64;
-    let mut sysno: i64 = MACOS_SYSCALL_BASE + id;
+    var ret: i64;
+    var sysno: i64 = MACOS_SYSCALL_BASE + id;
     asm {
         "syscall"
         in("rax") sysno
@@ -93,8 +93,8 @@ fun syscall4(id: i64, a1: i64, a2: i64, a3: i64, a4: i64) -> i64 {
 }
 
 fun syscall5(id: i64, a1: i64, a2: i64, a3: i64, a4: i64, a5: i64) -> i64 {
-    let mut ret: i64;
-    let mut sysno: i64 = MACOS_SYSCALL_BASE + id;
+    var ret: i64;
+    var sysno: i64 = MACOS_SYSCALL_BASE + id;
     asm {
         "syscall"
         in("rax") sysno
@@ -109,8 +109,8 @@ fun syscall5(id: i64, a1: i64, a2: i64, a3: i64, a4: i64, a5: i64) -> i64 {
 }
 
 fun syscall6(id: i64, a1: i64, a2: i64, a3: i64, a4: i64, a5: i64, a6: i64) -> i64 {
-    let mut ret: i64;
-    let mut sysno: i64 = MACOS_SYSCALL_BASE + id;
+    var ret: i64;
+    var sysno: i64 = MACOS_SYSCALL_BASE + id;
     asm {
         "syscall"
         in("rax") sysno

--- a/std/sys/macos/tty.wave
+++ b/std/sys/macos/tty.wave
@@ -63,7 +63,7 @@ fun tty_getattr(fd: i32, t: ptr<Termios>) -> i64 {
 }
 
 fun tty_setattr(fd: i32, action: i32, t: ptr<Termios>) -> i64 {
-    let mut req: i64 = TTY_TCSETS;
+    var req: i64 = TTY_TCSETS;
 
     if (action == TTY_TCSADRAIN) {
         req = TTY_TCSETSW;
@@ -84,15 +84,15 @@ fun tty_setfl(fd: i32, flags: i32) -> i64 {
 
 fun tty_enable_raw_nonblock(fd: i32, st: ptr<TtyRawState>) -> i64 {
     deref st.active = 0;
-    let vmin_idx: i32 = 16;
-    let vtime_idx: i32 = 17;
+    var vmin_idx: i32 = 16;
+    var vtime_idx: i32 = 17;
 
-    let mut orig: Termios;
+    var orig: Termios;
     if (tty_getattr(fd, &orig) < 0) {
         return -1;
     }
 
-    let mut raw: Termios = orig;
+    var raw: Termios = orig;
     raw.c_lflag = raw.c_lflag & ~(TTY_ICANON | TTY_ECHO);
     raw.c_cc[vmin_idx] = 0;
     raw.c_cc[vtime_idx] = 0;
@@ -101,13 +101,13 @@ fun tty_enable_raw_nonblock(fd: i32, st: ptr<TtyRawState>) -> i64 {
         return -1;
     }
 
-    let mut flags_raw: i64 = tty_getfl(fd);
+    var flags_raw: i64 = tty_getfl(fd);
     if (flags_raw < 0) {
         tty_setattr(fd, TTY_TCSANOW, &orig);
         return -1;
     }
 
-    let mut old_flags: i32 = flags_raw as i32;
+    var old_flags: i32 = flags_raw as i32;
     if (tty_setfl(fd, old_flags | TTY_O_NONBLOCK) < 0) {
         tty_setattr(fd, TTY_TCSANOW, &orig);
         return -1;
@@ -124,7 +124,7 @@ fun tty_restore(fd: i32, st: ptr<TtyRawState>) {
         return;
     }
 
-    let mut orig: Termios = deref st.term;
+    var orig: Termios = deref st.term;
     tty_setattr(fd, TTY_TCSANOW, &orig);
     tty_setfl(fd, deref st.flags);
 }

--- a/std/time/clock.wave
+++ b/std/time/clock.wave
@@ -27,8 +27,8 @@ fun time_now_monotonic(tp: ptr<TimeSpec>) -> i64 {
 }
 
 fun time_now_realtime_ns() -> i64 {
-    let mut ts: TimeSpec;
-    let mut r: i64 = time_now_realtime(&ts);
+    var ts: TimeSpec;
+    var r: i64 = time_now_realtime(&ts);
 
     if (r < 0) {
         return r;
@@ -38,8 +38,8 @@ fun time_now_realtime_ns() -> i64 {
 }
 
 fun time_now_monotonic_ns() -> i64 {
-    let mut ts: TimeSpec;
-    let mut r: i64 = time_now_monotonic(&ts);
+    var ts: TimeSpec;
+    var r: i64 = time_now_monotonic(&ts);
 
     if (r < 0) {
         return r;

--- a/std/time/diff.wave
+++ b/std/time/diff.wave
@@ -19,8 +19,8 @@
 import("std::sys::time");
 
 fun time_diff_ns(start_ts: TimeSpec, end_ts: TimeSpec) -> i64 {
-    let mut sec: i64 = end_ts.sec - start_ts.sec;
-    let mut nsec: i64 = end_ts.nsec - start_ts.nsec;
+    var sec: i64 = end_ts.sec - start_ts.sec;
+    var nsec: i64 = end_ts.nsec - start_ts.nsec;
 
     return (sec * 1000000000) + nsec;
 }

--- a/std/time/sleep.wave
+++ b/std/time/sleep.wave
@@ -23,12 +23,12 @@ fun time_sleep_ns(ns: i64) -> i64 {
         return 0;
     }
 
-    let mut req: TimeSpec = TimeSpec {
+    var req: TimeSpec = TimeSpec {
         sec: ns / 1000000000,
         nsec: ns % 1000000000
     };
 
-    let mut rem: TimeSpec;
+    var rem: TimeSpec;
 
     return nanosleep(&req, &rem);
 }

--- a/tests/cases/test101.wave
+++ b/tests/cases/test101.wave
@@ -19,6 +19,6 @@ fun main() {
     var buf: array<i8, 128>;
     var src: array<i8, 16>;
     var srclen: i64 = 16;
-    let n: i64 = do_recv(3, &buf, &src, &srclen);
+    var n: i64 = do_recv(3, &buf, &src, &srclen);
     println("recvfrom got {} bytes", n);
 }

--- a/tests/cases/test103.wave
+++ b/tests/cases/test103.wave
@@ -16,45 +16,45 @@ fun check_i64(label: str, got: i64, expected: i64) -> i64 {
 }
 
 fun main() {
-    let path: str = "/tmp/wave-std-test103.txt";
-    let copy_path: str = "/tmp/wave-std-test103-copy.txt";
-    let payload: str = "wave-std-phase1";
-    let bang: str = "!";
+    var path: str = "/tmp/wave-std-test103.txt";
+    var copy_path: str = "/tmp/wave-std-test103-copy.txt";
+    var payload: str = "wave-std-phase1";
+    var bang: str = "!";
 
     fs_remove(path);
     fs_remove(copy_path);
 
-    let payload_len: i64 = len(payload) as i64;
-    let write_n: i64 = fs_write_all(
+    var payload_len: i64 = len(payload) as i64;
+    var write_n: i64 = fs_write_all(
         path,
         payload as ptr<u8>,
         payload_len,
         FS_MODE_FILE_DEFAULT
     );
 
-    let mut passed: i64 = 0;
+    var passed: i64 = 0;
     passed += check_i64("fs_write_all", write_n, payload_len);
 
-    let mut exists: i64 = 0;
+    var exists: i64 = 0;
     if (fs_exists(path)) {
         exists = 1;
     }
     passed += check_i64("fs_exists", exists, 1);
 
-    let size0: i64 = fs_file_size(path);
+    var size0: i64 = fs_file_size(path);
     passed += check_i64("fs_file_size after write", size0, payload_len);
 
     var read_buf: array<u8, 128>;
-    let read_n: i64 = fs_read_all(path, &read_buf[0], 128);
+    var read_n: i64 = fs_read_all(path, &read_buf[0], 128);
     passed += check_i64("fs_read_all", read_n, payload_len);
 
-    let mut ok_prefix: i64 = 0;
+    var ok_prefix: i64 = 0;
     if (read_buf[0] == 119 && read_buf[1] == 97 && read_buf[2] == 118) {
         ok_prefix = 1;
     }
     passed += check_i64("read prefix bytes", ok_prefix, 1);
 
-    let append_n: i64 = fs_append_all(
+    var append_n: i64 = fs_append_all(
         path,
         bang as ptr<u8>,
         1,
@@ -62,30 +62,30 @@ fun main() {
     );
     passed += check_i64("fs_append_all", append_n, 1);
 
-    let size1: i64 = fs_file_size(path);
+    var size1: i64 = fs_file_size(path);
     passed += check_i64("fs_file_size after append", size1, payload_len + 1);
 
     var scratch: array<u8, 8>;
-    let copied: i64 = fs_copy(path, copy_path, &scratch[0], 8, FS_MODE_FILE_DEFAULT);
+    var copied: i64 = fs_copy(path, copy_path, &scratch[0], 8, FS_MODE_FILE_DEFAULT);
     passed += check_i64("fs_copy bytes", copied, payload_len + 1);
 
-    let copy_size: i64 = fs_file_size(copy_path);
+    var copy_size: i64 = fs_file_size(copy_path);
     passed += check_i64("copied file size", copy_size, payload_len + 1);
 
     var fds: array<i32, 2>;
-    let pr: i64 = io_pipe(&fds[0]);
+    var pr: i64 = io_pipe(&fds[0]);
     passed += check_i64("io_pipe", pr, 0);
 
     if (pr == 0) {
-        let wn: i64 = io_write_all(fds[1] as i64, "OK" as ptr<u8>, 2);
+        var wn: i64 = io_write_all(fds[1] as i64, "OK" as ptr<u8>, 2);
         passed += check_i64("pipe write", wn, 2);
         io_close(fds[1] as i64);
 
         var pipe_buf: array<u8, 2>;
-        let rn: i64 = io_read_exact(fds[0] as i64, &pipe_buf[0], 2);
+        var rn: i64 = io_read_exact(fds[0] as i64, &pipe_buf[0], 2);
         passed += check_i64("pipe read", rn, 2);
 
-        let mut pipe_ok: i64 = 0;
+        var pipe_ok: i64 = 0;
         if (pipe_buf[0] == 79 && pipe_buf[1] == 75) {
             pipe_ok = 1;
         }

--- a/tests/cases/test104.wave
+++ b/tests/cases/test104.wave
@@ -16,34 +16,34 @@ fun check_i64(label: str, got: i64, expected: i64) -> i64 {
 }
 
 fun main() {
-    let mut passed: i64 = 0;
-    let mut expected: i64 = 8;
+    var passed: i64 = 0;
+    var expected: i64 = 8;
 
-    let sfd: i64 = net_socket_tcp_v4();
+    var sfd: i64 = net_socket_tcp_v4();
     if (sfd >= 0) {
         expected = 14;
         passed += check_i64("net_socket_tcp_v4", 1, 1);
 
-        let r1: i64 = net_set_reuseaddr_flag(sfd, 1);
+        var r1: i64 = net_set_reuseaddr_flag(sfd, 1);
         passed += check_i64("net_set_reuseaddr_flag", r1, 0);
 
-        let v1: i64 = net_get_reuseaddr_flag(sfd);
-        let mut reuse_ok: i64 = 0;
+        var v1: i64 = net_get_reuseaddr_flag(sfd);
+        var reuse_ok: i64 = 0;
         if (v1 >= 1) {
             reuse_ok = 1;
         }
         passed += check_i64("net_get_reuseaddr_flag", reuse_ok, 1);
 
-        let r2: i64 = net_set_nonblock(sfd, 1);
+        var r2: i64 = net_set_nonblock(sfd, 1);
         passed += check_i64("net_set_nonblock on socket", r2, 0);
 
-        let v2: i64 = net_get_nonblock(sfd);
+        var v2: i64 = net_get_nonblock(sfd);
         passed += check_i64("net_get_nonblock socket=1", v2, 1);
 
-        let r3: i64 = net_set_nonblock(sfd, 0);
+        var r3: i64 = net_set_nonblock(sfd, 0);
         passed += check_i64("net_set_nonblock disable", r3, 0);
 
-        let v3: i64 = net_get_nonblock(sfd);
+        var v3: i64 = net_get_nonblock(sfd);
         passed += check_i64("net_get_nonblock socket=0", v3, 0);
 
         io_close(sfd);
@@ -52,17 +52,17 @@ fun main() {
     }
 
     var fds: array<i32, 2>;
-    let pr: i64 = io_pipe(&fds[0]);
+    var pr: i64 = io_pipe(&fds[0]);
     passed += check_i64("io_pipe", pr, 0);
 
     if (pr == 0) {
-        let read_fd: i64 = fds[0] as i64;
-        let write_fd: i64 = fds[1] as i64;
+        var read_fd: i64 = fds[0] as i64;
+        var write_fd: i64 = fds[1] as i64;
 
-        let nb: i64 = net_set_nonblock(read_fd, 1);
+        var nb: i64 = net_set_nonblock(read_fd, 1);
         passed += check_i64("net_set_nonblock pipe", nb, 0);
 
-        let nbv: i64 = net_get_nonblock(read_fd);
+        var nbv: i64 = net_get_nonblock(read_fd);
         passed += check_i64("net_get_nonblock pipe", nbv, 1);
 
         var pfd: PollFd = PollFd {
@@ -71,23 +71,23 @@ fun main() {
             revents: 0
         };
 
-        let p0: i64 = net_poll(&pfd, 1, 0);
+        var p0: i64 = net_poll(&pfd, 1, 0);
         passed += check_i64("net_poll before write", p0, 0);
 
-        let wn: i64 = io_write_all(write_fd, "Q" as ptr<u8>, 1);
+        var wn: i64 = io_write_all(write_fd, "Q" as ptr<u8>, 1);
         passed += check_i64("pipe write", wn, 1);
 
         pfd.revents = 0;
-        let p1: i64 = net_poll(&pfd, 1, 200);
+        var p1: i64 = net_poll(&pfd, 1, 200);
         passed += check_i64("net_poll after write", p1, 1);
 
-        let mut ev_ok: i64 = 0;
+        var ev_ok: i64 = 0;
         if ((pfd.revents & NET_POLLIN) != 0) {
             ev_ok = 1;
         }
         passed += check_i64("poll revents POLLIN", ev_ok, 1);
 
-        let wr: i64 = net_wait_readable(read_fd, 200);
+        var wr: i64 = net_wait_readable(read_fd, 200);
         passed += check_i64("net_wait_readable", wr, 1);
 
         io_close(read_fd);

--- a/tests/cases/test105.wave
+++ b/tests/cases/test105.wave
@@ -17,7 +17,7 @@ fun check_i64(label: str, got: i64, expected: i64) -> i64 {
 }
 
 fun main() {
-    let mut passed: i64 = 0;
+    var passed: i64 = 0;
 
     passed += check_i64("mem_page_size", mem_page_size(), MEM_PAGE_SIZE);
     passed += check_i64("mem_pages_for_size(1)", mem_pages_for_size(1), 1);
@@ -28,22 +28,22 @@ fun main() {
     );
     passed += check_i64("mem_size_align_page(1)", mem_size_align_page(1), MEM_PAGE_SIZE);
 
-    let p: ptr<u8> = mem_alloc_pages(1);
-    let mut p_ok: i64 = 0;
+    var p: ptr<u8> = mem_alloc_pages(1);
+    var p_ok: i64 = 0;
     if (p != null) {
         p_ok = 1;
     }
     passed += check_i64("mem_alloc_pages(1)", p_ok, 1);
     passed += check_i64("mem_free_pages(1)", mem_free_pages(p, 1), 0);
 
-    let ap: ptr<u8> = mem_alloc_aligned(33, 64);
-    let mut ap_ok: i64 = 0;
+    var ap: ptr<u8> = mem_alloc_aligned(33, 64);
+    var ap_ok: i64 = 0;
     if (ap != null) {
         ap_ok = 1;
     }
     passed += check_i64("mem_alloc_aligned", ap_ok, 1);
 
-    let mut aligned_ok: i64 = 0;
+    var aligned_ok: i64 = 0;
     if (mem_is_aligned(ap, 64)) {
         aligned_ok = 1;
     }
@@ -53,25 +53,25 @@ fun main() {
     var small: array<u8, 4>;
     var src: array<u8, 6> = [10, 20, 30, 40, 50, 60];
 
-    let c0: i64 = mem_copy_checked(&small[0], 4, &src[0], 6);
+    var c0: i64 = mem_copy_checked(&small[0], 4, &src[0], 6);
     passed += check_i64("mem_copy_checked overflow", c0, MEM_ERR_NO_SPACE);
 
-    let c1: i64 = mem_copy_checked(&small[0], 4, &src[0], 4);
+    var c1: i64 = mem_copy_checked(&small[0], 4, &src[0], 4);
     passed += check_i64("mem_copy_checked ok", c1, 4);
 
-    let mut copy_ok: i64 = 0;
+    var copy_ok: i64 = 0;
     if (small[0] == 10 && small[1] == 20 && small[2] == 30 && small[3] == 40) {
         copy_ok = 1;
     }
     passed += check_i64("mem_copy_checked bytes", copy_ok, 1);
 
-    let s0: i64 = mem_set_checked(&small[0], 4, 7, 5);
+    var s0: i64 = mem_set_checked(&small[0], 4, 7, 5);
     passed += check_i64("mem_set_checked overflow", s0, MEM_ERR_NO_SPACE);
 
-    let z0: i64 = mem_zero_checked(&small[0], 4, 4);
+    var z0: i64 = mem_zero_checked(&small[0], 4, 4);
     passed += check_i64("mem_zero_checked ok", z0, 4);
 
-    let mut zero_ok: i64 = 0;
+    var zero_ok: i64 = 0;
     if (small[0] == 0 && small[1] == 0 && small[2] == 0 && small[3] == 0) {
         zero_ok = 1;
     }
@@ -89,7 +89,7 @@ fun main() {
     bytes_store_be_i64(&be64[0], 0x0102030405060708);
     passed += check_i64("bytes_load_be_i64", bytes_load_be_i64(&be64[0]), 0x0102030405060708);
 
-    let mut pow2_ok: i64 = 0;
+    var pow2_ok: i64 = 0;
     if (is_pow2_i64(1024)) {
         pow2_ok = 1;
     }

--- a/tests/cases/test106.wave
+++ b/tests/cases/test106.wave
@@ -17,27 +17,27 @@ fun check_i64(label: str, got: i64, expected: i64) -> i64 {
 }
 
 fun main() {
-    let mut passed: i64 = 0;
+    var passed: i64 = 0;
 
-    let pid0: i64 = proc_getpid();
-    let mut ok_pid: i64 = 0;
+    var pid0: i64 = proc_getpid();
+    var ok_pid: i64 = 0;
     if (pid0 > 0) {
         ok_pid = 1;
     }
     passed += check_i64("proc_getpid", ok_pid, 1);
 
     // fork + wait + exit status
-    let c1: i64 = proc_fork();
+    var c1: i64 = proc_fork();
     if (c1 == 0) {
         proc_exit(23);
     }
 
     if (c1 > 0) {
         var st1: i32 = 0;
-        let w1: i64 = proc_wait(c1, &st1);
+        var w1: i64 = proc_wait(c1, &st1);
         passed += check_i64("proc_wait child1", w1, c1);
 
-        let mut exited_ok: i64 = 0;
+        var exited_ok: i64 = 0;
         if (proc_status_exited(st1)) {
             exited_ok = 1;
         }
@@ -49,14 +49,14 @@ fun main() {
 
     // pipe + dup2(stdout) + wait
     var fds: array<i32, 2>;
-    let pr: i64 = io_pipe(&fds[0]);
+    var pr: i64 = io_pipe(&fds[0]);
     passed += check_i64("io_pipe", pr, 0);
 
     if (pr == 0) {
-        let c2: i64 = proc_fork();
+        var c2: i64 = proc_fork();
         if (c2 == 0) {
             io_close(fds[0] as i64);
-            let dr: i64 = io_dup2(fds[1] as i64, IO_STDOUT_FD);
+            var dr: i64 = io_dup2(fds[1] as i64, IO_STDOUT_FD);
             if (dr < 0) {
                 proc_exit(125);
             }
@@ -69,23 +69,23 @@ fun main() {
             io_close(fds[1] as i64);
 
             var rbuf: array<u8, 32>;
-            let rn: i64 = io_read_at_most(fds[0] as i64, &rbuf[0], 32);
+            var rn: i64 = io_read_at_most(fds[0] as i64, &rbuf[0], 32);
             io_close(fds[0] as i64);
 
-            let mut read_ok: i64 = 0;
+            var read_ok: i64 = 0;
             if (rn >= 6) {
                 read_ok = 1;
             }
             passed += check_i64("pipe child stdout read", read_ok, 1);
 
-            let mut msg_ok: i64 = 0;
+            var msg_ok: i64 = 0;
             if (rbuf[0] == 72 && rbuf[1] == 69 && rbuf[2] == 76 && rbuf[3] == 76 && rbuf[4] == 79) {
                 msg_ok = 1;
             }
             passed += check_i64("pipe child stdout bytes", msg_ok, 1);
 
             var st2: i32 = 0;
-            let w2: i64 = proc_wait(c2, &st2);
+            var w2: i64 = proc_wait(c2, &st2);
             passed += check_i64("proc_wait child2", w2, c2);
             passed += check_i64("child2 exit code", proc_status_exit_code(st2) as i64, 0);
         } else {
@@ -101,37 +101,37 @@ fun main() {
     argv[1] = "WAVEPROC" as ptr<i8>;
     argv[2] = null;
 
-    let sr: ProcSpawnStdoutResult = proc_spawn_capture_stdout(
+    var sr: ProcSpawnStdoutResult = proc_spawn_capture_stdout(
         "/bin/echo",
         &argv[0],
         null
     );
 
     if (sr.status == 0 && sr.pid > 0) {
-        let mut spawn_ok: i64 = 0;
+        var spawn_ok: i64 = 0;
         if (sr.read_fd >= 0) {
             spawn_ok = 1;
         }
         passed += check_i64("proc_spawn_capture_stdout", spawn_ok, 1);
 
         var sbuf: array<u8, 64>;
-        let sn: i64 = io_read_at_most(sr.read_fd, &sbuf[0], 64);
+        var sn: i64 = io_read_at_most(sr.read_fd, &sbuf[0], 64);
         io_close(sr.read_fd);
 
-        let mut sn_ok: i64 = 0;
+        var sn_ok: i64 = 0;
         if (sn >= 9) {
             sn_ok = 1;
         }
         passed += check_i64("spawn stdout read", sn_ok, 1);
 
-        let mut sbytes_ok: i64 = 0;
+        var sbytes_ok: i64 = 0;
         if (sbuf[0] == 87 && sbuf[1] == 65 && sbuf[2] == 86 && sbuf[3] == 69 && sbuf[4] == 80) {
             sbytes_ok = 1;
         }
         passed += check_i64("spawn stdout bytes", sbytes_ok, 1);
 
         var st3: i32 = 0;
-        let w3: i64 = proc_wait(sr.pid, &st3);
+        var w3: i64 = proc_wait(sr.pid, &st3);
         passed += check_i64("proc_wait spawn child", w3, sr.pid);
         passed += check_i64("spawn child exit code", proc_status_exit_code(st3) as i64, 0);
     } else {

--- a/tests/cases/test108.wave
+++ b/tests/cases/test108.wave
@@ -12,12 +12,12 @@ struct WaveBootInfo {
 }
 
 fun copy_memory(dst: ptr<u8>, src: ptr<u8>, size: u64) {
-    let mut i: u64 = 0;
+    var i: u64 = 0;
 
     while (i < size) {
-        let d: ptr<u8> = (dst as u64 + i) as ptr<u8>;
-        let s: ptr<u8> = (src as u64 + i) as ptr<u8>;
-        let v: u8 = deref s;
+        var d: ptr<u8> = (dst as u64 + i) as ptr<u8>;
+        var s: ptr<u8> = (src as u64 + i) as ptr<u8>;
+        var v: u8 = deref s;
 
         deref d = v;
 

--- a/tests/cases/test26.wave
+++ b/tests/cases/test26.wave
@@ -1,6 +1,6 @@
 fun main(q :i32 = 0, w :i32 = 10,) {
     var a :str = "World";
-    let b :i32 = 2;
-    let mut c :i32 = 3;
+    var b :i32 = 2;
+    var c :i32 = 3;
     println("Hello {} {} {} {} {}", a, b, c, q, w);
 }

--- a/tests/cases/test3.wave
+++ b/tests/cases/test3.wave
@@ -1,5 +1,5 @@
 fun main() {
-    let a :i32 = 10;
+    var a :i32 = 10;
     var b :i32 = 5;
     println("Hello World");
 }

--- a/tests/cases/test56.wave
+++ b/tests/cases/test56.wave
@@ -5,7 +5,7 @@
 // =========================
 
 fun len(s: str) -> i32 {
-    let mut i: i32 = 0;
+    var i: i32 = 0;
     while (s[i] != 0) {
         i += 1;
     }
@@ -145,7 +145,7 @@ fun _socket_create_tcp() -> i64 {
 }
 
 fun _socket_bind_any(sockfd: i64, port: i16) -> i64 {
-    let mut addr: SockAddrIn = SockAddrIn {
+    var addr: SockAddrIn = SockAddrIn {
         sin_family: 2,
         sin_port: htons(port),
         sin_addr: 0,

--- a/tests/cases/test60.wave
+++ b/tests/cases/test60.wave
@@ -20,7 +20,7 @@ const MAP_PRIVATE: i32 = 2;
 const MAP_ANONYMOUS: i32 = 32;
 
 fun syscall_write(fd: i32, buf: ptr<i8>, len: i32) {
-    let r: i32;
+    var r: i32;
     asm {
         "mov rax, 1"
         "syscall"
@@ -32,7 +32,7 @@ fun syscall_write(fd: i32, buf: ptr<i8>, len: i32) {
 }
 
 fun syscall_read(fd: i32, buf: ptr<i8>, len:i32) -> i32 {
-    let r: i32;
+    var r: i32;
     asm {
         "mov rax, 0"
         "syscall"
@@ -45,7 +45,7 @@ fun syscall_read(fd: i32, buf: ptr<i8>, len:i32) -> i32 {
 }
 
 fun syscall_close(fd: i32) -> i32 {
-    let r: i32;
+    var r: i32;
     asm {
         "mov rax, 3"
         "syscall"
@@ -56,7 +56,7 @@ fun syscall_close(fd: i32) -> i32 {
 }
 
 fun syscall_mmap(addr: ptr<u8>, length: i32, prot: i32, flags: i32, fd: i32, offset: i32) -> ptr<u8> {
-    let r: ptr<u8>;
+    var r: ptr<u8>;
     asm {
         "mov rax, 9"
         "syscall"
@@ -72,7 +72,7 @@ fun syscall_mmap(addr: ptr<u8>, length: i32, prot: i32, flags: i32, fd: i32, off
 }
 
 fun syscall_munmap(addr: ptr<u8>, length: i32) -> i32 {
-    let r: i32;
+    var r: i32;
     asm {
         "mov rax, 11"
         "syscall"
@@ -84,7 +84,7 @@ fun syscall_munmap(addr: ptr<u8>, length: i32) -> i32 {
 }
 
 fun main() {
-    let length: i32 = 4096;
+    var length: i32 = 4096;
     var mem: ptr<u8> = syscall_mmap(
         null, length,
         PROT_READ | PROT_WRITE,

--- a/tests/cases/test66.wave
+++ b/tests/cases/test66.wave
@@ -176,27 +176,27 @@ fun test_mutability() {
     a = 20;
     println("var a = {}", a);
 
-    // let: immutable variable
-    let b: i32 = 30;
-    println("let b = {}", b);
+    // var: immutable variable
+    var b: i32 = 30;
+    println("var b = {}", b);
 
-    // let mut: immutable binding but mutable inner data
-    let mut c: Data = Data { value: 5 };
+    // var binding with mutable inner data
+    var c: Data = Data { value: 5 };
     c.value = 77;
-    println("let mut c.value = {}", c.value);
+    println("var c.value = {}", c.value);
 
-    // struct with let mut: fields can change
-    let mut t: Transform = Transform {
+    // struct with var: fields can change
+    var t: Transform = Transform {
         pos: Vec2 { x: 3.0, y: 4.0 },
         scale: 1.0
     };
     t.pos.x = 10.0;
     t.scale = 5.0;
-    println("let mut Transform({}, {}, {})", t.pos.x, t.pos.y, t.scale);
+    println("var Transform({}, {}, {})", t.pos.x, t.pos.y, t.scale);
 
-    // let: inner mutation must be rejected by compiler
-    let p: Stats = Stats { hp: 50, mp: 25 };
-    println("let p.hp = {}", p.hp);
+    // var: inner mutation must be rejected by compiler
+    var p: Stats = Stats { hp: 50, mp: 25 };
+    println("var p.hp = {}", p.hp);
 }
 
 fun main() {

--- a/tests/cases/test73.wave
+++ b/tests/cases/test73.wave
@@ -1,6 +1,6 @@
 fun main() {
     var x: i32 = 1;
-    let p: ptr<i32> = &x;
+    var p: ptr<i32> = &x;
     (deref p)++;
     println("{}", p);
 }

--- a/tests/cases/test80.wave
+++ b/tests/cases/test80.wave
@@ -16,8 +16,8 @@ fun choose() -> UniformType {
 }
 
 fun main() {
-    let a: UniformType = FLOAT;
-    let b: UniformType = choose();
+    var a: UniformType = FLOAT;
+    var b: UniformType = choose();
 
     println("a = {}", get_id(a)); // 0
     println("b = {}", get_id(b)); // 2

--- a/tests/cases/test82.wave
+++ b/tests/cases/test82.wave
@@ -28,10 +28,10 @@ fun test_var_initializer() -> i32 {
 
 fun test_let_mut_initializer() -> i32 {
     var sum: i32 = 0;
-    for (let mut i: i32 = 0; i < 4; i += 1) {
+    for (var i: i32 = 0; i < 4; i += 1) {
         sum += i;
     }
-    return check_i32("let mut init (0..3 sum)", sum, 6);
+    return check_i32("var init (0..3 sum)", sum, 6);
 }
 
 fun test_expression_initializer() -> i32 {

--- a/tests/cases/test95.wave
+++ b/tests/cases/test95.wave
@@ -6,7 +6,7 @@ fun calc_sum(x: i32, y: i32) -> i32 {
 }
 
 fun main() {
-    let total: i32 = calc_sum(3, 4);
+    var total: i32 = calc_sum(3, 4);
     println("sum={}", total);
 
     var msg_ptr: ptr<i8> = "Syscall says hi!\n";

--- a/tests/cases/test98.wave
+++ b/tests/cases/test98.wave
@@ -39,8 +39,8 @@ fun syscall6(id: i64, a1: i64, a2: i64, a3: i64, a4: i64, a5: i64, a6: i64) -> i
 }
 
 fun main() {
-    let a: i64 = syscall0(172);
-    let b: i64 = syscall3(64, 1, 2, 3);
-    let c: i64 = syscall6(222, 1, 2, 3, 4, 5, 6);
+    var a: i64 = syscall0(172);
+    var b: i64 = syscall3(64, 1, 2, 3);
+    var c: i64 = syscall6(222, 1, 2, 3, 4, 5, 6);
     println("{} {} {}", a, b, c);
 }

--- a/tests/cases/test99.wave
+++ b/tests/cases/test99.wave
@@ -1,6 +1,6 @@
 // wave-test: mode=build, runner=compile, target=riscv64-unknown-linux-gnu, emit=obj, object-arch=riscv64, object-bits=64, riscv-float-abi=lp64d
 fun syscall_mmap(addr: ptr<u8>, length: i64, prot: i64, flags: i64, fd: i64, offset: i64) -> ptr<u8> {
-    let r: ptr<u8>;
+    var r: ptr<u8>;
     asm {
         "li a7, 222"
         "ecall"
@@ -16,8 +16,8 @@ fun syscall_mmap(addr: ptr<u8>, length: i64, prot: i64, flags: i64, fd: i64, off
 }
 
 fun main() {
-    let mem: ptr<u8> = syscall_mmap(null, 4096, 1, 2, -1, 0);
-    let raw: i64;
+    var mem: ptr<u8> = syscall_mmap(null, 4096, 1, 2, -1, 0);
+    var raw: i64;
     asm {
         "mv a0, a1"
         in("a1") mem

--- a/tests/codegen_regressions.rs
+++ b/tests/codegen_regressions.rs
@@ -188,6 +188,34 @@ fn json_path_matching_accepts_unix_and_escaped_windows_separators() {
     ));
 }
 
+#[test]
+fn retired_let_declarations_are_rejected() {
+    let dir = temp_case_dir("retired-let-syntax");
+    let cases = [
+        ("let.wave", "fun main() { let value: i32 = 1; }\n"),
+        (
+            "let_mut.wave",
+            "fun main() { let mut value: i32 = 1; value += 1; }\n",
+        ),
+        (
+            "for_let.wave",
+            "fun main() { for (let index: i32 = 0; index < 1; index += 1) {} }\n",
+        ),
+    ];
+
+    for (file_name, source) in cases {
+        let source = write_wave(&dir, file_name, source);
+        let error = run_wavec_expect_failure([OsStr::new("check"), source.as_os_str()]);
+        assert!(error.contains("error[E2001]"), "{}: {}", file_name, error);
+        assert!(
+            error.contains("failed to parse function declaration"),
+            "{}: {}",
+            file_name,
+            error
+        );
+    }
+}
+
 fn run_link_tests_enabled() -> bool {
     std::env::var_os("WAVE_RUN_LINK_TESTS").is_some()
 }
@@ -325,17 +353,17 @@ fn semantic_validation_rejects_backend_only_type_failures_early() {
         ),
         (
             "narrow_call.wave",
-            "fun take(x: i32) {}\nfun main() { let wide: i64 = 1; take(wide); }\n",
+            "fun take(x: i32) {}\nfun main() { var wide: i64 = 1; take(wide); }\n",
             "argument 1 of function `take`",
         ),
         (
             "narrow_initializer.wave",
-            "fun main() { let wide: i64 = 1; let narrow: i32 = wide; }\n",
+            "fun main() { var wide: i64 = 1; var narrow: i32 = wide; }\n",
             "initializer for `narrow`",
         ),
         (
             "narrow_assignment.wave",
-            "fun main() { let wide: i64 = 1; var narrow: i32 = 0; narrow = wide; }\n",
+            "fun main() { var wide: i64 = 1; var narrow: i32 = 0; narrow = wide; }\n",
             "assignment to `narrow`",
         ),
         (
@@ -350,7 +378,7 @@ fn semantic_validation_rejects_backend_only_type_failures_early() {
         ),
         (
             "unknown_method.wave",
-            "struct Point { x: i32; }\nfun main() { let p: Point = Point { x: 1 }; p.missing(); }\n",
+            "struct Point { x: i32; }\nfun main() { var p: Point = Point { x: 1 }; p.missing(); }\n",
             "struct `Point` has no method `missing`",
         ),
         (
@@ -360,7 +388,7 @@ fn semantic_validation_rejects_backend_only_type_failures_early() {
         ),
         (
             "missing_struct_literal_field.wave",
-            "struct Point { x: i32; y: i32; }\nfun main() { let p: Point = Point { x: 1 }; }\n",
+            "struct Point { x: i32; y: i32; }\nfun main() { var p: Point = Point { x: 1 }; }\n",
             "struct literal `Point` is missing field(s): y",
         ),
         (
@@ -370,32 +398,32 @@ fn semantic_validation_rejects_backend_only_type_failures_early() {
         ),
         (
             "array_element.wave",
-            "fun main() { let values: array<i32, 1> = [\"text\"]; }\n",
+            "fun main() { var values: array<i32, 1> = [\"text\"]; }\n",
             "element 0 of initializer for `values`",
         ),
         (
             "invalid_condition.wave",
-            "struct Flag { value: i32; }\nfun main() { let flag: Flag = Flag { value: 1 }; if (flag) {} }\n",
+            "struct Flag { value: i32; }\nfun main() { var flag: Flag = Flag { value: 1 }; if (flag) {} }\n",
             "if condition must be bool, numeric, pointer, or string",
         ),
         (
             "invalid_match.wave",
-            "struct Value { x: i32; }\nfun main() { let v: Value = Value { x: 1 }; match (v) { _ => {} } }\n",
+            "struct Value { x: i32; }\nfun main() { var v: Value = Value { x: 1 }; match (v) { _ => {} } }\n",
             "match value must be an integer or enum",
         ),
         (
             "invalid_deref.wave",
-            "fun main() { let value: i32 = 1; println(\"{}\", deref value); }\n",
+            "fun main() { var value: i32 = 1; println(\"{}\", deref value); }\n",
             "deref expects a pointer",
         ),
         (
             "invalid_index_target.wave",
-            "fun main() { let value: i32 = 1; println(\"{}\", value[0]); }\n",
+            "fun main() { var value: i32 = 1; println(\"{}\", value[0]); }\n",
             "index access requires an array or pointer",
         ),
         (
             "invalid_index_type.wave",
-            "fun main() { let values: array<i32, 1> = [1]; println(\"{}\", values[\"text\"]); }\n",
+            "fun main() { var values: array<i32, 1> = [1]; println(\"{}\", values[\"text\"]); }\n",
             "index expression must be an integer",
         ),
         (
@@ -575,7 +603,7 @@ fn second_semantic_audit_rejects_unsafe_programs_before_codegen() {
         ),
         (
             "struct_format.wave",
-            "struct Pair { x: i32; }\nfun main() { let p: Pair = Pair { x: 1 }; println(\"{}\", p); }\n",
+            "struct Pair { x: i32; }\nfun main() { var p: Pair = Pair { x: 1 }; println(\"{}\", p); }\n",
             "found `Pair`",
         ),
         (
@@ -594,28 +622,23 @@ fn second_semantic_audit_rejects_unsafe_programs_before_codegen() {
             "input argument must be a mutable lvalue",
         ),
         (
-            "input_immutable.wave",
-            "fun main() { let value: i32 = 0; input(\"{}\", value); }\n",
-            "cannot write input into immutable binding `value`",
-        ),
-        (
             "invalid_struct_cast.wave",
-            "struct Pair { x: i32; }\nfun main() { let p: Pair = Pair { x: 1 }; let bits: i32 = p as i32; }\n",
+            "struct Pair { x: i32; }\nfun main() { var p: Pair = Pair { x: 1 }; var bits: i32 = p as i32; }\n",
             "invalid cast from `Pair` to `i32`",
         ),
         (
             "invalid_string_float_cast.wave",
-            "fun main() { let value: f32 = \"text\" as f32; }\n",
+            "fun main() { var value: f32 = \"text\" as f32; }\n",
             "invalid cast from `str` to `f32`",
         ),
         (
             "invalid_void_cast.wave",
-            "fun noop() {}\nfun main() { let value: i32 = noop() as i32; }\n",
+            "fun noop() {}\nfun main() { var value: i32 = noop() as i32; }\n",
             "invalid cast from `void` to `i32`",
         ),
         (
             "unknown_cast_type.wave",
-            "fun main() { let value: i32 = 1 as Missing; }\n",
+            "fun main() { var value: i32 = 1 as Missing; }\n",
             "unknown type `Missing` in cast target",
         ),
         (
@@ -665,17 +688,17 @@ fn second_semantic_audit_rejects_unsafe_programs_before_codegen() {
         ),
         (
             "out_of_range_literal.wave",
-            "fun main() { let value: i8 = 300; }\n",
+            "fun main() { var value: i8 = 300; }\n",
             "initializer for `value`",
         ),
         (
             "negative_out_of_range_literal.wave",
-            "fun main() { let value: i8 = -129; }\n",
+            "fun main() { var value: i8 = -129; }\n",
             "initializer for `value`",
         ),
         (
             "negative_unsigned_literal.wave",
-            "fun main() { let value: u8 = -1; }\n",
+            "fun main() { var value: u8 = -1; }\n",
             "initializer for `value`",
         ),
         (
@@ -685,7 +708,7 @@ fn second_semantic_audit_rejects_unsafe_programs_before_codegen() {
         ),
         (
             "duplicate_local.wave",
-            "fun main() { let value: i32 = 1; let value: i32 = 2; }\n",
+            "fun main() { var value: i32 = 1; var value: i32 = 2; }\n",
             "duplicate variable declaration `value` in the same scope",
         ),
         (
@@ -705,7 +728,7 @@ fn second_semantic_audit_rejects_unsafe_programs_before_codegen() {
         ),
         (
             "duplicate_match_value.wave",
-            "enum Mode -> i32 { First = 1, Second = 1 }\nfun main() { let mode: Mode = First; match (mode) { First => {} Second => {} } }\n",
+            "enum Mode -> i32 { First = 1, Second = 1 }\nfun main() { var mode: Mode = First; match (mode) { First => {} Second => {} } }\n",
             "duplicate match case pattern `value:1`",
         ),
         (
@@ -771,14 +794,14 @@ fun add(left: f32, right: f64) -> f32 {
 
 fun main() {
     noop();
-    let minimum: i8 = -128;
-    let bit_pattern: i8 = 0xFF;
-    let unsigned_max: u128 = 340282366920938463463374607431768211455;
-    let explicit: i8 = 300 as i8;
-    let values: ptr<array<i32, 2>> = &[1, 2];
+    var minimum: i8 = -128;
+    var bit_pattern: i8 = 0xFF;
+    var unsigned_max: u128 = 340282366920938463463374607431768211455;
+    var explicit: i8 = 300 as i8;
+    var values: ptr<array<i32, 2>> = &[1, 2];
     var input_value: i32 = 0;
     if (true) {
-        let minimum: i32 = 1;
+        var minimum: i32 = 1;
         println("{}", minimum);
     }
     println("{} {} {} {} {}", minimum, bit_pattern, unsigned_max, explicit, values);
@@ -837,12 +860,12 @@ fun value(flag: bool) -> i32 {
         "duplicate.wave",
         r#"
 fun other() {
-    let value: i32 = 0;
+    var value: i32 = 0;
 }
 
 fun main() {
-    let value: i32 = 1;
-    let value: i32 = 2;
+    var value: i32 = 1;
+    var value: i32 = 2;
 }
 "#,
     );
@@ -850,7 +873,7 @@ fun main() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("duplicate.wave:8:9"), "{}", stderr);
-    assert!(stderr.contains("let value: i32 = 2;"), "{}", stderr);
+    assert!(stderr.contains("var value: i32 = 2;"), "{}", stderr);
 
     let duplicate_type = write_wave(
         &dir,
@@ -870,7 +893,7 @@ fun main() {
     let imported = dir.join("broken.wave");
     fs::write(
         &imported,
-        "fun broken() {\n    let value: Missing = 1;\n}\n",
+        "fun broken() {\n    var value: Missing = 1;\n}\n",
     )
     .unwrap();
     let entry = write_wave(
@@ -882,13 +905,13 @@ fun main() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("broken.wave:2:9"), "{}", stderr);
-    assert!(stderr.contains("let value: Missing = 1;"), "{}", stderr);
+    assert!(stderr.contains("var value: Missing = 1;"), "{}", stderr);
     assert!(!stderr.contains("import_main.wave:1:1"), "{}", stderr);
 
     let generic_import = dir.join("generic_broken.wave");
     fs::write(
         &generic_import,
-        "struct Box<T> { value: T; }\nfun broken() {\n    let value: Box<i32, i64>;\n}\n",
+        "struct Box<T> { value: T; }\nfun broken() {\n    var value: Box<i32, i64>;\n}\n",
     )
     .unwrap();
     let generic_entry = write_wave(
@@ -961,11 +984,11 @@ fun infinite() -> i32 {
 }
 
 fun main() -> i32 {
-    let value: i32 = choose(true);
-    let bits: i64 = pointer_bits();
-    let pair: Pair = Pair { x: 1, y: 2 };
-    let items: array<i32, 2> = values();
-    let pointer: ptr<Pair> = &pair;
+    var value: i32 = choose(true);
+    var bits: i64 = pointer_bits();
+    var pair: Pair = Pair { x: 1, y: 2 };
+    var items: array<i32, 2> = values();
+    var pointer: ptr<Pair> = &pair;
     if (pointer) {
         if (value == 1 && bits != 0 && items[0] == 1 && widen(pair.y) == 2) {
             return narrow_explicitly(0);
@@ -2097,19 +2120,19 @@ fun id_ptr(p: ptr<i32>) -> ptr<i32> {
 }
 
 fun main() -> i32 {
-    let mut x: i32 = 1;
+    var x: i32 = 1;
     write_deref(&x, 41);
     if (x != 41) {
         return 1;
     }
 
-    let mut arr: array<i32, 3> = [1, 2, 3];
+    var arr: array<i32, 3> = [1, 2, 3];
     write_index(&arr[0], 9);
     if (arr[1] != 9) {
         return 2;
     }
 
-    let mut pair: Pair = Pair { a: 7, b: 8 };
+    var pair: Pair = Pair { a: 7, b: 8 };
     write_field(&pair, 99);
     if (pair.b != 99) {
         return 3;
@@ -2125,14 +2148,14 @@ fun main() -> i32 {
         return 5;
     }
 
-    let mut array_ptr_target: array<i32, 3> = [4, 5, 6];
+    var array_ptr_target: array<i32, 3> = [4, 5, 6];
     write_array_pointer(&array_ptr_target, 23);
     if (array_ptr_target[1] != 23) {
         return 6;
     }
 
-    let mut y: i32 = 88;
-    let mut pointer_box: PointerBox = PointerBox { data: &x };
+    var y: i32 = 88;
+    var pointer_box: PointerBox = PointerBox { data: &x };
     write_pointer_field(&pointer_box, &y);
     if (pointer_box.data != &y) {
         return 7;
@@ -2182,8 +2205,8 @@ fn freestanding_codegen_marks_functions_no_red_zone() {
         "leaf.wave",
         r#"
 fun leaf(a: i64, b: i64, c: i64, d: i64, e: i64) -> i64 {
-    let x: i64 = a + b;
-    let y: i64 = c + d;
+    var x: i64 = a + b;
+    var y: i64 = c + d;
     return x + y + e;
 }
 "#,
@@ -2446,7 +2469,7 @@ fun main() {
         "expr_noreturn.wave",
         r#"
 fun main() -> i64 {
-    let x: i64 = asm {
+    var x: i64 = asm {
         "jmp rax"
         in("rax") 0
         clobber("noreturn")
@@ -2476,7 +2499,7 @@ fun main() -> i64 {
         "clobber_operand_conflict.wave",
         r#"
 fun main() {
-    let x: i64 = 1;
+    var x: i64 = 1;
     asm {
         "mov rax, rax"
         in("rax") x
@@ -2706,7 +2729,7 @@ export(c) fun wave_make(a: u64, b: u64, c: u64) -> Triple {
 }
 
 fun main() -> i32 {
-    let value: Triple = wave_make(1, 2, 3);
+    var value: Triple = wave_make(1, 2, 3);
     if (wave_take(value) != 3) {
         return 1;
     }
@@ -2759,8 +2782,8 @@ fun main() -> i32 {
     if (c_i8(-1) != -1) { return 1; }
     if (c_u8(255) != 255) { return 2; }
     if (c_u32(4294967295) != 4294967295) { return 3; }
-    let narrow: i8 = -1;
-    let single: f32 = 1.5;
+    var narrow: i8 = -1;
+    var single: f32 = 1.5;
     if (c_variadic(2, narrow, single) != 0) { return 4; }
     return 0;
 }
@@ -3094,10 +3117,10 @@ fn c_variadic_promotions_use_semantic_expression_types() {
 extern(c) fun consume(count: i32, ...) -> i64;
 fun signed_result() -> i8 { return -1; }
 fun main() -> i32 {
-    let signed: i8 = -128;
-    let unsigned: u8 = 255;
-    let zero: i8 = 0;
-    let one: i8 = 1;
+    var signed: i8 = -128;
+    var unsigned: u8 = 255;
+    var zero: i8 = 0;
+    var one: i8 = 1;
     consume(10, signed, unsigned, signed + 127, zero - one, signed * zero - one, signed < zero, !zero, (signed + 127) * one, signed_result(), 255 as u8);
     consume(2, null as ptr<byte>, null as ptr<i32>);
     return 0;

--- a/tests/fixtures/aarch64_aapcs64/interop.wave
+++ b/tests/fixtures/aarch64_aapcs64/interop.wave
@@ -37,17 +37,17 @@ fun main() -> i32 {
     if (c_f32(1.5) != 1.5) { return 3; }
     if (c_f64(2.5) != 2.5) { return 4; }
 
-    let pair: Pair = c_pair(Pair { first: 11, second: 22 });
+    var pair: Pair = c_pair(Pair { first: 11, second: 22 });
     if (pair.first != 11 || pair.second != 22) { return 5; }
-    let floats: Floats = c_floats(Floats { first: 3.5, second: 4.5 });
+    var floats: Floats = c_floats(Floats { first: 3.5, second: 4.5 });
     if (floats.first != 3.5 || floats.second != 4.5) { return 6; }
-    let mixed: Mixed = c_mixed(Mixed { floating: 5.5, integer: -6 });
+    var mixed: Mixed = c_mixed(Mixed { floating: 5.5, integer: -6 });
     if (mixed.floating != 5.5 || mixed.integer != -6) { return 7; }
-    let triple: Triple = c_triple(Triple { first: 31, second: 32, third: 33 });
+    var triple: Triple = c_triple(Triple { first: 31, second: 32, third: 33 });
     if (triple.first != 31 || triple.second != 32 || triple.third != 33) { return 8; }
     if (c_stack_ten(1, 2, 3, 4, 5, 6, 7, 8, 9, 10) != 55) { return 9; }
 
-    let export_status: i32 = c_check_wave_exports();
+    var export_status: i32 = c_check_wave_exports();
     if (export_status != 0) { return 20 + export_status; }
     return 0;
 }

--- a/tests/fixtures/c_abi_edges/interop.wave
+++ b/tests/fixtures/c_abi_edges/interop.wave
@@ -66,38 +66,38 @@ fun main() -> i32 {
     c_f64(1.5);
     c_pointer(null);
 
-    let b1: Bytes1 = c_bytes1(Bytes1 { values: [1] });
-    let b2: Bytes2 = c_bytes2(Bytes2 { values: [2, 3] });
-    let b3: Bytes3 = c_bytes3(Bytes3 { values: [3, 4, 5] });
-    let b4: Bytes4 = c_bytes4(Bytes4 { values: [4, 5, 6, 7] });
-    let b5: Bytes5 = c_bytes5(Bytes5 { values: [5, 6, 7, 8, 9] });
-    let b6: Bytes6 = c_bytes6(Bytes6 { values: [6, 7, 8, 9, 10, 11] });
-    let b7: Bytes7 = c_bytes7(Bytes7 { values: [7, 8, 9, 10, 11, 12, 13] });
-    let b8: Bytes8 = c_bytes8(Bytes8 { values: [8, 9, 10, 11, 12, 13, 14, 15] });
-    let b9: Bytes9 = c_bytes9(Bytes9 { values: [9, 10, 11, 12, 13, 14, 15, 16, 17] });
-    let b12: Bytes12 = c_bytes12(Bytes12 { values: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23] });
-    let b16: Bytes16 = c_bytes16(Bytes16 { values: [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31] });
+    var b1: Bytes1 = c_bytes1(Bytes1 { values: [1] });
+    var b2: Bytes2 = c_bytes2(Bytes2 { values: [2, 3] });
+    var b3: Bytes3 = c_bytes3(Bytes3 { values: [3, 4, 5] });
+    var b4: Bytes4 = c_bytes4(Bytes4 { values: [4, 5, 6, 7] });
+    var b5: Bytes5 = c_bytes5(Bytes5 { values: [5, 6, 7, 8, 9] });
+    var b6: Bytes6 = c_bytes6(Bytes6 { values: [6, 7, 8, 9, 10, 11] });
+    var b7: Bytes7 = c_bytes7(Bytes7 { values: [7, 8, 9, 10, 11, 12, 13] });
+    var b8: Bytes8 = c_bytes8(Bytes8 { values: [8, 9, 10, 11, 12, 13, 14, 15] });
+    var b9: Bytes9 = c_bytes9(Bytes9 { values: [9, 10, 11, 12, 13, 14, 15, 16, 17] });
+    var b12: Bytes12 = c_bytes12(Bytes12 { values: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23] });
+    var b16: Bytes16 = c_bytes16(Bytes16 { values: [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31] });
     if (b1.values[0] != 1 || b2.values[1] != 3 || b3.values[2] != 5) { return 1; }
     if (b4.values[3] != 7 || b5.values[4] != 9 || b6.values[5] != 11) { return 2; }
     if (b7.values[6] != 13 || b8.values[7] != 15 || b9.values[8] != 17) { return 3; }
     if (b12.values[11] != 23 || b16.values[15] != 31) { return 4; }
 
-    let nested: Nested = c_nested(Nested { head: Bytes3 { values: [1, 2, 3] }, tail: Bytes5 { values: [4, 5, 6, 7, 8] } });
-    let array_member: ArrayMember = c_array_member(ArrayMember { values: [101, 102, 103] });
-    let pointer_member: PointerMember = c_pointer_member(PointerMember { value: null });
+    var nested: Nested = c_nested(Nested { head: Bytes3 { values: [1, 2, 3] }, tail: Bytes5 { values: [4, 5, 6, 7, 8] } });
+    var array_member: ArrayMember = c_array_member(ArrayMember { values: [101, 102, 103] });
+    var pointer_member: PointerMember = c_pointer_member(PointerMember { value: null });
     if (nested.head.values[2] != 3 || nested.tail.values[4] != 8) { return 5; }
     if (array_member.values[2] != 103 || pointer_member.value != null) { return 6; }
 
-    let signed: i8 = -128;
-    let unsigned: u8 = 255;
-    let zero: i8 = 0;
-    let one: i8 = 1;
+    var signed: i8 = -128;
+    var unsigned: u8 = 255;
+    var zero: i8 = 0;
+    var one: i8 = 1;
     if (c_promotions(10, signed, unsigned, signed + 127, zero - one, signed * zero - one, signed < zero, !zero, (signed + 127) * one, signed_result(), 255 as u8) != 379) {
         return 7;
     }
     if (c_pointer_variadic(2, null as ptr<byte>, null as ptr<Bytes3>) != 0) { return 8; }
 
-    let export_status: i32 = c_check_wave_exports();
+    var export_status: i32 = c_check_wave_exports();
     if (export_status != 0) { return 20 + export_status; }
     return 0;
 }

--- a/tests/fixtures/riscv64_psabi/interop.wave
+++ b/tests/fixtures/riscv64_psabi/interop.wave
@@ -66,7 +66,7 @@ export(c) fun wave_stack_ten(a0: i64, a1: i64, a2: i64, a3: i64, a4: i64, a5: i6
 export(c) fun wave_empty(value: Empty) -> Empty { return value; }
 
 fun main() -> i32 {
-    let empty: Empty = c_empty(Empty {});
+    var empty: Empty = c_empty(Empty {});
     if (c_i8(-128) != -128) { return 1; }
     if (c_u8(255) != 255) { return 2; }
     if (c_i16(-32768) != -32768) { return 3; }
@@ -74,30 +74,30 @@ fun main() -> i32 {
     if (c_i32(-2147483648) != -2147483648) { return 5; }
     if (c_u32(4294967295) != 4294967295) { return 6; }
 
-    let one: One = c_one(One { value: 7 });
+    var one: One = c_one(One { value: 7 });
     if (one.value != 7) { return 7; }
 
-    let pair: Pair = c_pair(Pair { first: 11, second: 22 });
+    var pair: Pair = c_pair(Pair { first: 11, second: 22 });
     if (pair.first != 11 || pair.second != 22) { return 8; }
 
-    let floats: Floats = c_floats(Floats { first: 1.5, second: 2.5 });
+    var floats: Floats = c_floats(Floats { first: 1.5, second: 2.5 });
     if (floats.first != 1.5 || floats.second != 2.5) { return 9; }
 
-    let float_array: FloatArray = c_float_array(FloatArray { values: [1.25, 2.75] });
+    var float_array: FloatArray = c_float_array(FloatArray { values: [1.25, 2.75] });
     if (float_array.values[0] != 1.25 || float_array.values[1] != 2.75) { return 24; }
 
-    let mixed: Mixed = c_mixed(Mixed { floating: 3.5, integer: -7 });
+    var mixed: Mixed = c_mixed(Mixed { floating: 3.5, integer: -7 });
     if (mixed.floating != 3.5 || mixed.integer != -7) { return 10; }
 
-    let mixed_reverse: MixedReverse = c_mixed_reverse(MixedReverse { integer: -8, floating: 4.5 });
+    var mixed_reverse: MixedReverse = c_mixed_reverse(MixedReverse { integer: -8, floating: 4.5 });
     if (mixed_reverse.integer != -8 || mixed_reverse.floating != 4.5) { return 25; }
 
-    let triple: Triple = c_triple(Triple { first: 31, second: 32, third: 33 });
+    var triple: Triple = c_triple(Triple { first: 31, second: 32, third: 33 });
     if (triple.first != 31 || triple.second != 32 || triple.third != 33) { return 11; }
 
     if (c_pointer(null) != null) { return 12; }
 
-    let nested: Nested = c_nested(Nested {
+    var nested: Nested = c_nested(Nested {
         head: 41,
         body: Padded { small: 42, wide: 43 },
         tail: 44
@@ -106,36 +106,36 @@ fun main() -> i32 {
         return 13;
     }
 
-    let arrayed: Arrayed = c_arrayed(Arrayed { values: [51, 52, 53], tail: 54 });
+    var arrayed: Arrayed = c_arrayed(Arrayed { values: [51, 52, 53], tail: 54 });
     if (arrayed.values[0] != 51) { return 14; }
     if (arrayed.values[1] != 52) { return 15; }
     if (arrayed.values[2] != 53) { return 16; }
     if (arrayed.tail != 54) { return 17; }
 
-    let nine: Nine = c_nine(Nine { values: [61, 62, 63, 64, 65, 66, 67, 68, 69] });
+    var nine: Nine = c_nine(Nine { values: [61, 62, 63, 64, 65, 66, 67, 68, 69] });
     if (nine.values[0] != 61 || nine.values[8] != 69) { return 18; }
 
-    let twelve: Twelve = c_twelve(Twelve { first: 71, second: 72, third: 73 });
+    var twelve: Twelve = c_twelve(Twelve { first: 71, second: 72, third: 73 });
     if (twelve.first != 71 || twelve.second != 72 || twelve.third != 73) { return 19; }
 
     if (c_stack_ten(1, 2, 3, 4, 5, 6, 7, 8, 9, 10) != 55) { return 20; }
     if (c_variadic_sum(10, 1 as i64, 2 as i64, 3 as i64, 4 as i64, 5 as i64, 6 as i64, 7 as i64, 8 as i64, 9 as i64, 10 as i64) != 55) {
         return 21;
     }
-    let first_float: f64 = 1.25;
-    let second_float: f64 = 2.5;
-    let third_float: f64 = 3.75;
-    let promoted_float: f32 = 0.5;
+    var first_float: f64 = 1.25;
+    var second_float: f64 = 2.5;
+    var third_float: f64 = 3.75;
+    var promoted_float: f32 = 0.5;
     if (c_variadic_f64(4, first_float, second_float, third_float, promoted_float) != 8.0) { return 22; }
-    let signed_small: i8 = -3;
-    let unsigned_small: u8 = 250;
-    let signed_short: i16 = -4;
-    let unsigned_short: u16 = 65000;
+    var signed_small: i8 = -3;
+    var unsigned_small: u8 = 250;
+    var signed_short: i16 = -4;
+    var unsigned_short: u16 = 65000;
     if (c_variadic_promotions(4, signed_small, unsigned_small, signed_short, unsigned_short) != 65243) {
         return 23;
     }
 
-    let export_status: i32 = c_check_wave_exports();
+    var export_status: i32 = c_check_wave_exports();
     if (export_status != 0) { return 30 + export_status; }
     return 0;
 }

--- a/tests/fixtures/x86_64_sysv/interop.wave
+++ b/tests/fixtures/x86_64_sysv/interop.wave
@@ -37,17 +37,17 @@ fun main() -> i32 {
     if (c_f32(1.5) != 1.5) { return 3; }
     if (c_f64(2.5) != 2.5) { return 4; }
 
-    let pair: Pair = c_pair(Pair { first: 11, second: 22 });
+    var pair: Pair = c_pair(Pair { first: 11, second: 22 });
     if (pair.first != 11 || pair.second != 22) { return 5; }
-    let floats: Floats = c_floats(Floats { first: 3.5, second: 4.5 });
+    var floats: Floats = c_floats(Floats { first: 3.5, second: 4.5 });
     if (floats.first != 3.5 || floats.second != 4.5) { return 6; }
-    let mixed: Mixed = c_mixed(Mixed { floating: 5.5, integer: -6 });
+    var mixed: Mixed = c_mixed(Mixed { floating: 5.5, integer: -6 });
     if (mixed.floating != 5.5 || mixed.integer != -6) { return 7; }
-    let triple: Triple = c_triple(Triple { first: 31, second: 32, third: 33 });
+    var triple: Triple = c_triple(Triple { first: 31, second: 32, third: 33 });
     if (triple.first != 31 || triple.second != 32 || triple.third != 33) { return 8; }
     if (c_stack_ten(1, 2, 3, 4, 5, 6, 7, 8, 9, 10) != 55) { return 9; }
 
-    let export_status: i32 = c_check_wave_exports();
+    var export_status: i32 = c_check_wave_exports();
     if (export_status != 0) { return 20 + export_status; }
     return 0;
 }

--- a/tools/check_std_policy.sh
+++ b/tools/check_std_policy.sh
@@ -30,11 +30,11 @@ if [[ -n "$libc_import_hits" ]]; then
   fi
 fi
 
-echo "[check] rule: std/** must not use 'var' declarations"
-var_hits="$(rg -n "\\bvar\\b" std --glob '*.wave' || true)"
-if [[ -n "$var_hits" ]]; then
-  echo "[FAIL] var declaration found in std:"
-  printf '%s\n' "$var_hits"
+echo "[check] rule: Wave sources must not use retired let declarations"
+let_hits="$(rg -n '(^|[({;])[[:space:]]*let([[:space:]]+mut)?[[:space:]]+[[:alpha:]_][[:alnum:]_]*[[:space:]]*:' . --glob '*.wave' || true)"
+if [[ -n "$let_hits" ]]; then
+  echo "[FAIL] retired let declaration found:"
+  printf '%s\n' "$let_hits"
   failed=1
 fi
 

--- a/tools/check_wave_corpus.py
+++ b/tools/check_wave_corpus.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+# This file is part of the Wave language project.
+# Copyright (c) 2024–2026 Wave Foundation
+# Copyright (c) 2024–2026 LunaStev and contributors
+#
+# This Source Code Form is subject to the terms of the
+# Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+# AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+
+"""Check every maintained Wave example and standard-library source file."""
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--wavec",
+        type=Path,
+        help="compiler executable (defaults to WAVEC or a local build)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=15.0,
+        help="per-file timeout in seconds (default: 15)",
+    )
+    return parser.parse_args()
+
+
+def resolve_wavec(explicit: Path | None) -> Path:
+    candidates = []
+    if explicit is not None:
+        candidates.append(explicit)
+    if os.environ.get("WAVEC"):
+        candidates.append(Path(os.environ["WAVEC"]))
+    candidates.extend(
+        [
+            ROOT / "target" / "release" / "wavec.exe",
+            ROOT / "target" / "release" / "wavec",
+            ROOT / "target" / "debug" / "wavec.exe",
+            ROOT / "target" / "debug" / "wavec",
+            ROOT / "target" / "x86_64-pc-windows-gnu" / "release" / "wavec.exe",
+            ROOT / "target" / "x86_64-pc-windows-gnu" / "debug" / "wavec.exe",
+        ]
+    )
+
+    for candidate in candidates:
+        path = candidate if candidate.is_absolute() else ROOT / candidate
+        if path.is_file():
+            return path
+
+    raise FileNotFoundError("wavec not found; build it or pass --wavec")
+
+
+def corpus_files() -> list[Path]:
+    files = set((ROOT / "examples").rglob("*.wave"))
+    files.update((ROOT / "std").rglob("*.wave"))
+    return sorted(files)
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        wavec = resolve_wavec(args.wavec)
+    except FileNotFoundError as error:
+        print(error, file=sys.stderr)
+        return 2
+
+    files = corpus_files()
+    failures: list[tuple[Path, str]] = []
+
+    print(f"Checking {len(files)} Wave corpus files with {wavec}")
+    with tempfile.TemporaryDirectory(prefix="wave-corpus-home-") as temp_home:
+        std_dest = Path(temp_home) / ".wave" / "lib" / "wave" / "std"
+        std_dest.parent.mkdir(parents=True)
+        shutil.copytree(ROOT / "std", std_dest)
+        compiler_env = os.environ.copy()
+        compiler_env["HOME"] = temp_home
+
+        for path in files:
+            relative = path.relative_to(ROOT)
+            try:
+                result = subprocess.run(
+                    [str(wavec), "check", str(relative)],
+                    cwd=ROOT,
+                    env=compiler_env,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    timeout=args.timeout,
+                    check=False,
+                )
+            except subprocess.TimeoutExpired:
+                failures.append((relative, f"timed out after {args.timeout:g}s"))
+                print(f"[TIMEOUT] {relative}")
+                continue
+
+            if result.returncode == 0:
+                print(f"[PASS] {relative}")
+                continue
+
+            detail = "\n".join(
+                part.rstrip() for part in (result.stdout, result.stderr) if part.strip()
+            )
+            failures.append((relative, detail or f"exit status {result.returncode}"))
+            print(f"[FAIL] {relative}")
+
+    print(f"Corpus result: {len(files) - len(failures)} passed, {len(failures)} failed")
+    for relative, detail in failures:
+        print(f"\n--- {relative} ---\n{detail}", file=sys.stderr)
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -15,6 +15,7 @@
 import subprocess
 import time
 import argparse
+import json
 from pathlib import Path
 import threading
 import socket
@@ -111,6 +112,12 @@ def parse_args():
         default=[],
         metavar="NAME",
         help="skip the named test; may be repeated",
+    )
+    parser.add_argument(
+        "--report-json",
+        type=Path,
+        metavar="PATH",
+        help="write a machine-readable result report",
     )
     return parser.parse_args()
 
@@ -215,25 +222,25 @@ def run_test56_server(cmd):
 
         if b"Welcome to the Wave HTTP Server!" in data:
             print(f"{GREEN}→ PASS (server responded){RESET}\n")
-            return 1
+            return 1, None
         else:
             print(f"{RED}→ FAIL (unexpected response){RESET}")
             print(data)
-            return 0
+            return 0, None
 
     except OSError as e:
         if e.errno in {errno.EPERM, errno.EACCES}:
             print(f"{CYAN}→ SKIP (local TCP sockets blocked by environment){RESET}\n")
-            return 2
+            return 2, "local TCP sockets blocked by environment"
 
         print(f"{RED}→ FAIL (server not responding){RESET}")
         print(e)
-        return 0
+        return 0, None
 
     except Exception as e:
         print(f"{RED}→ FAIL (server not responding){RESET}")
         print(e)
-        return 0
+        return 0, None
 
     finally:
         proc.terminate()
@@ -267,7 +274,7 @@ def run_and_classify(name, rel_path, cmd):
     skip_reason = skip_reason_for_metadata(name, rel_path)
     if skip_reason is not None:
         print(f"{CYAN}→ SKIP ({skip_reason}){RESET}\n")
-        return 2
+        return 2, skip_reason
 
     metadata = parse_test_metadata(rel_path)
     expected_exit = metadata.expected_exit
@@ -308,12 +315,12 @@ def run_and_classify(name, rel_path, cmd):
                 print(f"{YELLOW}--- STDERR ---{RESET}")
                 print(result.stderr.rstrip())
             print()
-            return 0
+            return 0, None
 
         if result.returncode == expected_exit:
             if expected_exit != 0:
                 print(f"{MAGENTA}→ PASS (expected exit={expected_exit}){RESET}\n")
-                return 3
+                return 3, None
             artifact_error = validate_compiled_artifact(
                 name,
                 ROOT / rel_path,
@@ -324,9 +331,9 @@ def run_and_classify(name, rel_path, cmd):
                 print(f"{RED}→ FAIL (artifact contract){RESET}")
                 print(artifact_error)
                 print()
-                return 0
+                return 0, None
             print(f"{GREEN}→ PASS{RESET}\n")
-            return 1
+            return 1, None
 
         print(
             f"{RED}→ FAIL (exit={result.returncode}, expected={expected_exit}){RESET}"
@@ -338,15 +345,15 @@ def run_and_classify(name, rel_path, cmd):
             print(f"{YELLOW}--- STDERR ---{RESET}")
             print(result.stderr.rstrip())
         print()
-        return 0
+        return 0, None
 
     except subprocess.TimeoutExpired:
         if name in KNOWN_TIMEOUT:
             print(f"{CYAN}→ SKIP (expected blocking / unimplemented){RESET}\n")
-            return 2
+            return 2, "expected blocking / unimplemented"
         else:
             print(f"{YELLOW}→ TIMEOUT ({TIMEOUT_SEC}s){RESET}\n")
-            return -1
+            return -1, f"timed out after {TIMEOUT_SEC}s"
 
 entries = list(iter_test_entries())
 selected_names = {name for name, _ in entries}
@@ -364,12 +371,12 @@ if not entries:
 
 try:
     for name, rel_path in entries:
-        result = run_and_classify(
+        result, detail = run_and_classify(
             name,
             rel_path,
             command_for_test(name, rel_path)
         )
-        results.append((name, result))
+        results.append((name, result, detail))
 
         time.sleep(0.3)
 except KeyboardInterrupt:
@@ -381,11 +388,11 @@ except ValueError as error:
 finally:
     shutil.rmtree(TEST_OUTPUT_DIR, ignore_errors=True)
 
-pass_zero = [name for name, r in results if r == 1]
-pass_nonzero = [name for name, r in results if r == 3]
-fail_tests = [name for name, r in results if r == 0]
-timeout_tests = [name for name, r in results if r == -1]
-skip_tests = [name for name, r in results if r == 2]
+pass_zero = [name for name, result, _ in results if result == 1]
+pass_nonzero = [name for name, result, _ in results if result == 3]
+fail_tests = [name for name, result, _ in results if result == 0]
+timeout_tests = [name for name, result, _ in results if result == -1]
+skip_tests = [name for name, result, _ in results if result == 2]
 
 print("\n=========================")
 print("🎉 FINAL TEST RESULT")
@@ -419,5 +426,37 @@ print(f"{RED}FAIL: {len(fail_tests)}{RESET}")
 print(f"{YELLOW}TIMEOUT: {len(timeout_tests)}{RESET}")
 print("=========================\n")
 
-if fail_tests or timeout_tests:
+report_failed = False
+if ARGS.report_json is not None:
+    statuses = {-1: "timeout", 0: "fail", 1: "pass", 2: "skip", 3: "pass"}
+    report = {
+        "compiler": str(WAVEC),
+        "host": {"os": HOST_OS, "arch": HOST_ARCH},
+        "summary": {
+            "pass": len(pass_zero) + len(pass_nonzero),
+            "skip": len(skip_tests),
+            "fail": len(fail_tests),
+            "timeout": len(timeout_tests),
+        },
+        "tests": [
+            {
+                "name": name,
+                "status": statuses[result],
+                **({"reason": detail} if detail else {}),
+            }
+            for name, result, detail in results
+        ],
+    }
+    try:
+        ARGS.report_json.parent.mkdir(parents=True, exist_ok=True)
+        ARGS.report_json.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print(f"Wrote test report to {ARGS.report_json}")
+    except OSError as error:
+        print(f"failed to write test report: {error}", file=sys.stderr)
+        report_failed = True
+
+if fail_tests or timeout_tests or report_failed:
     sys.exit(1)


### PR DESCRIPTION
## Summary

- retire `let` and `let mut` declarations in favor of the Wave-native `var` syntax, including `for` initializers
- migrate maintained examples, standard-library modules, tests, and ABI fixtures to `var`
- add std policy, warning-free rustdoc, examples/std corpus, feature-matrix, and platform E2E report gates to CI
- require a dedicated RV64 ABI and hosted Linux/QEMU validation job before release packaging
- make macOS Intel CI blocking and preserve platform skip reasons as JSON artifacts

## Testing

- `cargo fmt --all --check`
- `cargo check --locked --jobs 2`
- `cargo clippy --locked --all-targets --jobs 2 -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --jobs 2`
- `cargo test --locked --all-targets --jobs 2` (37 passed)
- `cargo build --locked --release --jobs 2`
- RISC-V-only and core64 LLVM feature builds
- RV64 QEMU contract tests (8 passed)
- maintained Wave corpus (92 passed)
- Wave E2E (100 passed, 8 platform/environment skips, 0 failed, 0 timed out)
- Python tooling tests, workflow YAML parsing, std policy check, and `git diff --check`
