### PR TITLE
Implement typed HIR variant frontend

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 open_collective: wave-lang
-github: [wavefnd, LunaStev]
+github: LunaStev

--- a/front/lexer/src/ident.rs
+++ b/front/lexer/src/ident.rs
@@ -71,6 +71,11 @@ impl<'a> Lexer<'a> {
                 lexeme: "enum".to_string(),
                 line: self.line,
             },
+            "variant" => Token {
+                token_type: TokenType::Variant,
+                lexeme: "variant".to_string(),
+                line: self.line,
+            },
             "static" => Token {
                 token_type: TokenType::Static,
                 lexeme: "static".to_string(),

--- a/front/lexer/src/token.rs
+++ b/front/lexer/src/token.rs
@@ -92,6 +92,7 @@ pub enum TokenType {
     Pub,
     Type,
     Enum,
+    Variant,
     Static,
     Var,
     Let,

--- a/front/parser/src/ast.rs
+++ b/front/parser/src/ast.rs
@@ -40,6 +40,7 @@ pub enum WaveType {
     Array(Box<WaveType>, u32),
     Void,
     Struct(String),
+    Variant(String),
 }
 
 #[derive(Debug, Clone)]
@@ -54,6 +55,7 @@ pub enum ASTNode {
     ProtoImpl(ProtoImplNode),
     TypeAlias(TypeAliasNode),
     Enum(EnumNode),
+    Variant(VariantNode),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -82,6 +84,20 @@ pub struct EnumNode {
 pub struct EnumVariantNode {
     pub name: String,
     pub explicit_value: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct VariantNode {
+    pub name: String,
+    pub generic_params: Vec<String>,
+    pub cases: Vec<VariantCaseNode>,
+    pub visibility: Visibility,
+}
+
+#[derive(Debug, Clone)]
+pub struct VariantCaseNode {
+    pub name: String,
+    pub payload_types: Vec<WaveType>,
 }
 
 #[derive(Debug, Clone)]
@@ -270,7 +286,13 @@ pub enum AssignOperator {
 pub enum MatchPattern {
     Int(String),
     Ident(String),
+    Binding(String),
     Wildcard,
+    Variant {
+        variant_type: String,
+        case_name: String,
+        payloads: Vec<MatchPattern>,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/front/parser/src/generics.rs
+++ b/front/parser/src/generics.rs
@@ -19,7 +19,7 @@
 use crate::ast::{
     ASTNode, EnumNode, Expression, ExternFunctionNode, FunctionNode, Literal, MatchArm,
     MatchPattern, ParameterNode, ProtoImplNode, StatementNode, StructNode, TypeAliasNode, Value,
-    VariableNode, WaveType,
+    VariableNode, VariantNode, WaveType,
 };
 use crate::types::{parse_type, split_top_level_generic_args, token_type_to_wave_type};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -31,6 +31,7 @@ struct GenericEnv {
     function_templates: HashMap<String, FunctionNode>,
     function_parameters: HashMap<String, Vec<ParameterNode>>,
     struct_templates: HashMap<String, StructNode>,
+    variant_generic_params: HashMap<String, Vec<String>>,
 
     function_instances: BTreeMap<String, FunctionNode>,
     struct_instances: BTreeMap<String, StructNode>,
@@ -83,6 +84,10 @@ pub fn monomorphize_generics(ast: Vec<ASTNode>) -> Result<Vec<ASTNode>, String> 
                     return Err(format!("duplicate generic struct template '{}'", s.name));
                 }
             }
+            ASTNode::Variant(variant) => {
+                env.variant_generic_params
+                    .insert(variant.name.clone(), variant.generic_params.clone());
+            }
             _ => {}
         }
     }
@@ -108,6 +113,13 @@ pub fn monomorphize_generics(ast: Vec<ASTNode>) -> Result<Vec<ASTNode>, String> 
             }
 
             ASTNode::Struct(_) => {}
+            ASTNode::Variant(variant) => {
+                out.push(ASTNode::Variant(rewrite_variant(
+                    variant,
+                    &empty_subst,
+                    &mut env,
+                )?));
+            }
             ASTNode::Variable(v) => {
                 out.push(ASTNode::Variable(rewrite_variable(
                     v,
@@ -261,6 +273,21 @@ fn rewrite_struct(
     Ok(s)
 }
 
+fn rewrite_variant(
+    mut variant: VariantNode,
+    subst: &HashMap<String, WaveType>,
+    env: &mut GenericEnv,
+) -> Result<VariantNode, String> {
+    for case in &mut variant.cases {
+        case.payload_types = case
+            .payload_types
+            .iter()
+            .map(|ty| rewrite_wave_type(ty, subst, env))
+            .collect::<Result<Vec<_>, _>>()?;
+    }
+    Ok(variant)
+}
+
 fn rewrite_proto(
     mut p: ProtoImplNode,
     subst: &HashMap<String, WaveType>,
@@ -321,6 +348,7 @@ fn rewrite_node(
         ASTNode::Expression(e) => Ok(ASTNode::Expression(rewrite_expression(e, subst, env)?)),
         ASTNode::Function(f) => Ok(ASTNode::Function(rewrite_function(f, subst, env)?)),
         ASTNode::Struct(s) => Ok(ASTNode::Struct(rewrite_struct(s, subst, env)?)),
+        ASTNode::Variant(variant) => Ok(ASTNode::Variant(rewrite_variant(variant, subst, env)?)),
         ASTNode::ExternFunction(e) => Ok(ASTNode::ExternFunction(rewrite_extern(e, subst, env)?)),
         ASTNode::ProtoImpl(p) => Ok(ASTNode::ProtoImpl(rewrite_proto(p, subst, env)?)),
         ASTNode::TypeAlias(TypeAliasNode {
@@ -669,6 +697,7 @@ fn rewrite_wave_type(
             *n,
         )),
         WaveType::Struct(name) => rewrite_struct_type(name, subst, env),
+        WaveType::Variant(name) => Ok(WaveType::Variant(name.clone())),
         _ => Ok(ty.clone()),
     }
 }
@@ -683,6 +712,29 @@ fn rewrite_struct_type(
     }
 
     if let Some((base, arg_strs)) = parse_type_application(name)? {
+        if let Some(parameters) = env.variant_generic_params.get(&base).cloned() {
+            if parameters.len() != arg_strs.len() {
+                return Err(format!(
+                    "generic variant '{}' expects {} type arguments, got {}",
+                    base,
+                    parameters.len(),
+                    arg_strs.len()
+                ));
+            }
+            let arguments = arg_strs
+                .into_iter()
+                .map(|argument| {
+                    let parsed = parse_wave_type_from_str(&argument)?;
+                    let rewritten = rewrite_wave_type(&parsed, subst, env)?;
+                    Ok(display_type_for_application(&rewritten))
+                })
+                .collect::<Result<Vec<_>, String>>()?;
+            return Ok(WaveType::Struct(format!(
+                "{}<{}>",
+                base,
+                arguments.join(",")
+            )));
+        }
         if !env.struct_templates.contains_key(&base) {
             return Err(format!(
                 "generic type '{}' is not declared as a generic struct",
@@ -888,6 +940,26 @@ fn mangle_type(ty: &WaveType) -> String {
         WaveType::Pointer(inner) => format!("p_{}", mangle_type(inner)),
         WaveType::Array(inner, n) => format!("a{}_{}", n, mangle_type(inner)),
         WaveType::Struct(name) => sanitize_ident(name),
+        WaveType::Variant(name) => format!("v_{}", sanitize_ident(name)),
+    }
+}
+
+fn display_type_for_application(ty: &WaveType) -> String {
+    match ty {
+        WaveType::Infer => "infer".to_string(),
+        WaveType::Int(bits) => format!("i{}", bits),
+        WaveType::Uint(bits) => format!("u{}", bits),
+        WaveType::Float(bits) => format!("f{}", bits),
+        WaveType::Bool => "bool".to_string(),
+        WaveType::Char => "char".to_string(),
+        WaveType::Byte => "byte".to_string(),
+        WaveType::String => "str".to_string(),
+        WaveType::Pointer(inner) => format!("ptr<{}>", display_type_for_application(inner)),
+        WaveType::Array(inner, size) => {
+            format!("array<{},{}>", display_type_for_application(inner), size)
+        }
+        WaveType::Void => "void".to_string(),
+        WaveType::Struct(name) | WaveType::Variant(name) => name.clone(),
     }
 }
 

--- a/front/parser/src/hir.rs
+++ b/front/parser/src/hir.rs
@@ -1,0 +1,455 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024–2026 Wave Foundation
+// Copyright (c) 2024–2026 LunaStev and contributors
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+
+//! Backend-neutral typed frontend program.
+//!
+//! [`TypedProgram`] is the boundary after import expansion, generic
+//! monomorphization, and semantic validation. It owns the final source AST in
+//! stable storage and assigns every expression a stable [`ExpressionId`]. This
+//! lets future variant and async lowering attach semantic facts without using
+//! backend-owned state or expression addresses as public identities.
+
+use crate::ast::{ASTNode, Expression, MatchPattern, StatementNode, WaveType};
+use crate::verification::{analyze_hir_expression_types, SemanticDiagnostic};
+use std::collections::HashMap;
+use std::fmt;
+
+/// Stable identity of an expression within one [`TypedProgram`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ExpressionId(usize);
+
+impl ExpressionId {
+    pub fn index(self) -> usize {
+        self.0
+    }
+}
+
+/// Stable identity of a match pattern within one [`TypedProgram`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct PatternId(usize);
+
+impl PatternId {
+    pub fn index(self) -> usize {
+        self.0
+    }
+}
+
+/// The semantic type known before contextual lowering is performed.
+///
+/// Literal forms remain explicit because their final representation can depend
+/// on an assignment, argument, return, or aggregate context. They are not
+/// silently committed to a backend type at this boundary.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HirExpressionType {
+    Resolved(WaveType),
+    IntegerLiteral,
+    FloatLiteral,
+    Null,
+    ArrayLiteral,
+    AddressedArrayLiteral,
+    Unknown,
+}
+
+/// Fully resolved variant constructor selected by semantic analysis.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HirVariantConstruction {
+    pub variant_type: WaveType,
+    pub case_name: String,
+    pub discriminant: u32,
+    pub payload_types: Vec<WaveType>,
+}
+
+/// Concrete variant case selected by a semantically validated pattern.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HirVariantPattern {
+    pub variant_type: WaveType,
+    pub case_name: String,
+    pub discriminant: u32,
+    pub payload_types: Vec<WaveType>,
+}
+
+/// Semantically validated frontend program consumed by later lowering passes.
+///
+/// The syntax is boxed before analysis, so moving `TypedProgram` never changes
+/// expression addresses. Addresses are only an internal lookup optimization;
+/// consumers observe stable `ExpressionId` values.
+#[derive(Debug)]
+pub struct TypedProgram {
+    syntax: Box<[ASTNode]>,
+    expression_ids: HashMap<usize, ExpressionId>,
+    expression_types: Vec<HirExpressionType>,
+    variant_constructions: Vec<Option<HirVariantConstruction>>,
+    pattern_ids: HashMap<usize, PatternId>,
+    variant_patterns: Vec<Option<HirVariantPattern>>,
+}
+
+/// Semantic lowering failure that retains the syntax used for source mapping.
+#[derive(Debug)]
+pub struct HirLoweringError {
+    syntax: Box<[ASTNode]>,
+    diagnostic: SemanticDiagnostic,
+}
+
+impl HirLoweringError {
+    pub fn syntax(&self) -> &[ASTNode] {
+        &self.syntax
+    }
+
+    pub fn diagnostic(&self) -> &SemanticDiagnostic {
+        &self.diagnostic
+    }
+
+    pub fn into_parts(self) -> (Box<[ASTNode]>, SemanticDiagnostic) {
+        (self.syntax, self.diagnostic)
+    }
+}
+
+impl fmt::Display for HirLoweringError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.diagnostic.fmt(formatter)
+    }
+}
+
+impl std::error::Error for HirLoweringError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.diagnostic)
+    }
+}
+
+impl TypedProgram {
+    /// Validates a final AST and builds its stable typed frontend representation.
+    pub fn lower(syntax: Vec<ASTNode>) -> Result<Self, HirLoweringError> {
+        let syntax = syntax.into_boxed_slice();
+        let (analyzed_types, analyzed_variants, analyzed_patterns) =
+            match analyze_hir_expression_types(&syntax) {
+                Ok(analysis) => analysis,
+                Err(diagnostic) => return Err(HirLoweringError { syntax, diagnostic }),
+            };
+        let mut expression_ids = HashMap::with_capacity(analyzed_types.len());
+        let mut expression_types = Vec::with_capacity(analyzed_types.len());
+        let mut variant_constructions = Vec::with_capacity(analyzed_variants.len());
+
+        walk_nodes(&syntax, &mut |expression| {
+            let address = expression as *const Expression as usize;
+            let id = ExpressionId(expression_types.len());
+            expression_ids.insert(address, id);
+            expression_types.push(
+                analyzed_types
+                    .get(&address)
+                    .cloned()
+                    .unwrap_or(HirExpressionType::Unknown),
+            );
+            variant_constructions.push(analyzed_variants.get(&address).cloned());
+        });
+
+        let mut pattern_ids = HashMap::with_capacity(analyzed_patterns.len());
+        let mut variant_patterns = Vec::with_capacity(analyzed_patterns.len());
+        walk_patterns_in_nodes(&syntax, &mut |pattern| {
+            let address = pattern as *const MatchPattern as usize;
+            let id = PatternId(variant_patterns.len());
+            pattern_ids.insert(address, id);
+            variant_patterns.push(analyzed_patterns.get(&address).cloned());
+        });
+
+        Ok(Self {
+            syntax,
+            expression_ids,
+            expression_types,
+            variant_constructions,
+            pattern_ids,
+            variant_patterns,
+        })
+    }
+
+    pub fn syntax(&self) -> &[ASTNode] {
+        &self.syntax
+    }
+
+    pub fn expression_count(&self) -> usize {
+        self.expression_types.len()
+    }
+
+    pub fn expression_id(&self, expression: &Expression) -> Option<ExpressionId> {
+        self.expression_ids
+            .get(&(expression as *const Expression as usize))
+            .copied()
+    }
+
+    pub fn expression_type(&self, id: ExpressionId) -> Option<&HirExpressionType> {
+        self.expression_types.get(id.index())
+    }
+
+    pub fn type_of(&self, expression: &Expression) -> Option<&HirExpressionType> {
+        self.expression_id(expression)
+            .and_then(|id| self.expression_type(id))
+    }
+
+    pub fn variant_construction(&self, id: ExpressionId) -> Option<&HirVariantConstruction> {
+        self.variant_constructions.get(id.index())?.as_ref()
+    }
+
+    pub fn pattern_id(&self, pattern: &MatchPattern) -> Option<PatternId> {
+        self.pattern_ids
+            .get(&(pattern as *const MatchPattern as usize))
+            .copied()
+    }
+
+    pub fn variant_pattern(&self, id: PatternId) -> Option<&HirVariantPattern> {
+        self.variant_patterns.get(id.index())?.as_ref()
+    }
+}
+
+fn walk_nodes(nodes: &[ASTNode], visit: &mut impl FnMut(&Expression)) {
+    for node in nodes {
+        walk_node(node, visit);
+    }
+}
+
+fn walk_node(node: &ASTNode, visit: &mut impl FnMut(&Expression)) {
+    match node {
+        ASTNode::Function(function) => walk_nodes(&function.body, visit),
+        ASTNode::Struct(structure) => {
+            for method in &structure.methods {
+                walk_nodes(&method.body, visit);
+            }
+        }
+        ASTNode::ProtoImpl(implementation) => {
+            for method in &implementation.methods {
+                walk_nodes(&method.body, visit);
+            }
+        }
+        ASTNode::Statement(statement) => walk_statement(statement, visit),
+        ASTNode::Variable(variable) => {
+            if let Some(initializer) = &variable.initial_value {
+                walk_expression(initializer, visit);
+            }
+        }
+        ASTNode::Expression(expression) => walk_expression(expression, visit),
+        ASTNode::ExternFunction(_)
+        | ASTNode::Program(_)
+        | ASTNode::TypeAlias(_)
+        | ASTNode::Enum(_)
+        | ASTNode::Variant(_) => {}
+    }
+}
+
+fn walk_statement(statement: &StatementNode, visit: &mut impl FnMut(&Expression)) {
+    match statement {
+        StatementNode::PrintFormat { args, .. }
+        | StatementNode::PrintlnFormat { args, .. }
+        | StatementNode::Input { args, .. } => {
+            for argument in args {
+                walk_expression(argument, visit);
+            }
+        }
+        StatementNode::If {
+            condition,
+            body,
+            else_if_blocks,
+            else_block,
+        } => {
+            walk_expression(condition, visit);
+            walk_nodes(body, visit);
+            if let Some(blocks) = else_if_blocks {
+                for (condition, body) in blocks.iter() {
+                    walk_expression(condition, visit);
+                    walk_nodes(body, visit);
+                }
+            }
+            if let Some(body) = else_block {
+                walk_nodes(body, visit);
+            }
+        }
+        StatementNode::For {
+            initialization,
+            condition,
+            increment,
+            body,
+        } => {
+            walk_node(initialization, visit);
+            walk_expression(condition, visit);
+            walk_expression(increment, visit);
+            walk_nodes(body, visit);
+        }
+        StatementNode::While { condition, body } => {
+            walk_expression(condition, visit);
+            walk_nodes(body, visit);
+        }
+        StatementNode::Match { value, arms } => {
+            walk_expression(value, visit);
+            for arm in arms {
+                walk_nodes(&arm.body, visit);
+            }
+        }
+        StatementNode::Assign { value, .. } => walk_expression(value, visit),
+        StatementNode::AsmBlock {
+            inputs, outputs, ..
+        } => {
+            for (_, expression) in inputs.iter().chain(outputs.iter()) {
+                walk_expression(expression, visit);
+            }
+        }
+        StatementNode::Return(Some(expression)) | StatementNode::Expression(expression) => {
+            walk_expression(expression, visit)
+        }
+        StatementNode::Print(_)
+        | StatementNode::Println(_)
+        | StatementNode::Variable(_)
+        | StatementNode::Import(_)
+        | StatementNode::Break
+        | StatementNode::Continue
+        | StatementNode::Return(None) => {}
+    }
+}
+
+fn walk_expression(expression: &Expression, visit: &mut impl FnMut(&Expression)) {
+    visit(expression);
+    match expression {
+        Expression::StructLiteral { fields, .. } => {
+            for (_, value) in fields {
+                walk_expression(value, visit);
+            }
+        }
+        Expression::FunctionCall { args, .. } => {
+            for argument in args {
+                walk_expression(argument, visit);
+            }
+        }
+        Expression::MethodCall { object, args, .. } => {
+            walk_expression(object, visit);
+            for argument in args {
+                walk_expression(argument, visit);
+            }
+        }
+        Expression::Deref(inner)
+        | Expression::AddressOf(inner)
+        | Expression::Grouped(inner)
+        | Expression::Unary { expr: inner, .. }
+        | Expression::Cast { expr: inner, .. }
+        | Expression::FieldAccess { object: inner, .. }
+        | Expression::IncDec { target: inner, .. } => walk_expression(inner, visit),
+        Expression::BinaryExpression { left, right, .. }
+        | Expression::IndexAccess {
+            target: left,
+            index: right,
+        }
+        | Expression::AssignOperation {
+            target: left,
+            value: right,
+            ..
+        }
+        | Expression::Assignment {
+            target: left,
+            value: right,
+        } => {
+            walk_expression(left, visit);
+            walk_expression(right, visit);
+        }
+        Expression::ArrayLiteral(values) => {
+            for value in values {
+                walk_expression(value, visit);
+            }
+        }
+        Expression::AsmBlock {
+            inputs, outputs, ..
+        } => {
+            for (_, expression) in inputs.iter().chain(outputs.iter()) {
+                walk_expression(expression, visit);
+            }
+        }
+        Expression::Null | Expression::Literal(_) | Expression::Variable(_) => {}
+    }
+}
+
+fn walk_patterns_in_nodes(nodes: &[ASTNode], visit: &mut impl FnMut(&MatchPattern)) {
+    for node in nodes {
+        match node {
+            ASTNode::Function(function) => walk_patterns_in_nodes(&function.body, visit),
+            ASTNode::Struct(structure) => {
+                for method in &structure.methods {
+                    walk_patterns_in_nodes(&method.body, visit);
+                }
+            }
+            ASTNode::ProtoImpl(implementation) => {
+                for method in &implementation.methods {
+                    walk_patterns_in_nodes(&method.body, visit);
+                }
+            }
+            ASTNode::Statement(statement) => walk_patterns_in_statement(statement, visit),
+            ASTNode::ExternFunction(_)
+            | ASTNode::Program(_)
+            | ASTNode::Variable(_)
+            | ASTNode::Expression(_)
+            | ASTNode::TypeAlias(_)
+            | ASTNode::Enum(_)
+            | ASTNode::Variant(_) => {}
+        }
+    }
+}
+
+fn walk_patterns_in_statement(statement: &StatementNode, visit: &mut impl FnMut(&MatchPattern)) {
+    match statement {
+        StatementNode::If {
+            body,
+            else_if_blocks,
+            else_block,
+            ..
+        } => {
+            walk_patterns_in_nodes(body, visit);
+            if let Some(blocks) = else_if_blocks {
+                for (_, body) in blocks.iter() {
+                    walk_patterns_in_nodes(body, visit);
+                }
+            }
+            if let Some(body) = else_block {
+                walk_patterns_in_nodes(body, visit);
+            }
+        }
+        StatementNode::For {
+            initialization,
+            body,
+            ..
+        } => {
+            walk_patterns_in_nodes(std::slice::from_ref(initialization.as_ref()), visit);
+            walk_patterns_in_nodes(body, visit);
+        }
+        StatementNode::While { body, .. } => walk_patterns_in_nodes(body, visit),
+        StatementNode::Match { arms, .. } => {
+            for arm in arms {
+                walk_pattern(&arm.pattern, visit);
+                walk_patterns_in_nodes(&arm.body, visit);
+            }
+        }
+        StatementNode::Print(_)
+        | StatementNode::PrintFormat { .. }
+        | StatementNode::Println(_)
+        | StatementNode::PrintlnFormat { .. }
+        | StatementNode::Input { .. }
+        | StatementNode::Variable(_)
+        | StatementNode::Import(_)
+        | StatementNode::Assign { .. }
+        | StatementNode::AsmBlock { .. }
+        | StatementNode::Break
+        | StatementNode::Continue
+        | StatementNode::Return(_)
+        | StatementNode::Expression(_) => {}
+    }
+}
+
+fn walk_pattern(pattern: &MatchPattern, visit: &mut impl FnMut(&MatchPattern)) {
+    visit(pattern);
+    if let MatchPattern::Variant { payloads, .. } = pattern {
+        for payload in payloads {
+            walk_pattern(payload, visit);
+        }
+    }
+}

--- a/front/parser/src/lib.rs
+++ b/front/parser/src/lib.rs
@@ -13,8 +13,9 @@
 //! Wave syntax, AST, import expansion, generic specialization, and semantic validation.
 //!
 //! Parsing intentionally produces a source-oriented AST first. Imports and
-//! generics are expanded before the semantic verifier establishes the typed
-//! program contract consumed by code generation.
+//! generics are expanded before the semantic verifier establishes a
+//! backend-neutral [`hir::TypedProgram`]. The legacy LLVM path still consumes
+//! its syntax view while backend lowering migrates to typed expression IDs.
 
 // These legacy parser APIs are being migrated incrementally; keep new lints fatal
 // without forcing risky mechanical rewrites into a release hardening change.
@@ -44,6 +45,7 @@ pub mod ast;
 pub mod expr;
 pub mod format;
 pub mod generics;
+pub mod hir;
 pub mod import;
 pub mod parser;
 pub mod stdlib;

--- a/front/parser/src/parser/control.rs
+++ b/front/parser/src/parser/control.rs
@@ -62,7 +62,10 @@ fn expect_fat_arrow(tokens: &mut Peekable<Iter<Token>>) -> bool {
     true
 }
 
-fn parse_match_pattern(tokens: &mut Peekable<Iter<Token>>) -> Option<MatchPattern> {
+fn parse_match_pattern(
+    tokens: &mut Peekable<Iter<Token>>,
+    payload_position: bool,
+) -> Option<MatchPattern> {
     skip_ws_and_newlines(tokens);
 
     match tokens.next()? {
@@ -75,10 +78,81 @@ fn parse_match_pattern(tokens: &mut Peekable<Iter<Token>>) -> Option<MatchPatter
             ..
         } => {
             if name == "_" {
-                Some(MatchPattern::Wildcard)
-            } else {
-                Some(MatchPattern::Ident(name.clone()))
+                return Some(MatchPattern::Wildcard);
             }
+
+            let mut segments = vec![name.clone()];
+            loop {
+                skip_ws_and_newlines(tokens);
+                if !matches!(
+                    tokens.peek().map(|token| &token.token_type),
+                    Some(TokenType::DoubleColon)
+                ) {
+                    break;
+                }
+                tokens.next();
+                skip_ws_and_newlines(tokens);
+                match tokens.next() {
+                    Some(Token {
+                        token_type: TokenType::Identifier(segment),
+                        ..
+                    }) => segments.push(segment.clone()),
+                    _ => {
+                        println!("Error: Expected case name after '::' in match pattern");
+                        return None;
+                    }
+                }
+            }
+
+            if segments.len() == 1 {
+                return if payload_position {
+                    Some(MatchPattern::Binding(name.clone()))
+                } else {
+                    Some(MatchPattern::Ident(name.clone()))
+                };
+            }
+
+            let case_name = segments.pop().unwrap();
+            let variant_type = segments.join("::");
+            let mut payloads = Vec::new();
+            skip_ws_and_newlines(tokens);
+            if matches!(
+                tokens.peek().map(|token| &token.token_type),
+                Some(TokenType::Lparen)
+            ) {
+                tokens.next();
+                loop {
+                    skip_ws_and_newlines(tokens);
+                    if matches!(
+                        tokens.peek().map(|token| &token.token_type),
+                        Some(TokenType::Rparen)
+                    ) {
+                        tokens.next();
+                        break;
+                    }
+                    payloads.push(parse_match_pattern(tokens, true)?);
+                    skip_ws_and_newlines(tokens);
+                    match tokens.peek().map(|token| &token.token_type) {
+                        Some(TokenType::Comma) => {
+                            tokens.next();
+                        }
+                        Some(TokenType::Rparen) => {
+                            tokens.next();
+                            break;
+                        }
+                        _ => {
+                            println!("Error: Expected ',' or ')' in variant pattern");
+                            return None;
+                        }
+                    }
+                }
+            }
+
+            Some(MatchPattern::Variant {
+                variant_type,
+                case_name,
+                payloads,
+            })
         }
         other => {
             println!(
@@ -331,20 +405,43 @@ pub fn parse_while(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
 pub fn parse_match(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
     skip_ws_and_newlines(tokens);
 
-    if tokens.peek()?.token_type != TokenType::Lparen {
-        println!("Error: Expected '(' after 'match'");
-        return None;
+    let parenthesized = tokens.peek()?.token_type == TokenType::Lparen;
+    if parenthesized {
+        tokens.next();
     }
-    tokens.next(); // consume '('
-
-    let value = parse_expression(tokens)?;
-
-    skip_ws_and_newlines(tokens);
-    if tokens.peek()?.token_type != TokenType::Rparen {
-        println!("Error: Expected ')' after match value");
-        return None;
+    let value = if parenthesized {
+        parse_expression(tokens)?
+    } else {
+        let mut expression_tokens = Vec::new();
+        while let Some(token) = tokens.peek() {
+            if token.token_type == TokenType::Lbrace {
+                break;
+            }
+            expression_tokens.push((*token).clone());
+            tokens.next();
+        }
+        let mut expression_iter = expression_tokens.iter().peekable();
+        let value = parse_expression(&mut expression_iter)?;
+        while matches!(
+            expression_iter.peek().map(|token| &token.token_type),
+            Some(TokenType::Whitespace | TokenType::Newline)
+        ) {
+            expression_iter.next();
+        }
+        if expression_iter.peek().is_some() {
+            println!("Error: Unexpected token after match value");
+            return None;
+        }
+        value
+    };
+    if parenthesized {
+        skip_ws_and_newlines(tokens);
+        if tokens.peek()?.token_type != TokenType::Rparen {
+            println!("Error: Expected ')' after match value");
+            return None;
+        }
+        tokens.next();
     }
-    tokens.next(); // consume ')'
 
     skip_ws_and_newlines(tokens);
     if tokens.peek()?.token_type != TokenType::Lbrace {
@@ -367,7 +464,7 @@ pub fn parse_match(tokens: &mut Peekable<Iter<Token>>) -> Option<ASTNode> {
             break;
         }
 
-        let pattern = parse_match_pattern(tokens)?;
+        let pattern = parse_match_pattern(tokens, false)?;
         if matches!(pattern, MatchPattern::Wildcard) {
             if saw_wildcard {
                 println!("Error: Duplicate wildcard arm `_` in match");

--- a/front/parser/src/parser/decl.rs
+++ b/front/parser/src/parser/decl.rs
@@ -18,9 +18,10 @@
 
 use crate::ast::{
     ASTNode, EnumNode, EnumVariantNode, Expression, ExternFunctionNode, Mutability, TypeAliasNode,
-    VariableNode, Visibility, WaveType,
+    VariableNode, VariantCaseNode, VariantNode, Visibility, WaveType,
 };
 use crate::expr::parse_expression;
+use crate::parser::functions::parse_generic_param_names;
 use crate::parser::types::{parse_type, token_type_to_wave_type};
 use crate::types::parse_type_from_stream;
 use lexer::token::TokenType;
@@ -934,6 +935,114 @@ pub fn parse_enum(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
         name,
         repr_type,
         variants,
+        visibility: Visibility::Private,
+    }))
+}
+
+pub fn parse_variant(tokens: &mut Peekable<Iter<'_, Token>>) -> Option<ASTNode> {
+    skip_ws(tokens);
+    let name = match tokens.next() {
+        Some(Token {
+            token_type: TokenType::Identifier(name),
+            ..
+        }) => name.clone(),
+        _ => {
+            println!("Error: Expected variant name after 'variant'");
+            return None;
+        }
+    };
+    let generic_params = parse_generic_param_names(tokens)?;
+
+    skip_ws(tokens);
+    if !matches!(
+        tokens.next().map(|token| &token.token_type),
+        Some(TokenType::Lbrace)
+    ) {
+        println!("Error: Expected '{{' to start variant '{}'", name);
+        return None;
+    }
+
+    let mut cases = Vec::new();
+    loop {
+        skip_ws(tokens);
+        if matches!(
+            tokens.peek().map(|token| &token.token_type),
+            Some(TokenType::Rbrace)
+        ) {
+            tokens.next();
+            break;
+        }
+
+        let case_name = match tokens.next() {
+            Some(Token {
+                token_type: TokenType::Identifier(case_name),
+                ..
+            }) => case_name.clone(),
+            _ => {
+                println!("Error: Expected case name in variant '{}'", name);
+                return None;
+            }
+        };
+
+        skip_ws(tokens);
+        let mut payload_types = Vec::new();
+        if matches!(
+            tokens.peek().map(|token| &token.token_type),
+            Some(TokenType::Lparen)
+        ) {
+            tokens.next();
+            loop {
+                skip_ws(tokens);
+                if matches!(
+                    tokens.peek().map(|token| &token.token_type),
+                    Some(TokenType::Rparen)
+                ) {
+                    tokens.next();
+                    break;
+                }
+                payload_types.push(parse_type_from_stream(tokens)?);
+                skip_ws(tokens);
+                match tokens.peek().map(|token| &token.token_type) {
+                    Some(TokenType::Comma) => {
+                        tokens.next();
+                    }
+                    Some(TokenType::Rparen) => {
+                        tokens.next();
+                        break;
+                    }
+                    _ => {
+                        println!(
+                            "Error: Expected ',' or ')' after payload type in '{}::{}'",
+                            name, case_name
+                        );
+                        return None;
+                    }
+                }
+            }
+        }
+
+        cases.push(VariantCaseNode {
+            name: case_name,
+            payload_types,
+        });
+
+        skip_ws(tokens);
+        match tokens.peek().map(|token| &token.token_type) {
+            Some(TokenType::Comma) => {
+                tokens.next();
+            }
+            Some(TokenType::Rbrace) => {}
+            _ => {
+                println!("Error: Expected ',' or '}}' after variant case");
+                return None;
+            }
+        }
+    }
+
+    Some(ASTNode::Variant(VariantNode {
+        name,
+        generic_params,
+        cases,
         visibility: Visibility::Private,
     }))
 }

--- a/front/parser/src/parser/parse.rs
+++ b/front/parser/src/parser/parse.rs
@@ -259,6 +259,10 @@ pub fn parse_syntax_only(tokens: &[Token]) -> Result<Vec<ASTNode>, ParseError> {
                         iter.next();
                         parse_enum(&mut iter)
                     }
+                    Some(TokenType::Variant) => {
+                        iter.next();
+                        parse_variant(&mut iter)
+                    }
                     Some(TokenType::Const) => {
                         iter.next();
                         parse_const(&mut iter)
@@ -282,6 +286,7 @@ pub fn parse_syntax_only(tokens: &[Token]) -> Result<Vec<ASTNode>, ParseError> {
                         "pub export(c) fun",
                         "pub struct",
                         "pub enum",
+                        "pub variant",
                         "pub type",
                         "pub const",
                         "pub static",
@@ -318,6 +323,7 @@ pub fn parse_syntax_only(tokens: &[Token]) -> Result<Vec<ASTNode>, ParseError> {
                     ASTNode::Struct(structure) => structure.visibility = Visibility::Public,
                     ASTNode::TypeAlias(alias) => alias.visibility = Visibility::Public,
                     ASTNode::Enum(enumeration) => enumeration.visibility = Visibility::Public,
+                    ASTNode::Variant(variant) => variant.visibility = Visibility::Public,
                     ASTNode::Variable(variable) => variable.visibility = Visibility::Public,
                     _ => unreachable!("public parser only constructs importable declarations"),
                 }
@@ -441,6 +447,22 @@ pub fn parse_syntax_only(tokens: &[Token]) -> Result<Vec<ASTNode>, ParseError> {
                     .with_help("check enum repr type, braces, and variant values"));
                 }
             }
+            TokenType::Variant => {
+                let anchor = (*token).clone();
+                iter.next();
+                if let Some(node) = parse_variant(&mut iter) {
+                    nodes.push(node);
+                } else {
+                    return Err(ParseError::syntax_at(
+                        Some(&anchor),
+                        "failed to parse variant declaration",
+                    )
+                    .with_context("top-level variant declaration")
+                    .with_expected("variant Result<T, E> { Ok(T), Err(E) }")
+                    .with_found_token(iter.peek().copied())
+                    .with_help("check generic parameters, payload types, commas, and braces"));
+                }
+            }
             TokenType::Struct => {
                 let anchor = (*token).clone();
                 iter.next();
@@ -483,8 +505,8 @@ pub fn parse_syntax_only(tokens: &[Token]) -> Result<Vec<ASTNode>, ParseError> {
                     ParseError::syntax_at(Some(token), "unexpected token at top level")
                         .with_context("top-level items")
                         .with_expected_many([
-                            "import", "extern", "pub", "const", "static", "type", "enum", "struct",
-                            "proto", "fun", "export",
+                            "import", "extern", "pub", "const", "static", "type", "enum",
+                            "variant", "struct", "proto", "fun", "export",
                         ])
                         .with_found_token(Some(token))
                         .with_help("only declarations are allowed at top level"),

--- a/front/parser/src/verification.rs
+++ b/front/parser/src/verification.rs
@@ -21,6 +21,7 @@ use crate::ast::{
     ASTNode, AssignOperator, Expression, FunctionNode, IncDecKind, Literal, MatchPattern,
     Mutability, Operator, StatementNode, WaveType,
 };
+use crate::hir::{HirExpressionType, HirVariantConstruction, HirVariantPattern};
 use crate::types::{parse_type, split_top_level_generic_args, token_type_to_wave_type};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -74,6 +75,12 @@ struct FunctionType {
 }
 
 #[derive(Clone, Debug)]
+struct VariantType {
+    generic_params: Vec<String>,
+    cases: Vec<(String, Vec<WaveType>)>,
+}
+
+#[derive(Clone, Debug)]
 enum ExpressionType {
     // Literal and null states stay distinct until an expected type supplies the
     // width, signedness, element type, or pointer pointee required to commit.
@@ -98,6 +105,8 @@ struct ProgramTypes {
     type_names: HashSet<String>,
     generic_type_params: HashSet<String>,
     struct_generic_params: HashMap<String, Vec<String>>,
+    variants: HashMap<String, VariantType>,
+    variant_generic_params: HashMap<String, Vec<String>>,
 }
 
 impl ProgramTypes {
@@ -111,6 +120,7 @@ impl ProgramTypes {
                 ASTNode::Struct(structure) => Some(structure.name.as_str()),
                 ASTNode::TypeAlias(alias) => Some(alias.name.as_str()),
                 ASTNode::Enum(enumeration) => Some(enumeration.name.as_str()),
+                ASTNode::Variant(variant) => Some(variant.name.as_str()),
                 _ => None,
             };
             if let Some(name) = type_name {
@@ -134,6 +144,10 @@ impl ProgramTypes {
                         out.generic_type_params
                             .extend(method.generic_params.iter().cloned());
                     }
+                }
+                ASTNode::Variant(variant) => {
+                    out.generic_type_params
+                        .extend(variant.generic_params.iter().cloned());
                 }
                 ASTNode::ProtoImpl(implementation) => {
                     for method in &implementation.methods {
@@ -321,6 +335,35 @@ impl ProgramTypes {
                         })?;
                     }
                 }
+                ASTNode::Variant(variant) => {
+                    let mut names = HashSet::new();
+                    let mut cases = Vec::with_capacity(variant.cases.len());
+                    for case in &variant.cases {
+                        if !names.insert(case.name.clone()) {
+                            return Err(failure(
+                                format!(
+                                    "duplicate case `{}` in variant `{}`",
+                                    case.name, variant.name
+                                ),
+                                Some(SemanticSpanHint {
+                                    kind: SemanticSpanKind::Declaration,
+                                    text: case.name.clone(),
+                                    occurrence: 2,
+                                }),
+                            ));
+                        }
+                        cases.push((case.name.clone(), case.payload_types.clone()));
+                    }
+                    out.variant_generic_params
+                        .insert(variant.name.clone(), variant.generic_params.clone());
+                    out.variants.insert(
+                        variant.name.clone(),
+                        VariantType {
+                            generic_params: variant.generic_params.clone(),
+                            cases,
+                        },
+                    );
+                }
                 _ => {}
             }
         }
@@ -349,7 +392,11 @@ impl ProgramTypes {
         let Some((base, arguments)) = parse_named_type_application(name) else {
             return HashMap::new();
         };
-        let Some(parameters) = self.struct_generic_params.get(&base) else {
+        let Some(parameters) = self
+            .struct_generic_params
+            .get(&base)
+            .or_else(|| self.variant_generic_params.get(&base))
+        else {
             return HashMap::new();
         };
         parameters.iter().cloned().zip(arguments).collect()
@@ -378,6 +425,35 @@ impl ProgramTypes {
         matches!(ty, WaveType::Struct(name) if self.generic_type_params.contains(name))
     }
 
+    fn variant_type(&self, name: &str) -> Option<&VariantType> {
+        self.variants.get(self.named_type_base(name))
+    }
+
+    fn variant_constructor<'b>(&self, name: &'b str) -> Option<(&'b str, &'b str)> {
+        let (owner, case) = name.rsplit_once("::")?;
+        self.variant_type(owner)?;
+        Some((owner, case))
+    }
+
+    fn variant_case(&self, owner: &str, case: &str) -> Option<(u32, Vec<WaveType>)> {
+        let definition = self.variant_type(owner)?;
+        let substitution = self.generic_substitution(owner);
+        definition
+            .cases
+            .iter()
+            .enumerate()
+            .find(|(_, (name, _))| name == case)
+            .map(|(index, (_, payloads))| {
+                (
+                    index as u32,
+                    payloads
+                        .iter()
+                        .map(|ty| self.canonical_type(&substitute_wave_type(ty, &substitution)))
+                        .collect(),
+                )
+            })
+    }
+
     fn validate_type(
         &self,
         ty: &WaveType,
@@ -390,15 +466,19 @@ impl ProgramTypes {
             WaveType::Pointer(inner) | WaveType::Array(inner, _) => {
                 self.validate_type(inner, generic_params, false, context)
             }
-            WaveType::Struct(name) => {
-                if generic_params.contains(name) {
+            WaveType::Struct(name) | WaveType::Variant(name) => {
+                if matches!(ty, WaveType::Struct(_)) && generic_params.contains(name) {
                     return Ok(());
                 }
                 let base = self.named_type_base(name);
                 if !self.is_known_named_type(name) {
                     return Err(format!("unknown type `{}` in {}", name, context));
                 }
-                let expected_arity = self.struct_generic_params.get(base).map_or(0, Vec::len);
+                let expected_arity = self
+                    .struct_generic_params
+                    .get(base)
+                    .or_else(|| self.variant_generic_params.get(base))
+                    .map_or(0, Vec::len);
                 let arguments = parse_named_type_application(name)
                     .map(|(_, arguments)| arguments)
                     .unwrap_or_default();
@@ -442,7 +522,14 @@ impl ProgramTypes {
                         })
                         .collect::<Vec<_>>()
                         .join(",");
-                    WaveType::Struct(format!("{}<{}>", base, arguments))
+                    let name = format!("{}<{}>", base, arguments);
+                    if self.variants.contains_key(&base) {
+                        WaveType::Variant(name)
+                    } else {
+                        WaveType::Struct(name)
+                    }
+                } else if self.variants.contains_key(name) {
+                    WaveType::Variant(name.clone())
                 } else {
                     ty.clone()
                 };
@@ -455,6 +542,7 @@ impl ProgramTypes {
             WaveType::Array(inner, size) => {
                 WaveType::Array(Box::new(self.canonical_type_inner(inner, seen)), *size)
             }
+            WaveType::Variant(name) => WaveType::Variant(name.clone()),
             _ => ty.clone(),
         }
     }
@@ -585,6 +673,20 @@ fn substitute_wave_type(ty: &WaveType, substitutions: &HashMap<String, WaveType>
         WaveType::Array(inner, size) => {
             WaveType::Array(Box::new(substitute_wave_type(inner, substitutions)), *size)
         }
+        WaveType::Variant(name) => {
+            if let Some((base, arguments)) = parse_named_type_application(name) {
+                let arguments = arguments
+                    .iter()
+                    .map(|argument| {
+                        display_wave_type(&substitute_wave_type(argument, substitutions))
+                    })
+                    .collect::<Vec<_>>()
+                    .join(",");
+                WaveType::Variant(format!("{}<{}>", base, arguments))
+            } else {
+                ty.clone()
+            }
+        }
         _ => ty.clone(),
     }
 }
@@ -606,6 +708,81 @@ fn substitute_function_type(
     }
 }
 
+fn infer_variant_substitution(
+    program: &ProgramTypes,
+    template: &WaveType,
+    actual: &ExpressionType,
+    generic_params: &[String],
+    substitutions: &mut HashMap<String, WaveType>,
+) -> Result<(), String> {
+    let actual = match actual {
+        ExpressionType::Known(ty) => program.canonical_type(ty),
+        ExpressionType::IntLiteral(_) => WaveType::Int(32),
+        ExpressionType::FloatLiteral => WaveType::Float(32),
+        _ => return Ok(()),
+    };
+    infer_variant_type_pair(program, template, &actual, generic_params, substitutions)
+}
+
+fn infer_variant_type_pair(
+    program: &ProgramTypes,
+    template: &WaveType,
+    actual: &WaveType,
+    generic_params: &[String],
+    substitutions: &mut HashMap<String, WaveType>,
+) -> Result<(), String> {
+    if let WaveType::Struct(name) = template {
+        if generic_params.contains(name) {
+            if let Some(previous) = substitutions.get(name) {
+                if program.canonical_type(previous) != program.canonical_type(actual) {
+                    return Err(format!(
+                        "conflicting inferred types `{}` and `{}` for variant generic `{}`",
+                        display_wave_type(previous),
+                        display_wave_type(actual),
+                        name
+                    ));
+                }
+            } else {
+                substitutions.insert(name.clone(), actual.clone());
+            }
+            return Ok(());
+        }
+    }
+
+    match (template, actual) {
+        (WaveType::Pointer(template), WaveType::Pointer(actual))
+        | (WaveType::Array(template, _), WaveType::Array(actual, _)) => {
+            infer_variant_type_pair(program, template, actual, generic_params, substitutions)
+        }
+        (WaveType::Struct(template_name), WaveType::Struct(actual_name))
+        | (WaveType::Struct(template_name), WaveType::Variant(actual_name))
+        | (WaveType::Variant(template_name), WaveType::Struct(actual_name))
+        | (WaveType::Variant(template_name), WaveType::Variant(actual_name)) => {
+            let Some((template_base, template_args)) = parse_named_type_application(template_name)
+            else {
+                return Ok(());
+            };
+            let Some((actual_base, actual_args)) = parse_named_type_application(actual_name) else {
+                return Ok(());
+            };
+            if template_base != actual_base || template_args.len() != actual_args.len() {
+                return Ok(());
+            }
+            for (template_arg, actual_arg) in template_args.iter().zip(&actual_args) {
+                infer_variant_type_pair(
+                    program,
+                    template_arg,
+                    actual_arg,
+                    generic_params,
+                    substitutions,
+                )?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
 struct Validator<'a> {
     program: &'a ProgramTypes,
     scopes: Vec<HashMap<String, Binding>>,
@@ -618,6 +795,9 @@ struct Validator<'a> {
     primary_span: Option<SemanticSpanHint>,
     diagnostic_help: Option<String>,
     expression_types: HashMap<usize, WaveType>,
+    hir_expression_types: HashMap<usize, HirExpressionType>,
+    hir_variant_constructions: HashMap<usize, HirVariantConstruction>,
+    hir_variant_patterns: HashMap<usize, HirVariantPattern>,
 }
 
 impl<'a> Validator<'a> {
@@ -634,6 +814,9 @@ impl<'a> Validator<'a> {
             primary_span: None,
             diagnostic_help: None,
             expression_types: HashMap::new(),
+            hir_expression_types: HashMap::new(),
+            hir_variant_constructions: HashMap::new(),
+            hir_variant_patterns: HashMap::new(),
         }
     }
 
@@ -830,7 +1013,8 @@ impl<'a> Validator<'a> {
                 }
 
                 if let Some(initial_value) = &variable.initial_value {
-                    let actual = self.validate_expr(initial_value)?;
+                    let actual =
+                        self.validate_expr_expected(initial_value, Some(&variable.type_name))?;
                     self.require_assignable(
                         &actual,
                         &variable.type_name,
@@ -871,7 +1055,7 @@ impl<'a> Validator<'a> {
                     .lookup_binding(variable)
                     .ok_or_else(|| format!("use of undeclared identifier `{}`", variable))?;
                 self.ensure_mutable_binding(variable, &binding, "assign")?;
-                let actual = self.validate_expr(value)?;
+                let actual = self.validate_expr_expected(value, Some(&binding.ty))?;
                 self.require_assignable(
                     &actual,
                     &binding.ty,
@@ -972,60 +1156,25 @@ impl<'a> Validator<'a> {
             StatementNode::Match { value, arms } => {
                 self.mark_span(SemanticSpanKind::Keyword, "match");
                 let value_type = self.validate_expr(value)?;
-                if !self.is_integer_expression(&value_type) {
-                    return Err(format!(
-                        "match value must be an integer or enum, found `{}`",
-                        display_expression_type(&value_type)
-                    ));
-                }
-                let mut seen = HashSet::new();
-                let mut has_wildcard = false;
-                let mut all_arms_terminate = !arms.is_empty();
-
-                for arm in arms {
-                    let key = match &arm.pattern {
-                        MatchPattern::Int(raw) => {
-                            self.mark_span(SemanticSpanKind::Keyword, raw.clone());
-                            let value = parse_integer_value(raw)
-                                .ok_or_else(|| format!("invalid integer match case `{}`", raw))?;
-                            format!("value:{}", value)
+                match &value_type {
+                    ExpressionType::Known(ty) => match self.program.canonical_type(ty) {
+                        WaveType::Variant(name) => self.validate_variant_match(&name, arms),
+                        _ if self.is_integer_expression(&value_type) => {
+                            self.validate_integer_match(arms)
                         }
-                        MatchPattern::Ident(name) => {
-                            self.mark_span(SemanticSpanKind::Identifier, name.clone());
-                            let binding = self
-                                .lookup_binding(name)
-                                .ok_or_else(|| format!("unknown match case constant `{}`", name))?;
-                            if !matches!(binding.mutability, Mutability::Const)
-                                || !is_integer_type(&self.program.canonical_type(&binding.ty))
-                            {
-                                return Err(format!(
-                                    "match case `{}` must name an integer or enum constant",
-                                    name
-                                ));
-                            }
-                            let value =
-                                self.program.constant_values.get(name).ok_or_else(|| {
-                                    format!(
-                                    "match case `{}` does not have a compile-time integer value",
-                                    name
-                                )
-                                })?;
-                            format!("value:{}", value)
-                        }
-                        MatchPattern::Wildcard => {
-                            self.mark_span(SemanticSpanKind::Keyword, "_");
-                            has_wildcard = true;
-                            "wildcard:_".to_string()
-                        }
-                    };
-                    if !seen.insert(key.clone()) {
-                        return Err(format!("duplicate match case pattern `{}`", key));
+                        _ => Err(format!(
+                            "match value must be an integer, enum, or variant, found `{}`",
+                            display_expression_type(&value_type)
+                        )),
+                    },
+                    _ if self.is_integer_expression(&value_type) => {
+                        self.validate_integer_match(arms)
                     }
-
-                    all_arms_terminate &= !self.validate_scoped_block(&arm.body)?;
+                    _ => Err(format!(
+                        "match value must be an integer, enum, or variant, found `{}`",
+                        display_expression_type(&value_type)
+                    )),
                 }
-
-                Ok(!(has_wildcard && all_arms_terminate))
             }
             StatementNode::Break => {
                 self.mark_span(SemanticSpanKind::Keyword, "break");
@@ -1058,6 +1207,339 @@ impl<'a> Validator<'a> {
         }
     }
 
+    fn validate_integer_match(&mut self, arms: &[crate::ast::MatchArm]) -> Result<bool, String> {
+        let mut seen = HashSet::new();
+        let mut has_wildcard = false;
+        let mut all_arms_terminate = !arms.is_empty();
+
+        for arm in arms {
+            let key = match &arm.pattern {
+                MatchPattern::Int(raw) => {
+                    self.mark_span(SemanticSpanKind::Keyword, raw.clone());
+                    let value = parse_integer_value(raw)
+                        .ok_or_else(|| format!("invalid integer match case `{}`", raw))?;
+                    format!("value:{}", value)
+                }
+                MatchPattern::Ident(name) => {
+                    self.mark_span(SemanticSpanKind::Identifier, name.clone());
+                    let binding = self
+                        .lookup_binding(name)
+                        .ok_or_else(|| format!("unknown match case constant `{}`", name))?;
+                    if !matches!(binding.mutability, Mutability::Const)
+                        || !is_integer_type(&self.program.canonical_type(&binding.ty))
+                    {
+                        return Err(format!(
+                            "match case `{}` must name an integer or enum constant",
+                            name
+                        ));
+                    }
+                    let value = self.program.constant_values.get(name).ok_or_else(|| {
+                        format!(
+                            "match case `{}` does not have a compile-time integer value",
+                            name
+                        )
+                    })?;
+                    format!("value:{}", value)
+                }
+                MatchPattern::Wildcard => {
+                    self.mark_span(SemanticSpanKind::Keyword, "_");
+                    has_wildcard = true;
+                    "wildcard:_".to_string()
+                }
+                MatchPattern::Binding(_) | MatchPattern::Variant { .. } => {
+                    return Err("variant patterns require a variant match value".to_string())
+                }
+            };
+            if !seen.insert(key.clone()) {
+                return Err(format!("duplicate match case pattern `{}`", key));
+            }
+            all_arms_terminate &= !self.validate_scoped_block(&arm.body)?;
+        }
+
+        Ok(!(has_wildcard && all_arms_terminate))
+    }
+
+    fn validate_variant_match(
+        &mut self,
+        variant_name: &str,
+        arms: &[crate::ast::MatchArm],
+    ) -> Result<bool, String> {
+        let definition = self.program.variant_type(variant_name).cloned().unwrap();
+        let all_cases = definition
+            .cases
+            .iter()
+            .map(|(name, _)| name.clone())
+            .collect::<HashSet<_>>();
+        let expected_type = WaveType::Variant(variant_name.to_string());
+        let mut seen_patterns = HashSet::new();
+        let mut covered_patterns: Vec<&MatchPattern> = Vec::new();
+        let mut all_arms_terminate = !arms.is_empty();
+
+        for arm in arms {
+            if self.variant_patterns_cover(&covered_patterns, &expected_type) {
+                return Err(
+                    if covered_patterns
+                        .iter()
+                        .any(|pattern| matches!(pattern, MatchPattern::Wildcard))
+                    {
+                        "match pattern after wildcard is unreachable".to_string()
+                    } else {
+                        "match pattern is unreachable because previous variant patterns are exhaustive"
+                        .to_string()
+                    },
+                );
+            }
+            let mut bindings = HashMap::new();
+            match &arm.pattern {
+                MatchPattern::Wildcard => {}
+                MatchPattern::Variant {
+                    variant_type,
+                    case_name,
+                    ..
+                } => {
+                    if self.program.named_type_base(variant_type)
+                        != self.program.named_type_base(variant_name)
+                    {
+                        return Err(format!(
+                            "case `{}::{}` does not belong to variant `{}`",
+                            variant_type, case_name, variant_name
+                        ));
+                    }
+                    let key = variant_pattern_key(&arm.pattern);
+                    if !seen_patterns.insert(key) {
+                        return Err(format!(
+                            "duplicate variant case `{}::{}` in match",
+                            variant_type, case_name
+                        ));
+                    }
+                    self.collect_variant_pattern_bindings(
+                        &arm.pattern,
+                        &expected_type,
+                        &mut bindings,
+                    )?;
+                }
+                MatchPattern::Int(_) | MatchPattern::Ident(_) | MatchPattern::Binding(_) => {
+                    return Err(format!(
+                        "match on variant `{}` requires a qualified case pattern or `_`",
+                        variant_name
+                    ))
+                }
+            }
+
+            let arm_falls_through = self.with_scope(|validator| {
+                for (name, ty) in bindings {
+                    validator.insert_current_binding(
+                        name,
+                        Binding {
+                            mutability: Mutability::Var,
+                            ty,
+                        },
+                        "pattern binding",
+                    )?;
+                }
+                validator.validate_block(&arm.body)
+            })?;
+            all_arms_terminate &= !arm_falls_through;
+            covered_patterns.push(&arm.pattern);
+        }
+
+        let exhaustive = self.variant_patterns_cover(&covered_patterns, &expected_type);
+        if !exhaustive {
+            let mut missing = all_cases
+                .iter()
+                .filter(|case| {
+                    !covered_patterns.iter().any(|pattern| {
+                        matches!(
+                            pattern,
+                            MatchPattern::Variant { case_name, .. } if case_name == *case
+                        )
+                    })
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            missing.sort();
+            if missing.is_empty() {
+                return Err(format!(
+                    "non-exhaustive match on variant `{}`; patterns do not cover all payload shapes",
+                    variant_name
+                ));
+            }
+            return Err(format!(
+                "non-exhaustive match on variant `{}`; missing case(s): {}",
+                variant_name,
+                missing.join(", ")
+            ));
+        }
+
+        Ok(!(exhaustive && all_arms_terminate))
+    }
+
+    fn collect_variant_pattern_bindings(
+        &mut self,
+        pattern: &MatchPattern,
+        expected: &WaveType,
+        bindings: &mut HashMap<String, WaveType>,
+    ) -> Result<(), String> {
+        match pattern {
+            MatchPattern::Binding(name) => {
+                if bindings.insert(name.clone(), expected.clone()).is_some() {
+                    return Err(format!("duplicate pattern binding `{}`", name));
+                }
+                Ok(())
+            }
+            MatchPattern::Wildcard => Ok(()),
+            MatchPattern::Variant {
+                variant_type,
+                case_name,
+                payloads,
+            } => {
+                let WaveType::Variant(expected_name) = self.program.canonical_type(expected) else {
+                    return Err(format!(
+                        "nested variant pattern `{}::{}` cannot match payload type `{}`",
+                        variant_type,
+                        case_name,
+                        display_wave_type(expected)
+                    ));
+                };
+                if self.program.named_type_base(variant_type)
+                    != self.program.named_type_base(&expected_name)
+                {
+                    return Err(format!(
+                        "case `{}::{}` does not belong to payload variant `{}`",
+                        variant_type, case_name, expected_name
+                    ));
+                }
+                let (discriminant, payload_types) = self
+                    .program
+                    .variant_case(&expected_name, case_name)
+                    .ok_or_else(|| {
+                        format!(
+                            "unknown case `{}` in variant `{}`",
+                            case_name, expected_name
+                        )
+                    })?;
+                if payloads.len() != payload_types.len() {
+                    return Err(format!(
+                        "variant pattern `{}::{}` expects {} payload pattern(s), found {}",
+                        variant_type,
+                        case_name,
+                        payload_types.len(),
+                        payloads.len()
+                    ));
+                }
+                self.hir_variant_patterns.insert(
+                    pattern as *const MatchPattern as usize,
+                    HirVariantPattern {
+                        variant_type: WaveType::Variant(expected_name.clone()),
+                        case_name: case_name.clone(),
+                        discriminant,
+                        payload_types: payload_types.clone(),
+                    },
+                );
+                for (payload, ty) in payloads.iter().zip(&payload_types) {
+                    self.collect_variant_pattern_bindings(payload, ty, bindings)?;
+                }
+                Ok(())
+            }
+            MatchPattern::Int(_) | MatchPattern::Ident(_) => {
+                Err("variant payload patterns support bindings, `_`, or nested cases".to_string())
+            }
+        }
+    }
+
+    fn variant_pattern_is_irrefutable(&self, pattern: &MatchPattern, expected: &WaveType) -> bool {
+        match pattern {
+            MatchPattern::Binding(_) | MatchPattern::Wildcard => true,
+            MatchPattern::Variant {
+                variant_type,
+                case_name,
+                payloads,
+            } => {
+                let WaveType::Variant(expected_name) = self.program.canonical_type(expected) else {
+                    return false;
+                };
+                if self.program.named_type_base(variant_type)
+                    != self.program.named_type_base(&expected_name)
+                {
+                    return false;
+                }
+                let Some(definition) = self.program.variant_type(&expected_name) else {
+                    return false;
+                };
+                if definition.cases.len() != 1 || definition.cases[0].0 != *case_name {
+                    return false;
+                }
+                let Some((_, payload_types)) = self.program.variant_case(&expected_name, case_name)
+                else {
+                    return false;
+                };
+                payloads.len() == payload_types.len()
+                    && payloads
+                        .iter()
+                        .zip(&payload_types)
+                        .all(|(payload, ty)| self.variant_pattern_is_irrefutable(payload, ty))
+            }
+            MatchPattern::Int(_) | MatchPattern::Ident(_) => false,
+        }
+    }
+
+    fn variant_patterns_cover(&self, patterns: &[&MatchPattern], expected: &WaveType) -> bool {
+        if patterns
+            .iter()
+            .any(|pattern| matches!(pattern, MatchPattern::Binding(_) | MatchPattern::Wildcard))
+        {
+            return true;
+        }
+        let WaveType::Variant(expected_name) = self.program.canonical_type(expected) else {
+            return false;
+        };
+        let Some(definition) = self.program.variant_type(&expected_name) else {
+            return false;
+        };
+        definition.cases.iter().all(|(case_name, _)| {
+            let case_patterns = patterns
+                .iter()
+                .filter_map(|pattern| match pattern {
+                    MatchPattern::Variant {
+                        variant_type,
+                        case_name: pattern_case,
+                        payloads,
+                    } if self.program.named_type_base(variant_type)
+                        == self.program.named_type_base(&expected_name)
+                        && pattern_case == case_name =>
+                    {
+                        Some(payloads)
+                    }
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            if case_patterns.is_empty() {
+                return false;
+            }
+            let Some((_, payload_types)) = self.program.variant_case(&expected_name, case_name)
+            else {
+                return false;
+            };
+            if payload_types.is_empty() {
+                return true;
+            }
+            if payload_types.len() == 1 {
+                let nested = case_patterns
+                    .iter()
+                    .filter_map(|payloads| payloads.first())
+                    .collect::<Vec<_>>();
+                return self.variant_patterns_cover(&nested, &payload_types[0]);
+            }
+            case_patterns.iter().any(|payloads| {
+                payloads.len() == payload_types.len()
+                    && payloads
+                        .iter()
+                        .zip(&payload_types)
+                        .all(|(pattern, ty)| self.variant_pattern_is_irrefutable(pattern, ty))
+            })
+        })
+    }
+
     fn validate_return(&mut self, value: Option<&Expression>) -> Result<(), String> {
         let function = self
             .current_function
@@ -1077,7 +1559,7 @@ impl<'a> Validator<'a> {
                 display_wave_type(&expected)
             )),
             (expected, Some(expression)) => {
-                let actual = self.validate_expr(expression)?;
+                let actual = self.validate_expr_expected(expression, Some(&expected))?;
                 self.require_assignable(
                     &actual,
                     &expected,
@@ -1172,8 +1654,20 @@ impl<'a> Validator<'a> {
     }
 
     fn validate_expr(&mut self, expression: &Expression) -> Result<ExpressionType, String> {
-        let result = self.validate_expr_inner(expression);
+        self.validate_expr_expected(expression, None)
+    }
+
+    fn validate_expr_expected(
+        &mut self,
+        expression: &Expression,
+        expected: Option<&WaveType>,
+    ) -> Result<ExpressionType, String> {
+        let result = self.validate_expr_inner(expression, expected);
         if let Ok(expression_type) = &result {
+            self.hir_expression_types.insert(
+                expression as *const Expression as usize,
+                hir_expression_type(self.program, expression_type),
+            );
             if let Some(ty) = canonical_expression_type(self.program, expression_type) {
                 self.expression_types
                     .insert(expression as *const Expression as usize, ty);
@@ -1182,7 +1676,11 @@ impl<'a> Validator<'a> {
         result
     }
 
-    fn validate_expr_inner(&mut self, expression: &Expression) -> Result<ExpressionType, String> {
+    fn validate_expr_inner(
+        &mut self,
+        expression: &Expression,
+        expected: Option<&WaveType>,
+    ) -> Result<ExpressionType, String> {
         match expression {
             Expression::Literal(literal) => Ok(match literal {
                 Literal::Int(raw) => ExpressionType::IntLiteral(raw.clone()),
@@ -1194,6 +1692,9 @@ impl<'a> Validator<'a> {
             }),
             Expression::Null => Ok(ExpressionType::Null),
             Expression::Variable(name) => {
+                if self.program.variant_constructor(name).is_some() {
+                    return self.validate_variant_constructor(expression, name, &[], expected);
+                }
                 if let Some(binding) = self.lookup_binding(name) {
                     Ok(ExpressionType::Known(binding.ty))
                 } else {
@@ -1282,7 +1783,17 @@ impl<'a> Validator<'a> {
                 args,
             } => {
                 self.mark_span(SemanticSpanKind::Identifier, name.clone());
-                self.validate_function_call(name, type_args, args)
+                if self.program.variant_constructor(name).is_some() {
+                    if !type_args.is_empty() {
+                        return Err(format!(
+                            "variant constructor `{}` does not accept function type arguments",
+                            name
+                        ));
+                    }
+                    self.validate_variant_constructor(expression, name, args, expected)
+                } else {
+                    self.validate_function_call(name, type_args, args)
+                }
             }
             Expression::MethodCall { object, name, args } => {
                 self.mark_span(SemanticSpanKind::Identifier, name.clone());
@@ -1310,7 +1821,7 @@ impl<'a> Validator<'a> {
                         .ok_or_else(|| {
                             format!("struct `{}` has no field `{}`", name, field_name)
                         })?;
-                    let actual = self.validate_expr(value)?;
+                    let actual = self.validate_expr_expected(value, Some(&expected))?;
                     self.require_assignable(
                         &actual,
                         &expected,
@@ -1406,7 +1917,11 @@ impl<'a> Validator<'a> {
                 }
                 self.ensure_mutable_write_target(target, "assign")?;
                 let target_type = self.validate_expr(target)?;
-                let value_type = self.validate_expr(value)?;
+                let value_type = if let ExpressionType::Known(expected) = &target_type {
+                    self.validate_expr_expected(value, Some(expected))?
+                } else {
+                    self.validate_expr(value)?
+                };
                 if let ExpressionType::Known(expected) = &target_type {
                     let context = find_base_var(target, false)
                         .map(|(name, _)| format!("assignment to `{}`", name))
@@ -1429,7 +1944,11 @@ impl<'a> Validator<'a> {
                 }
                 self.ensure_mutable_write_target(target, "modify with compound assignment")?;
                 let target_type = self.validate_expr(target)?;
-                let value_type = self.validate_expr(value)?;
+                let value_type = if let ExpressionType::Known(expected) = &target_type {
+                    self.validate_expr_expected(value, Some(expected))?
+                } else {
+                    self.validate_expr(value)?
+                };
                 if matches!(operator, AssignOperator::Assign) {
                     if let ExpressionType::Known(expected) = &target_type {
                         let context = find_base_var(target, false)
@@ -1548,6 +2067,118 @@ impl<'a> Validator<'a> {
             signature.variadic,
         )?;
         Ok(ExpressionType::Known(signature.return_type))
+    }
+
+    fn validate_variant_constructor(
+        &mut self,
+        expression: &Expression,
+        name: &str,
+        args: &[Expression],
+        expected: Option<&WaveType>,
+    ) -> Result<ExpressionType, String> {
+        let (owner, case_name) = self
+            .program
+            .variant_constructor(name)
+            .ok_or_else(|| format!("unknown variant constructor `{}`", name))?;
+        let definition = self.program.variant_type(owner).cloned().unwrap();
+        let (_, (_, template_payloads)) = definition
+            .cases
+            .iter()
+            .enumerate()
+            .find(|(_, (case, _))| case == case_name)
+            .ok_or_else(|| format!("unknown case `{}` in variant `{}`", case_name, owner))?;
+
+        if args.len() != template_payloads.len() {
+            return Err(format!(
+                "variant constructor `{}` expects {} payload value(s), found {}",
+                name,
+                template_payloads.len(),
+                args.len()
+            ));
+        }
+
+        let expected_variant = expected
+            .map(|ty| self.program.canonical_type(ty))
+            .and_then(|ty| match ty {
+                WaveType::Variant(name)
+                    if self.program.named_type_base(&name)
+                        == self.program.named_type_base(owner) =>
+                {
+                    Some(name)
+                }
+                _ => None,
+            });
+
+        let concrete_name = if let Some(name) = expected_variant {
+            name
+        } else if definition.generic_params.is_empty() {
+            owner.to_string()
+        } else {
+            let mut substitutions = HashMap::new();
+            for (argument, template) in args.iter().zip(template_payloads) {
+                let actual = self.validate_expr(argument)?;
+                infer_variant_substitution(
+                    self.program,
+                    template,
+                    &actual,
+                    &definition.generic_params,
+                    &mut substitutions,
+                )?;
+            }
+            let unresolved = definition
+                .generic_params
+                .iter()
+                .filter(|param| !substitutions.contains_key(*param))
+                .cloned()
+                .collect::<Vec<_>>();
+            if !unresolved.is_empty() {
+                return Err(format!(
+                    "cannot resolve generic argument(s) {} for variant constructor `{}`; add an explicit destination type",
+                    unresolved.join(", "),
+                    name
+                ));
+            }
+            let arguments = definition
+                .generic_params
+                .iter()
+                .map(|param| display_wave_type(&substitutions[param]))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("{}<{}>", owner, arguments)
+        };
+
+        let substitution = self.program.generic_substitution(&concrete_name);
+        let payload_types = template_payloads
+            .iter()
+            .map(|ty| {
+                self.program
+                    .canonical_type(&substitute_wave_type(ty, &substitution))
+            })
+            .collect::<Vec<_>>();
+        for (index, (argument, payload_type)) in args.iter().zip(&payload_types).enumerate() {
+            let actual = self.validate_expr_expected(argument, Some(payload_type))?;
+            self.require_assignable(
+                &actual,
+                payload_type,
+                &format!("payload {} of variant constructor `{}`", index + 1, name),
+            )?;
+        }
+
+        let (discriminant, _) = self
+            .program
+            .variant_case(&concrete_name, case_name)
+            .expect("validated variant case remains available");
+        let variant_type = WaveType::Variant(concrete_name);
+        self.hir_variant_constructions.insert(
+            expression as *const Expression as usize,
+            HirVariantConstruction {
+                variant_type: variant_type.clone(),
+                case_name: case_name.to_string(),
+                discriminant,
+                payload_types,
+            },
+        );
+        Ok(ExpressionType::Known(variant_type))
     }
 
     fn validate_method_call(
@@ -1706,7 +2337,7 @@ impl<'a> Validator<'a> {
         }
 
         for (index, (argument, expected)) in args.iter().zip(params).enumerate() {
-            let actual = self.validate_expr(argument)?;
+            let actual = self.validate_expr_expected(argument, Some(expected))?;
             self.require_assignable(
                 &actual,
                 expected,
@@ -1872,7 +2503,7 @@ impl<'a> Validator<'a> {
         let target = self.program.canonical_type(target);
         if matches!(
             target,
-            WaveType::Void | WaveType::Array(_, _) | WaveType::Struct(_)
+            WaveType::Void | WaveType::Array(_, _) | WaveType::Struct(_) | WaveType::Variant(_)
         ) {
             return false;
         }
@@ -1898,7 +2529,7 @@ impl<'a> Validator<'a> {
         };
         if matches!(
             source,
-            WaveType::Void | WaveType::Array(_, _) | WaveType::Struct(_)
+            WaveType::Void | WaveType::Array(_, _) | WaveType::Struct(_) | WaveType::Variant(_)
         ) {
             return false;
         }
@@ -2115,6 +2746,18 @@ fn canonical_expression_type(program: &ProgramTypes, ty: &ExpressionType) -> Opt
         ExpressionType::IntLiteral(_) => Some(WaveType::Int(32)),
         ExpressionType::FloatLiteral => Some(WaveType::Float(32)),
         _ => None,
+    }
+}
+
+fn hir_expression_type(program: &ProgramTypes, ty: &ExpressionType) -> HirExpressionType {
+    match ty {
+        ExpressionType::Known(ty) => HirExpressionType::Resolved(program.canonical_type(ty)),
+        ExpressionType::IntLiteral(_) => HirExpressionType::IntegerLiteral,
+        ExpressionType::FloatLiteral => HirExpressionType::FloatLiteral,
+        ExpressionType::Null => HirExpressionType::Null,
+        ExpressionType::ArrayLiteral(_) => HirExpressionType::ArrayLiteral,
+        ExpressionType::AddressedArrayLiteral(_) => HirExpressionType::AddressedArrayLiteral,
+        ExpressionType::Unknown => HirExpressionType::Unknown,
     }
 }
 
@@ -2551,6 +3194,29 @@ fn display_wave_type(ty: &WaveType) -> String {
         WaveType::Array(inner, size) => format!("array<{}, {}>", display_wave_type(inner), size),
         WaveType::Void => "void".to_string(),
         WaveType::Struct(name) => name.clone(),
+        WaveType::Variant(name) => name.clone(),
+    }
+}
+
+fn variant_pattern_key(pattern: &MatchPattern) -> String {
+    match pattern {
+        MatchPattern::Int(raw) => format!("int:{}", raw),
+        MatchPattern::Ident(name) => format!("ident:{}", name),
+        MatchPattern::Binding(_) | MatchPattern::Wildcard => "*".to_string(),
+        MatchPattern::Variant {
+            variant_type,
+            case_name,
+            payloads,
+        } => format!(
+            "{}::{}({})",
+            variant_type,
+            case_name,
+            payloads
+                .iter()
+                .map(variant_pattern_key)
+                .collect::<Vec<_>>()
+                .join(",")
+        ),
     }
 }
 
@@ -2565,6 +3231,36 @@ pub fn validate_program_detailed(nodes: &[ASTNode]) -> Result<(), SemanticDiagno
 pub fn analyze_expression_types(
     nodes: &[ASTNode],
 ) -> Result<HashMap<usize, WaveType>, SemanticDiagnostic> {
+    analyze_program_types(nodes).map(|analysis| analysis.expression_types)
+}
+
+pub(crate) fn analyze_hir_expression_types(
+    nodes: &[ASTNode],
+) -> Result<
+    (
+        HashMap<usize, HirExpressionType>,
+        HashMap<usize, HirVariantConstruction>,
+        HashMap<usize, HirVariantPattern>,
+    ),
+    SemanticDiagnostic,
+> {
+    analyze_program_types(nodes).map(|analysis| {
+        (
+            analysis.hir_expression_types,
+            analysis.hir_variant_constructions,
+            analysis.hir_variant_patterns,
+        )
+    })
+}
+
+struct ProgramAnalysis {
+    expression_types: HashMap<usize, WaveType>,
+    hir_expression_types: HashMap<usize, HirExpressionType>,
+    hir_variant_constructions: HashMap<usize, HirVariantConstruction>,
+    hir_variant_patterns: HashMap<usize, HirVariantPattern>,
+}
+
+fn analyze_program_types(nodes: &[ASTNode]) -> Result<ProgramAnalysis, SemanticDiagnostic> {
     let program = ProgramTypes::collect(nodes).map_err(|(index, message, primary)| {
         semantic_diagnostic_for_top_level(nodes, index, message, primary)
     })?;
@@ -2640,7 +3336,12 @@ pub fn analyze_expression_types(
         }
     }
 
-    Ok(validator.expression_types)
+    Ok(ProgramAnalysis {
+        expression_types: validator.expression_types,
+        hir_expression_types: validator.hir_expression_types,
+        hir_variant_constructions: validator.hir_variant_constructions,
+        hir_variant_patterns: validator.hir_variant_patterns,
+    })
 }
 
 fn top_level_span_hint(node: &ASTNode) -> SemanticSpanHint {
@@ -2653,6 +3354,7 @@ fn top_level_span_hint(node: &ASTNode) -> SemanticSpanHint {
         }
         ASTNode::TypeAlias(alias) => (SemanticSpanKind::Declaration, alias.name.clone()),
         ASTNode::Enum(enumeration) => (SemanticSpanKind::Declaration, enumeration.name.clone()),
+        ASTNode::Variant(variant) => (SemanticSpanKind::Declaration, variant.name.clone()),
         ASTNode::Variable(variable) => (SemanticSpanKind::Declaration, variable.name.clone()),
         ASTNode::Statement(_) | ASTNode::Expression(_) | ASTNode::Program(_) => {
             (SemanticSpanKind::Keyword, "program".to_string())
@@ -2693,7 +3395,31 @@ fn validate_declaration_types(
     for (index, node) in nodes.iter().enumerate() {
         let result = match node {
             ASTNode::Function(function) => {
-                validate_unique_generic_params(&function.generic_params, &function.name)
+                let mut result =
+                    validate_unique_generic_params(&function.generic_params, &function.name);
+                if result.is_ok() && function.export.is_some() {
+                    for parameter in &function.parameters {
+                        if is_direct_variant_type(program, &parameter.param_type) {
+                            result = Err(format!(
+                                "export(c) function `{}` cannot expose variant parameter `{}` directly",
+                                function.name, parameter.name
+                            ));
+                            break;
+                        }
+                    }
+                    if result.is_ok()
+                        && function
+                            .return_type
+                            .as_ref()
+                            .is_some_and(|ty| is_direct_variant_type(program, ty))
+                    {
+                        result = Err(format!(
+                            "export(c) function `{}` cannot return a variant directly",
+                            function.name
+                        ));
+                    }
+                }
+                result
             }
             ASTNode::Struct(structure) => {
                 let mut result =
@@ -2759,6 +3485,39 @@ fn validate_declaration_types(
                     result
                 }
             }
+            ASTNode::Variant(variant) => {
+                let mut result =
+                    validate_unique_generic_params(&variant.generic_params, &variant.name);
+                let generics: HashSet<String> = variant.generic_params.iter().cloned().collect();
+                if result.is_ok() && variant.cases.is_empty() {
+                    result = Err(format!(
+                        "variant `{}` must declare at least one case",
+                        variant.name
+                    ));
+                }
+                if result.is_ok() {
+                    for case in &variant.cases {
+                        for payload in &case.payload_types {
+                            result = program.validate_type(
+                                payload,
+                                &generics,
+                                false,
+                                &format!("payload of `{}::{}`", variant.name, case.name),
+                            );
+                            if result.is_err() {
+                                break;
+                            }
+                        }
+                        if result.is_err() {
+                            break;
+                        }
+                    }
+                }
+                if result.is_ok() {
+                    result = validate_finite_variant(&variant.name, program);
+                }
+                result
+            }
             ASTNode::ExternFunction(function) => {
                 let mut params = HashSet::new();
                 let mut result = Ok(());
@@ -2791,6 +3550,23 @@ fn validate_declaration_types(
                         &format!("return type of extern function `{}`", function.name),
                     );
                 }
+                if result.is_ok() {
+                    for (name, ty) in &function.params {
+                        if is_direct_variant_type(program, ty) {
+                            result = Err(format!(
+                                "extern(c) function `{}` cannot expose variant parameter `{}` directly",
+                                function.name, name
+                            ));
+                            break;
+                        }
+                    }
+                }
+                if result.is_ok() && is_direct_variant_type(program, &function.return_type) {
+                    result = Err(format!(
+                        "extern(c) function `{}` cannot return a variant directly",
+                        function.name
+                    ));
+                }
                 result
             }
             ASTNode::Variable(variable) => program.validate_type(
@@ -2809,6 +3585,72 @@ fn validate_declaration_types(
     }
 
     Ok(())
+}
+
+fn is_direct_variant_type(program: &ProgramTypes, ty: &WaveType) -> bool {
+    matches!(program.canonical_type(ty), WaveType::Variant(_))
+}
+
+fn validate_finite_variant(name: &str, program: &ProgramTypes) -> Result<(), String> {
+    let mut active = HashSet::new();
+    let mut checked = HashSet::new();
+    validate_finite_named_type(name, name, program, &mut active, &mut checked)
+}
+
+fn validate_finite_named_type(
+    root: &str,
+    name: &str,
+    program: &ProgramTypes,
+    active: &mut HashSet<String>,
+    checked: &mut HashSet<String>,
+) -> Result<(), String> {
+    let base = program.named_type_base(name).to_string();
+    if checked.contains(&base) || program.generic_type_params.contains(&base) {
+        return Ok(());
+    }
+    if !active.insert(base.clone()) {
+        return Err(format!(
+            "variant `{}` has infinite size through direct recursive payload `{}`; use `ptr<{}>` for indirection",
+            root, base, base
+        ));
+    }
+
+    if let Some(alias) = program.aliases.get(&base) {
+        validate_finite_payload_type(root, alias, program, active, checked)?;
+    } else if let Some(fields) = program.structs.get(&base) {
+        for field in fields.values() {
+            validate_finite_payload_type(root, field, program, active, checked)?;
+        }
+    } else if let Some(variant) = program.variants.get(&base) {
+        for (_, payloads) in &variant.cases {
+            for payload in payloads {
+                validate_finite_payload_type(root, payload, program, active, checked)?;
+            }
+        }
+    }
+
+    active.remove(&base);
+    checked.insert(base);
+    Ok(())
+}
+
+fn validate_finite_payload_type(
+    root: &str,
+    ty: &WaveType,
+    program: &ProgramTypes,
+    active: &mut HashSet<String>,
+    checked: &mut HashSet<String>,
+) -> Result<(), String> {
+    match ty {
+        WaveType::Pointer(_) => Ok(()),
+        WaveType::Array(inner, _) => {
+            validate_finite_payload_type(root, inner, program, active, checked)
+        }
+        WaveType::Struct(name) | WaveType::Variant(name) => {
+            validate_finite_named_type(root, name, program, active, checked)
+        }
+        _ => Ok(()),
+    }
 }
 
 fn validate_alias_cycle(

--- a/front/parser/tests/typed_hir.rs
+++ b/front/parser/tests/typed_hir.rs
@@ -1,0 +1,86 @@
+//! Contracts for the backend-neutral typed frontend boundary.
+
+use lexer::Lexer;
+use parser::ast::{ASTNode, Expression, WaveType};
+use parser::hir::{HirExpressionType, TypedProgram};
+use parser::parse_syntax_only;
+
+fn lower(source: &str) -> TypedProgram {
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize().expect("lex should succeed");
+    let syntax = parse_syntax_only(&tokens).expect("parse should succeed");
+    TypedProgram::lower(syntax).expect("semantic lowering should succeed")
+}
+
+#[test]
+fn assigns_stable_ids_and_preserves_semantic_expression_types() {
+    let program = lower(
+        r#"
+fun calculate(left: i64, right: i64) -> i64 {
+    var total: i64 = left + right;
+    var literal: i64 = 1;
+    var pointer: ptr<i8> = null;
+    return total;
+}
+"#,
+    );
+
+    let ASTNode::Function(function) = &program.syntax()[0] else {
+        panic!("expected function");
+    };
+    let ASTNode::Variable(total) = &function.body[0] else {
+        panic!("expected total variable");
+    };
+    let binary = total.initial_value.as_ref().expect("expected initializer");
+    assert_eq!(
+        program.type_of(binary),
+        Some(&HirExpressionType::Resolved(WaveType::Int(64)))
+    );
+
+    let Expression::BinaryExpression { left, right, .. } = binary else {
+        panic!("expected binary expression");
+    };
+    let left_id = program.expression_id(left).expect("left expression id");
+    let right_id = program.expression_id(right).expect("right expression id");
+    assert_ne!(left_id, right_id);
+    assert_eq!(left_id.index() + 1, right_id.index());
+    assert_eq!(
+        program.expression_type(left_id),
+        Some(&HirExpressionType::Resolved(WaveType::Int(64)))
+    );
+
+    let ASTNode::Variable(literal) = &function.body[1] else {
+        panic!("expected literal variable");
+    };
+    assert_eq!(
+        program.type_of(literal.initial_value.as_ref().unwrap()),
+        Some(&HirExpressionType::IntegerLiteral)
+    );
+
+    let ASTNode::Variable(pointer) = &function.body[2] else {
+        panic!("expected pointer variable");
+    };
+    assert_eq!(
+        program.type_of(pointer.initial_value.as_ref().unwrap()),
+        Some(&HirExpressionType::Null)
+    );
+    assert_eq!(program.expression_count(), 6);
+}
+
+#[test]
+fn rejects_invalid_programs_before_constructing_typed_hir() {
+    let mut lexer = Lexer::new(
+        r#"
+fun invalid() -> i32 {
+    return missing;
+}
+"#,
+    );
+    let tokens = lexer.tokenize().expect("lex should succeed");
+    let syntax = parse_syntax_only(&tokens).expect("parse should succeed");
+    let error = TypedProgram::lower(syntax).expect_err("lowering must reject invalid input");
+    assert!(error
+        .diagnostic()
+        .message
+        .contains("undeclared identifier `missing`"));
+}

--- a/front/parser/tests/variant_frontend.rs
+++ b/front/parser/tests/variant_frontend.rs
@@ -1,0 +1,315 @@
+//! Frontend contracts for payload variants and variant matching.
+
+use lexer::Lexer;
+use parser::ast::{ASTNode, MatchPattern, StatementNode, WaveType};
+use parser::generics::monomorphize_generics;
+use parser::hir::{HirExpressionType, TypedProgram};
+use parser::parse_syntax_only;
+
+fn syntax(source: &str) -> Vec<ASTNode> {
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize().expect("lex should succeed");
+    parse_syntax_only(&tokens).expect("parse should succeed")
+}
+
+fn lower(source: &str) -> TypedProgram {
+    let ast = syntax(source);
+    let ast = monomorphize_generics(ast).expect("generic rewriting should succeed");
+    TypedProgram::lower(ast).expect("typed HIR lowering should succeed")
+}
+
+fn semantic_error(source: &str) -> String {
+    let ast = syntax(source);
+    TypedProgram::lower(ast)
+        .expect_err("semantic validation must reject the program")
+        .diagnostic()
+        .message
+        .clone()
+}
+
+#[test]
+fn parses_variant_declarations_and_recursive_patterns() {
+    let program = lower(
+        r#"
+variant Cell<T> {
+    Value(T)
+}
+
+variant Envelope<T> {
+    Cell(Cell<T>)
+}
+
+fun unwrap(item: Envelope<i32>) -> i32 {
+    match item {
+        Envelope::Cell(Cell::Value(value)) => {
+            return value;
+        }
+    }
+}
+
+variant Bit {
+    Zero,
+    One
+}
+
+variant WrappedBit {
+    Bit(Bit)
+}
+
+fun unwrap_bit(item: WrappedBit) -> i32 {
+    match item {
+        WrappedBit::Bit(Bit::Zero) => { return 0; }
+        WrappedBit::Bit(Bit::One) => { return 1; }
+    }
+}
+"#,
+    );
+
+    let ASTNode::Variant(cell) = &program.syntax()[0] else {
+        panic!("expected variant declaration");
+    };
+    assert_eq!(cell.name, "Cell");
+    assert_eq!(cell.generic_params, ["T"]);
+    assert_eq!(cell.cases[0].payload_types, [WaveType::Struct("T".into())]);
+
+    let ASTNode::Function(unwrap) = &program.syntax()[2] else {
+        panic!("expected unwrap function");
+    };
+    let ASTNode::Statement(StatementNode::Match { arms, .. }) = &unwrap.body[0] else {
+        panic!("expected match statement");
+    };
+    assert!(matches!(
+        &arms[0].pattern,
+        MatchPattern::Variant { payloads, .. }
+            if matches!(payloads.as_slice(), [MatchPattern::Variant { .. }])
+    ));
+    let outer = program
+        .variant_pattern(program.pattern_id(&arms[0].pattern).unwrap())
+        .expect("outer variant pattern metadata");
+    assert_eq!(outer.discriminant, 0);
+    assert_eq!(outer.payload_types, [WaveType::Variant("Cell<i32>".into())]);
+    let MatchPattern::Variant { payloads, .. } = &arms[0].pattern else {
+        unreachable!()
+    };
+    let nested = program
+        .variant_pattern(program.pattern_id(&payloads[0]).unwrap())
+        .expect("nested variant pattern metadata");
+    assert_eq!(nested.variant_type, WaveType::Variant("Cell<i32>".into()));
+}
+
+#[test]
+fn resolves_contextual_generic_constructors_into_typed_hir() {
+    let program = lower(
+        r#"
+variant Option<T> {
+    Some(T),
+    None
+}
+
+fun some() -> Option<i32> {
+    return Option::Some(7);
+}
+
+fun none() -> Option<i32> {
+    return Option::None;
+}
+"#,
+    );
+
+    for index in [1, 2] {
+        let ASTNode::Function(function) = &program.syntax()[index] else {
+            panic!("expected function");
+        };
+        let ASTNode::Statement(StatementNode::Return(Some(expression))) = &function.body[0] else {
+            panic!("expected constructor return");
+        };
+        assert_eq!(
+            program.type_of(expression),
+            Some(&HirExpressionType::Resolved(WaveType::Variant(
+                "Option<i32>".into()
+            )))
+        );
+        let construction = program
+            .variant_construction(program.expression_id(expression).unwrap())
+            .expect("variant construction metadata");
+        assert_eq!(construction.discriminant, (index - 1) as u32);
+        assert_eq!(
+            construction.payload_types,
+            if index == 1 {
+                vec![WaveType::Int(32)]
+            } else {
+                Vec::new()
+            }
+        );
+    }
+}
+
+#[test]
+fn infers_generic_arguments_through_nested_variant_payloads() {
+    let program = lower(
+        r#"
+variant Inner<T> {
+    Value(T)
+}
+
+variant Outer<T> {
+    Wrap(Inner<T>)
+}
+
+fun make() {
+    Outer::Wrap(Inner::Value(7));
+}
+"#,
+    );
+
+    let ASTNode::Function(make) = &program.syntax()[2] else {
+        panic!("expected make function");
+    };
+    let ASTNode::Statement(StatementNode::Expression(initializer)) = &make.body[0] else {
+        panic!("expected constructor expression");
+    };
+    assert_eq!(
+        program.type_of(initializer),
+        Some(&HirExpressionType::Resolved(WaveType::Variant(
+            "Outer<i32>".into()
+        )))
+    );
+}
+
+#[test]
+fn rejects_invalid_variant_declarations_and_constructors() {
+    let cases = [
+        (
+            "variant Bad { Same, Same }",
+            "duplicate case `Same` in variant `Bad`",
+        ),
+        (
+            "variant Option<T> { Some(T), None } fun bad() -> Option<i32> { return Option::Missing; }",
+            "unknown case `Missing` in variant `Option`",
+        ),
+        (
+            "variant Option<T> { Some(T), None } fun bad() -> Option<i32> { return Option::Some; }",
+            "expects 1 payload value(s), found 0",
+        ),
+        (
+            "variant Option<T> { Some(T), None } fun bad() -> Option<i32> { return Option::Some(\"text\"); }",
+            "expected `i32`, found `str`",
+        ),
+        (
+            "variant Option<T> { Some(T), None } fun bad() { var value = Option::None; }",
+            "cannot resolve generic argument(s) T",
+        ),
+        (
+            "variant Loop<T> { Next(T, Loop<T>), End }",
+            "variant `Loop` has infinite size",
+        ),
+        (
+            "variant Option<T> { Some(T), None } export(c) fun bad(value: Option<i32>) {}",
+            "cannot expose variant parameter `value` directly",
+        ),
+        (
+            "variant Option<T> { Some(T), None } export(c) fun bad() -> Option<i32> { return Option::None; }",
+            "cannot return a variant directly",
+        ),
+        (
+            "variant First { Value } variant Second { Value } fun bad() -> First { return Second::Value; }",
+            "expected `First`, found `Second`",
+        ),
+    ];
+
+    for (source, expected) in cases {
+        let error = semantic_error(source);
+        assert!(
+            error.contains(expected),
+            "expected `{expected}` in `{error}` for source `{source}`"
+        );
+    }
+}
+
+#[test]
+fn enforces_variant_match_scope_uniqueness_and_exhaustiveness() {
+    let cases = [
+        (
+            "variant Option<T> { Some(T), None } fun bad(value: Option<i32>) { match value { Option::Some(item) => {} } }",
+            "non-exhaustive match on variant `Option<i32>`",
+        ),
+        (
+            "variant Option<T> { Some(T), None } fun bad(value: Option<i32>) { match value { Option::Some(item) => {}, Option::Some(other) => {}, Option::None => {} } }",
+            "duplicate variant case `Option::Some`",
+        ),
+        (
+            "variant Pair { Values(i32, i32) } fun bad(value: Pair) { match value { Pair::Values(item, item) => {} } }",
+            "duplicate pattern binding `item`",
+        ),
+        (
+            "variant Option<T> { Some(T), None } fun bad(value: Option<i32>) { match value { _ => {}, Option::None => {} } }",
+            "match pattern after wildcard is unreachable",
+        ),
+        (
+            "variant Flag { Off, On } fun bad(value: Flag) { match value { Flag::Off => {}, Flag::On => {}, _ => {} } }",
+            "previous variant patterns are exhaustive",
+        ),
+        (
+            "variant Option<T> { Some(T), None } fun bad(value: Option<i32>) { match value { Option::Some() => {}, Option::None => {} } }",
+            "expects 1 payload pattern(s), found 0",
+        ),
+        (
+            "variant Option<T> { Some(T), None } fun bad(value: Option<i32>) { match value { Option::Some(item) => {}, Option::None => {} } var leaked: i32 = item; }",
+            "undeclared identifier `item`",
+        ),
+        (
+            "variant Inner { A, B } variant Outer { Wrap(Inner) } fun bad(value: Outer) { match value { Outer::Wrap(Inner::A) => {} } }",
+            "patterns do not cover all payload shapes",
+        ),
+    ];
+
+    for (source, expected) in cases {
+        let error = semantic_error(source);
+        assert!(
+            error.contains(expected),
+            "expected `{expected}` in `{error}` for source `{source}`"
+        );
+    }
+}
+
+#[test]
+fn permits_pointer_indirection_in_recursive_variants() {
+    lower(
+        r#"
+variant List<T> {
+    Node(T, ptr<List<T>>),
+    End
+}
+"#,
+    );
+}
+
+#[test]
+fn preserves_variant_types_through_generic_monomorphization() {
+    let program = lower(
+        r#"
+variant Option<T> {
+    Some(T),
+    None
+}
+
+fun wrap<T>(value: T) -> Option<T> {
+    return Option::Some(value);
+}
+
+fun concrete() -> Option<i64> {
+    return wrap<i64>(7);
+}
+"#,
+    );
+
+    assert!(program.syntax().iter().any(|node| {
+        matches!(
+            node,
+            ASTNode::Function(function)
+                if function.name.contains("wrap$g$i64")
+                    && function.return_type
+                        == Some(WaveType::Struct("Option<i64>".into()))
+        )
+    }));
+}

--- a/llvm/src/codegen/types.rs
+++ b/llvm/src/codegen/types.rs
@@ -96,6 +96,12 @@ pub fn wave_type_to_llvm_type<'ctx>(
             .get(name)
             .unwrap_or_else(|| panic!("Struct type '{}' not found", name))
             .as_basic_type_enum(),
+        WaveType::Variant(name) => {
+            panic!(
+                "variant type '{}' reached LLVM before variant lowering",
+                name
+            )
+        }
     }
 }
 

--- a/llvm/src/statement/control.rs
+++ b/llvm/src/statement/control.rs
@@ -169,6 +169,9 @@ fn eval_match_case_const<'ctx>(
         MatchPattern::Wildcard => {
             panic!("internal error: wildcard cannot be lowered as a switch case constant");
         }
+        MatchPattern::Binding(_) | MatchPattern::Variant { .. } => {
+            panic!("variant pattern reached LLVM before variant lowering");
+        }
     }
 }
 
@@ -530,6 +533,9 @@ pub(super) fn gen_match_ir<'ctx>(
                 let case_block =
                     context.append_basic_block(current_fn, &format!("match.case.{}", idx));
                 case_entries.push((case_value, case_block, arm));
+            }
+            MatchPattern::Binding(_) | MatchPattern::Variant { .. } => {
+                panic!("variant pattern reached LLVM before variant lowering");
             }
         }
     }

--- a/src/module_resolver.rs
+++ b/src/module_resolver.rs
@@ -7,6 +7,7 @@
 use ::error::{WaveError, WaveErrorKind};
 use ::parser::ast::*;
 use ::parser::import::{local_import_unit_with_config, ImportConfig};
+use ::parser::types::{parse_type, split_top_level_generic_args, token_type_to_wave_type};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
@@ -27,6 +28,7 @@ pub struct ResolvedModuleGraph {
 enum SymbolKind {
     Function,
     Struct,
+    VariantConstructor,
     Type,
     Value,
 }
@@ -108,6 +110,14 @@ struct InferenceTypes {
     methods: HashMap<(String, String), CallableType>,
     fields: HashMap<String, HashMap<String, WaveType>>,
     globals: HashMap<String, WaveType>,
+    variants: HashMap<String, InferenceVariantConstructor>,
+}
+
+#[derive(Clone)]
+struct InferenceVariantConstructor {
+    owner: String,
+    generic_params: Vec<String>,
+    payload_types: Vec<WaveType>,
 }
 
 fn infer_variable_types(ast: &mut [ASTNode]) -> Result<(), String> {
@@ -143,6 +153,18 @@ fn infer_variable_types(ast: &mut [ASTNode]) -> Result<(), String> {
                         CallableType {
                             generic_params: method.generic_params.clone(),
                             return_type: method.return_type.clone().unwrap_or(WaveType::Void),
+                        },
+                    );
+                }
+            }
+            ASTNode::Variant(variant) => {
+                for case in &variant.cases {
+                    types.variants.insert(
+                        format!("{}::{}", variant.name, case.name),
+                        InferenceVariantConstructor {
+                            owner: variant.name.clone(),
+                            generic_params: variant.generic_params.clone(),
+                            payload_types: case.payload_types.clone(),
                         },
                     );
                 }
@@ -299,15 +321,25 @@ fn infer_expression_type(
         Expression::Literal(Literal::Char(_)) => Ok(WaveType::Char),
         Expression::Literal(Literal::Byte(_)) => Ok(WaveType::Byte),
         Expression::Null => Err("`null` needs an explicit pointer type".to_string()),
-        Expression::Variable(name) => locals
-            .get(name)
-            .or_else(|| types.globals.get(name))
-            .cloned()
-            .ok_or_else(|| format!("unknown value '{}'", name)),
+        Expression::Variable(name) => {
+            if let Some(ty) = locals.get(name).or_else(|| types.globals.get(name)) {
+                Ok(ty.clone())
+            } else if types.variants.contains_key(name) {
+                infer_variant_constructor_type(name, &[], types, locals)
+            } else {
+                Err(format!("unknown value '{}'", name))
+            }
+        }
         Expression::StructLiteral { name, .. } => Ok(WaveType::Struct(name.clone())),
         Expression::FunctionCall {
             name, type_args, ..
         } => {
+            if let Some(constructor) = types.variants.get(name) {
+                let Expression::FunctionCall { args, .. } = expression else {
+                    unreachable!()
+                };
+                return infer_variant_constructor_type_from(name, constructor, args, types, locals);
+            }
             let callable = types
                 .functions
                 .get(name)
@@ -417,6 +449,159 @@ fn infer_expression_type(
     }
 }
 
+fn infer_variant_constructor_type(
+    name: &str,
+    args: &[Expression],
+    types: &InferenceTypes,
+    locals: &HashMap<String, WaveType>,
+) -> Result<WaveType, String> {
+    let constructor = types
+        .variants
+        .get(name)
+        .ok_or_else(|| format!("unknown variant constructor '{}'", name))?;
+    infer_variant_constructor_type_from(name, constructor, args, types, locals)
+}
+
+fn infer_variant_constructor_type_from(
+    name: &str,
+    constructor: &InferenceVariantConstructor,
+    args: &[Expression],
+    types: &InferenceTypes,
+    locals: &HashMap<String, WaveType>,
+) -> Result<WaveType, String> {
+    if args.len() != constructor.payload_types.len() {
+        return Err(format!(
+            "variant constructor '{}' expects {} payload value(s), found {}",
+            name,
+            constructor.payload_types.len(),
+            args.len()
+        ));
+    }
+    if constructor.generic_params.is_empty() {
+        return Ok(WaveType::Struct(constructor.owner.clone()));
+    }
+
+    let mut substitutions = HashMap::new();
+    for (argument, template) in args.iter().zip(&constructor.payload_types) {
+        let actual = infer_expression_type(argument, types, locals)?;
+        infer_module_variant_substitution(
+            template,
+            &actual,
+            &constructor.generic_params,
+            &mut substitutions,
+        )?;
+    }
+    let missing = constructor
+        .generic_params
+        .iter()
+        .filter(|parameter| !substitutions.contains_key(*parameter))
+        .cloned()
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        return Err(format!(
+            "cannot infer generic argument(s) {} for variant constructor '{}'",
+            missing.join(", "),
+            name
+        ));
+    }
+    let arguments = constructor
+        .generic_params
+        .iter()
+        .map(|parameter| module_type_name(&substitutions[parameter]))
+        .collect::<Vec<_>>()
+        .join(",");
+    Ok(WaveType::Struct(format!(
+        "{}<{}>",
+        constructor.owner, arguments
+    )))
+}
+
+fn infer_module_variant_substitution(
+    template: &WaveType,
+    actual: &WaveType,
+    generic_params: &[String],
+    substitutions: &mut HashMap<String, WaveType>,
+) -> Result<(), String> {
+    if let WaveType::Struct(name) = template {
+        if generic_params.contains(name) {
+            if let Some(previous) = substitutions.get(name) {
+                if previous != actual {
+                    return Err(format!(
+                        "conflicting inferred types {:?} and {:?} for variant generic '{}'",
+                        previous, actual, name
+                    ));
+                }
+            } else {
+                substitutions.insert(name.clone(), actual.clone());
+            }
+            return Ok(());
+        }
+    }
+    match (template, actual) {
+        (WaveType::Pointer(template), WaveType::Pointer(actual))
+        | (WaveType::Array(template, _), WaveType::Array(actual, _)) => {
+            infer_module_variant_substitution(template, actual, generic_params, substitutions)
+        }
+        (WaveType::Struct(template_name), WaveType::Struct(actual_name))
+        | (WaveType::Struct(template_name), WaveType::Variant(actual_name))
+        | (WaveType::Variant(template_name), WaveType::Struct(actual_name))
+        | (WaveType::Variant(template_name), WaveType::Variant(actual_name)) => {
+            let Some((template_base, template_args)) =
+                parse_module_named_type_application(template_name)
+            else {
+                return Ok(());
+            };
+            let Some((actual_base, actual_args)) = parse_module_named_type_application(actual_name)
+            else {
+                return Ok(());
+            };
+            if template_base != actual_base || template_args.len() != actual_args.len() {
+                return Ok(());
+            }
+            for (template_arg, actual_arg) in template_args.iter().zip(&actual_args) {
+                infer_module_variant_substitution(
+                    template_arg,
+                    actual_arg,
+                    generic_params,
+                    substitutions,
+                )?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+fn parse_module_named_type_application(name: &str) -> Option<(String, Vec<WaveType>)> {
+    let (base, tail) = name.split_once('<')?;
+    let inner = tail.strip_suffix('>')?;
+    let arguments = split_top_level_generic_args(inner)?
+        .into_iter()
+        .map(|argument| {
+            let token = parse_type(&argument)?;
+            token_type_to_wave_type(&token)
+        })
+        .collect::<Option<Vec<_>>>()?;
+    Some((base.trim().to_string(), arguments))
+}
+
+fn module_type_name(ty: &WaveType) -> String {
+    match ty {
+        WaveType::Infer => "infer".to_string(),
+        WaveType::Int(bits) => format!("i{}", bits),
+        WaveType::Uint(bits) => format!("u{}", bits),
+        WaveType::Float(bits) => format!("f{}", bits),
+        WaveType::Bool => "bool".to_string(),
+        WaveType::Char => "char".to_string(),
+        WaveType::Byte => "byte".to_string(),
+        WaveType::String => "str".to_string(),
+        WaveType::Pointer(inner) => format!("ptr<{}>", module_type_name(inner)),
+        WaveType::Array(inner, size) => format!("array<{},{}>", module_type_name(inner), size),
+        WaveType::Void => "void".to_string(),
+        WaveType::Struct(name) | WaveType::Variant(name) => name.clone(),
+    }
+}
+
 fn expression_literal_kind(expression: &Expression) -> Option<bool> {
     match expression {
         Expression::Literal(Literal::Int(_)) => Some(false),
@@ -455,6 +640,7 @@ fn substitute_type(ty: &WaveType, substitutions: &HashMap<String, WaveType>) -> 
         WaveType::Array(inner, size) => {
             WaveType::Array(Box::new(substitute_type(inner, substitutions)), *size)
         }
+        WaveType::Variant(name) => WaveType::Variant(name.clone()),
         _ => ty.clone(),
     }
 }
@@ -552,6 +738,16 @@ impl Resolver<'_> {
                             format!("re-exported symbol '{}' conflicts in this module", selected),
                             "remove one re-export or rename the local declaration",
                         ));
+                    }
+                    let prefix = format!("{}::", selected);
+                    for (qualified, constructor) in &child.symbols {
+                        if qualified.starts_with(&prefix)
+                            && constructor.kind == SymbolKind::VariantConstructor
+                        {
+                            interface
+                                .symbols
+                                .insert(qualified.clone(), constructor.clone());
+                        }
                     }
                 }
             }
@@ -713,6 +909,27 @@ fn collect_symbols(
                     }
                 }
             }
+            ASTNode::Variant(variant) => {
+                insert_symbol(
+                    path,
+                    &mut symbols,
+                    &variant.name,
+                    variant.visibility,
+                    SymbolKind::Type,
+                    is_entry,
+                )?;
+                let lowered_owner = internal_name(path, &variant.name, is_entry);
+                for case in &variant.cases {
+                    symbols.insert(
+                        format!("{}::{}", variant.name, case.name),
+                        ModuleSymbol {
+                            lowered: format!("{}::{}", lowered_owner, case.name),
+                            visibility: variant.visibility,
+                            kind: SymbolKind::VariantConstructor,
+                        },
+                    );
+                }
+            }
             ASTNode::Variable(variable)
                 if matches!(variable.mutability, Mutability::Const | Mutability::Static) =>
             {
@@ -788,6 +1005,16 @@ fn bind_import(
                 ));
             }
             names.selected.insert(selected.clone(), symbol.clone());
+            let prefix = format!("{}::", selected);
+            for (qualified, constructor) in &interface.symbols {
+                if qualified.starts_with(&prefix)
+                    && constructor.kind == SymbolKind::VariantConstructor
+                {
+                    names
+                        .selected
+                        .insert(qualified.clone(), constructor.clone());
+                }
+            }
         }
         return Ok(());
     }
@@ -887,6 +1114,7 @@ fn rewrite_type(ty: WaveType, names: &NameContext, path: &Path) -> Result<WaveTy
             size,
         )),
         WaveType::Struct(name) => Ok(WaveType::Struct(rewrite_type_name(&name, names, path)?)),
+        WaveType::Variant(name) => Ok(WaveType::Variant(rewrite_type_name(&name, names, path)?)),
         other => Ok(other),
     }
 }
@@ -1003,6 +1231,17 @@ fn rewrite_top_level(
                 variant.name = names.own[&variant.name].lowered.clone();
             }
             Ok(ASTNode::Enum(enumeration))
+        }
+        ASTNode::Variant(mut variant) => {
+            variant.name = names.own[&variant.name].lowered.clone();
+            for case in &mut variant.cases {
+                case.payload_types = case
+                    .payload_types
+                    .drain(..)
+                    .map(|ty| rewrite_type(ty, names, path))
+                    .collect::<Result<_, _>>()?;
+            }
+            Ok(ASTNode::Variant(variant))
         }
         ASTNode::Variable(mut variable) => {
             variable.name = names.own[&variable.name].lowered.clone();
@@ -1174,14 +1413,9 @@ fn rewrite_statement(
             arms: arms
                 .into_iter()
                 .map(|mut arm| {
-                    if let MatchPattern::Ident(name) = &mut arm.pattern {
-                        if !locals.contains(name) {
-                            if let Some(symbol) = resolve_name(name, names, path)? {
-                                *name = symbol.lowered;
-                            }
-                        }
-                    }
+                    rewrite_match_pattern(&mut arm.pattern, names, path, locals)?;
                     let mut scope = locals.clone();
+                    collect_pattern_bindings(&arm.pattern, &mut scope);
                     arm.body = rewrite_block(arm.body, names, path, &mut scope)?;
                     Ok(arm)
                 })
@@ -1246,6 +1480,68 @@ fn rewrite_expressions(
         .collect()
 }
 
+fn rewrite_match_pattern(
+    pattern: &mut MatchPattern,
+    names: &NameContext,
+    path: &Path,
+    locals: &HashSet<String>,
+) -> Result<(), WaveError> {
+    match pattern {
+        MatchPattern::Ident(name) => {
+            if !locals.contains(name) {
+                if let Some(symbol) = resolve_name(name, names, path)? {
+                    *name = symbol.lowered;
+                }
+            }
+        }
+        MatchPattern::Variant {
+            variant_type,
+            case_name,
+            payloads,
+        } => {
+            let qualified = format!("{}::{}", variant_type, case_name);
+            let symbol = resolve_name(&qualified, names, path)?.ok_or_else(|| {
+                module_error(
+                    path,
+                    "Unknown variant case",
+                    format!("variant case '{}' is not declared", qualified),
+                    "check the variant type and case name",
+                )
+            })?;
+            if symbol.kind != SymbolKind::VariantConstructor {
+                return Err(module_error(
+                    path,
+                    "Invalid variant pattern",
+                    format!("'{}' is not a variant case", qualified),
+                    "use a qualified case declared by a variant",
+                ));
+            }
+            let (owner, case) = symbol.lowered.rsplit_once("::").unwrap();
+            *variant_type = owner.to_string();
+            *case_name = case.to_string();
+            for payload in payloads {
+                rewrite_match_pattern(payload, names, path, locals)?;
+            }
+        }
+        MatchPattern::Int(_) | MatchPattern::Binding(_) | MatchPattern::Wildcard => {}
+    }
+    Ok(())
+}
+
+fn collect_pattern_bindings(pattern: &MatchPattern, locals: &mut HashSet<String>) {
+    match pattern {
+        MatchPattern::Binding(name) => {
+            locals.insert(name.clone());
+        }
+        MatchPattern::Variant { payloads, .. } => {
+            for payload in payloads {
+                collect_pattern_bindings(payload, locals);
+            }
+        }
+        MatchPattern::Int(_) | MatchPattern::Ident(_) | MatchPattern::Wildcard => {}
+    }
+}
+
 fn rewrite_expression(
     expression: Expression,
     names: &NameContext,
@@ -1286,11 +1582,18 @@ fn rewrite_expression(
                         fields: Vec::new(),
                     }
                 }
-                Some(symbol) if symbol.kind == SymbolKind::Function => Expression::FunctionCall {
-                    name: symbol.lowered,
-                    type_args,
-                    args,
-                },
+                Some(symbol)
+                    if matches!(
+                        symbol.kind,
+                        SymbolKind::Function | SymbolKind::VariantConstructor
+                    ) =>
+                {
+                    Expression::FunctionCall {
+                        name: symbol.lowered,
+                        type_args,
+                        args,
+                    }
+                }
                 Some(_) => {
                     return Err(module_error(
                         path,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -14,15 +14,17 @@
 //!
 //! This module owns user-facing phase boundaries and diagnostics. Frontend work
 //! must finish in the order target preprocessing, parsing, import expansion,
-//! semantic validation, monomorphization, and concrete-AST validation before an
-//! AST reaches LLVM. Backend panics are caught here and translated into Wave
-//! diagnostics; lower layers should not duplicate that presentation policy.
+//! template validation, monomorphization, and typed HIR construction. The
+//! legacy LLVM path currently receives the HIR's syntax view. Backend panics
+//! are caught here and translated into Wave diagnostics; lower layers should
+//! not duplicate that presentation policy.
 
 use crate::module_resolver::{demangle_module_names, resolve_import_graph};
 use crate::{DebugFlags, DepFlags, LinkFlags, LlvmFlags};
 use ::error::*;
 use ::parser::ast::*;
 use ::parser::generics::monomorphize_generics;
+use ::parser::hir::TypedProgram;
 use ::parser::import::*;
 use ::parser::verification::{validate_program_detailed, SemanticSpanHint, SemanticSpanKind};
 use ::parser::*;
@@ -107,33 +109,37 @@ fn parse_wave_tokens_or_exit(
     })
 }
 
-fn validate_wave_ast_or_exit(file_path: &Path, source: &str, ast: &[ASTNode]) {
-    if let Err(diagnostic) = validate_program_detailed(ast) {
-        let node = ast.get(diagnostic.top_level_index);
-        let (line, column, span_len) = diagnostic
-            .primary
-            .as_ref()
-            .and_then(|hint| semantic_hint_position(source, node, 1, hint))
-            .unwrap_or((1, 1, 1));
-        let mut error = WaveError::new(
-            WaveErrorKind::InvalidStatement(diagnostic.message.clone()),
-            format!("semantic validation failed: {}", diagnostic.message),
-            file_path.display().to_string(),
-            line,
-            column,
-        )
-        .with_code(diagnostic.code)
-        .with_source_code(source.to_string())
-        .with_span_len(span_len)
-        .with_context("semantic validation")
-        .with_label(diagnostic.label)
-        .with_help(diagnostic.help);
-        if let Some(note) = diagnostic.note {
-            error = error.with_note(note);
-        }
-        error.display_auto();
+fn lower_wave_hir_or_exit(file_path: &Path, source: &str, ast: Vec<ASTNode>) -> TypedProgram {
+    match TypedProgram::lower(ast) {
+        Ok(program) => program,
+        Err(error) => {
+            let (ast, diagnostic) = error.into_parts();
+            let node = ast.get(diagnostic.top_level_index);
+            let (line, column, span_len) = diagnostic
+                .primary
+                .as_ref()
+                .and_then(|hint| semantic_hint_position(source, node, 1, hint))
+                .unwrap_or((1, 1, 1));
+            let mut error = WaveError::new(
+                WaveErrorKind::InvalidStatement(diagnostic.message.clone()),
+                format!("semantic validation failed: {}", diagnostic.message),
+                file_path.display().to_string(),
+                line,
+                column,
+            )
+            .with_code(diagnostic.code)
+            .with_source_code(source.to_string())
+            .with_span_len(span_len)
+            .with_context("semantic validation")
+            .with_label(diagnostic.label)
+            .with_help(diagnostic.help);
+            if let Some(note) = diagnostic.note {
+                error = error.with_note(note);
+            }
+            error.display_auto();
 
-        process::exit(1);
+            process::exit(1);
+        }
     }
 }
 
@@ -248,7 +254,7 @@ fn is_declaration_occurrence(source: &str, offset: usize, name: &str) -> bool {
     let line_start = source[..offset].rfind('\n').map_or(0, |index| index + 1);
     let prefix = source[line_start..offset].trim_start();
     [
-        "fun ", "struct ", "proto ", "enum ", "type ", "var ", "const ", "static ",
+        "fun ", "struct ", "proto ", "enum ", "variant ", "type ", "var ", "const ", "static ",
     ]
     .iter()
     .any(|keyword| prefix.ends_with(keyword))
@@ -263,10 +269,11 @@ fn semantic_node_key(node: &ASTNode) -> (u8, String) {
         ASTNode::ProtoImpl(implementation) => (2, implementation.target.clone()),
         ASTNode::TypeAlias(alias) => (3, alias.name.clone()),
         ASTNode::Enum(enumeration) => (4, enumeration.name.clone()),
-        ASTNode::Variable(variable) => (5, variable.name.clone()),
-        ASTNode::Statement(_) => (6, String::new()),
-        ASTNode::Expression(_) => (7, String::new()),
-        ASTNode::Program(_) => (8, String::new()),
+        ASTNode::Variant(variant) => (5, variant.name.clone()),
+        ASTNode::Variable(variable) => (6, variable.name.clone()),
+        ASTNode::Statement(_) => (7, String::new()),
+        ASTNode::Expression(_) => (8, String::new()),
+        ASTNode::Program(_) => (9, String::new()),
     }
 }
 
@@ -294,6 +301,9 @@ fn semantic_node_scope(
         }
         ASTNode::Enum(enumeration) => {
             format!("enum {}", demangle_module_names(&enumeration.name))
+        }
+        ASTNode::Variant(variant) => {
+            format!("variant {}", demangle_module_names(&variant.name))
         }
         ASTNode::Variable(variable) => demangle_module_names(&variable.name),
         ASTNode::Statement(_) | ASTNode::Expression(_) | ASTNode::Program(_) => {
@@ -908,12 +918,12 @@ fn build_backend_options(llvm: &LlvmFlags) -> BackendOptions {
     }
 }
 
-fn frontend_prepare_wave_ast(
+fn frontend_prepare_wave_hir(
     file_path: &Path,
     debug: &DebugFlags,
     dep: &DepFlags,
     llvm: Option<&LlvmFlags>,
-) -> (String, Vec<ASTNode>) {
+) -> (String, TypedProgram) {
     let raw_code = match fs::read_to_string(file_path) {
         Ok(c) => c,
         Err(_) => {
@@ -986,8 +996,8 @@ fn frontend_prepare_wave_ast(
         }
     };
 
-    validate_wave_ast_or_exit(file_path, &code, &ast);
-    (code, ast)
+    let hir = lower_wave_hir_or_exit(file_path, &code, ast);
+    (code, hir)
 }
 
 pub(crate) unsafe fn check_wave_file(
@@ -996,7 +1006,7 @@ pub(crate) unsafe fn check_wave_file(
     dep: &DepFlags,
     llvm: &LlvmFlags,
 ) {
-    let _ = frontend_prepare_wave_ast(file_path, debug, dep, Some(llvm));
+    let _ = frontend_prepare_wave_hir(file_path, debug, dep, Some(llvm));
 }
 
 pub(crate) unsafe fn emit_wave_ast_text(
@@ -1005,8 +1015,8 @@ pub(crate) unsafe fn emit_wave_ast_text(
     dep: &DepFlags,
     llvm: &LlvmFlags,
 ) -> String {
-    let (_, ast) = frontend_prepare_wave_ast(file_path, debug, dep, Some(llvm));
-    format!("{:#?}\n", ast)
+    let (_, hir) = frontend_prepare_wave_hir(file_path, debug, dep, Some(llvm));
+    format!("{:#?}\n", hir.syntax())
 }
 
 pub(crate) unsafe fn emit_wave_ir_text(
@@ -1016,15 +1026,16 @@ pub(crate) unsafe fn emit_wave_ir_text(
     dep: &DepFlags,
     llvm: &LlvmFlags,
 ) -> String {
-    let (code, ast) = frontend_prepare_wave_ast(file_path, debug, dep, Some(llvm));
+    let (code, hir) = frontend_prepare_wave_hir(file_path, debug, dep, Some(llvm));
     let backend_opts = build_backend_options(llvm);
 
-    let ir = match run_panic_guarded(|| unsafe { generate_ir(&ast, opt_flag, &backend_opts) }) {
-        Ok(ir) => ir,
-        Err((msg, loc)) => {
-            emit_codegen_panic_and_exit(file_path, &code, "llvm-ir-generation", msg, loc)
-        }
-    };
+    let ir =
+        match run_panic_guarded(|| unsafe { generate_ir(hir.syntax(), opt_flag, &backend_opts) }) {
+            Ok(ir) => ir,
+            Err((msg, loc)) => {
+                emit_codegen_panic_and_exit(file_path, &code, "llvm-ir-generation", msg, loc)
+            }
+        };
 
     if debug.ir {
         println!("\n===== LLVM IR =====\n{}", ir);
@@ -1050,8 +1061,17 @@ unsafe fn emit_wave_codegen_file(
     output: &Path,
     kind: CodegenFileKind,
 ) {
-    let (code, ast) = frontend_prepare_wave_ast(file_path, debug, dep, Some(llvm));
-    emit_wave_codegen_file_from_ast(file_path, &code, &ast, opt_flag, debug, llvm, output, kind);
+    let (code, hir) = frontend_prepare_wave_hir(file_path, debug, dep, Some(llvm));
+    emit_wave_codegen_file_from_ast(
+        file_path,
+        &code,
+        hir.syntax(),
+        opt_flag,
+        debug,
+        llvm,
+        output,
+        kind,
+    );
 }
 
 unsafe fn emit_wave_codegen_file_from_ast(
@@ -1216,14 +1236,14 @@ pub(crate) unsafe fn run_wave_file(
         }
     };
 
-    validate_wave_ast_or_exit(file_path, &code, &ast);
+    let hir = lower_wave_hir_or_exit(file_path, &code, ast);
 
     let file_stem = file_path.file_stem().unwrap().to_str().unwrap();
     let object_patch = format!("{}.o", file_stem);
     emit_wave_codegen_file_from_ast(
         file_path,
         &code,
-        &ast,
+        hir.syntax(),
         opt_flag,
         debug,
         llvm,
@@ -1345,7 +1365,7 @@ pub(crate) unsafe fn object_build_wave_file(
         process::exit(1);
     });
 
-    validate_wave_ast_or_exit(file_path, &code, &ast);
+    let hir = lower_wave_hir_or_exit(file_path, &code, ast);
 
     let file_stem = file_path.file_stem().unwrap().to_str().unwrap();
     let default_object_path = PathBuf::from(format!("{}.o", file_stem));
@@ -1353,7 +1373,7 @@ pub(crate) unsafe fn object_build_wave_file(
     emit_wave_codegen_file_from_ast(
         file_path,
         &code,
-        &ast,
+        hir.syntax(),
         opt_flag,
         debug,
         llvm,

--- a/tests/codegen_regressions.rs
+++ b/tests/codegen_regressions.rs
@@ -115,6 +115,91 @@ where
     )
 }
 
+#[test]
+fn variant_frontend_resolves_imported_types_constructors_and_patterns() {
+    let dir = temp_case_dir("variant-imports");
+    write_wave(
+        &dir,
+        "option.wave",
+        r#"
+pub variant Option<T> {
+    Some(T),
+    None
+}
+"#,
+    );
+    let selected = write_wave(
+        &dir,
+        "selected.wave",
+        r#"
+import("./option")::{Option};
+
+fun unwrap(value: Option<i32>) -> i32 {
+    match value {
+        Option::Some(item) => { return item; }
+        Option::None => { return 0; }
+    }
+}
+"#,
+    );
+    let namespaced = write_wave(
+        &dir,
+        "namespaced.wave",
+        r#"
+import("./option" as option);
+
+fun make() -> option::Option<i32> {
+    return option::Option::Some(7);
+}
+
+fun infer() {
+    var value = option::Option::Some(9);
+    match value {
+        option::Option::Some(item) => {}
+        option::Option::None => {}
+    }
+}
+"#,
+    );
+    write_wave(&dir, "facade.wave", "pub import(\"./option\")::{Option};\n");
+    let reexported = write_wave(
+        &dir,
+        "reexported.wave",
+        r#"
+import("./facade")::{Option};
+
+fun empty() -> Option<i32> {
+    return Option::None;
+}
+"#,
+    );
+    let nested = write_wave(
+        &dir,
+        "nested.wave",
+        r#"
+variant Inner<T> {
+    Value(T)
+}
+
+variant Outer<T> {
+    Wrap(Inner<T>)
+}
+
+fun infer_nested() {
+    var value = Outer::Wrap(Inner::Value(11));
+    match value {
+        Outer::Wrap(Inner::Value(item)) => {}
+    }
+}
+"#,
+    );
+
+    run_wavec(["check", selected.to_str().unwrap()]);
+    run_wavec(["check", namespaced.to_str().unwrap()]);
+    run_wavec(["check", reexported.to_str().unwrap()]);
+    run_wavec(["check", nested.to_str().unwrap()]);
+}
+
 fn bytes_contains(haystack: &[u8], needle: &[u8]) -> bool {
     haystack
         .windows(needle.len())
@@ -568,7 +653,7 @@ fn semantic_validation_rejects_backend_only_type_failures_early() {
         (
             "invalid_match.wave",
             "struct Value { x: i32; }\nfun main() { var v: Value = Value { x: 1 }; match (v) { _ => {} } }\n",
-            "match value must be an integer or enum",
+            "match value must be an integer, enum, or variant",
         ),
         (
             "invalid_deref.wave",


### PR DESCRIPTION
## Summary
- introduce a backend-neutral typed HIR boundary with stable expression and pattern identities
- implement generic payload variant declarations, constructors, recursive patterns, exhaustiveness, finite-size checks, and C ABI exposure guards
- resolve variant types and constructors through selected, namespaced, and re-exported imports
- remove the temporarily unavailable wavefnd GitHub Sponsors entry from FUNDING.yml

## Backend boundary
LLVM variant layout and lowering are intentionally left for the follow-up backend change. Explicit guards prevent variant types or patterns from reaching legacy LLVM lowering silently.

## Validation
- cargo fmt --all --check
- cargo test --workspace --locked --jobs 2
- cargo clippy --locked --all-targets --jobs 2 -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc --locked --no-deps --jobs 2
- git diff --check