### PR TITLE
docs: add file I/O examples

### DIFF
--- a/examples/file_io.wave
+++ b/examples/file_io.wave
@@ -1,0 +1,98 @@
+import("std::fs::consts")::{
+    FS_MODE_FILE_DEFAULT,
+};
+
+import("std::fs::file")::{
+    fs_remove,
+    fs_open_read,
+    fs_open_write,
+    fs_close,
+    fs_read_all,
+    fs_write_all,
+};
+
+import("std::io::fd")::{
+    io_read,
+};
+
+fun main() {
+    var path: str = "/tmp/wave-file-io-example.txt";
+    var payload: str = "wave-file-io";
+
+    fs_remove(path);
+
+    // Open a file using the path-based std::fs::file API.
+    var write_fd: i64 = fs_open_write(
+        path,
+        FS_MODE_FILE_DEFAULT
+    );
+
+    if (write_fd < 0) {
+        println("fs_open_write failed: {}", write_fd);
+        return;
+    }
+
+    fs_close(write_fd);
+
+    var write_n: i64 = fs_write_all(
+        path,
+        payload as ptr<u8>,
+        12,
+        FS_MODE_FILE_DEFAULT
+    );
+
+    if (write_n < 0) {
+        println("fs_write_all failed: {}", write_n);
+        fs_remove(path);
+        return;
+    }
+
+    println("bytes written = {}", write_n);
+
+    // fs_read_all reads from a path into caller-owned storage.
+    // It does not allocate or return a str.
+    var read_buf: array<u8, 64>;
+
+    var read_n: i64 = fs_read_all(
+        path,
+        &read_buf[0],
+        64
+    );
+
+    if (read_n < 0) {
+        println("fs_read_all failed: {}", read_n);
+        fs_remove(path);
+        return;
+    }
+
+    println("fs_read_all bytes = {}", read_n);
+
+    // io_read works with an already-open file descriptor.
+    var read_fd: i64 = fs_open_read(path);
+
+    if (read_fd < 0) {
+        println("fs_open_read failed: {}", read_fd);
+        fs_remove(path);
+        return;
+    }
+
+    var fd_buf: array<u8, 64>;
+
+    var fd_n: i64 = io_read(
+        read_fd,
+        &fd_buf[0],
+        64
+    );
+
+    if (fd_n < 0) {
+        println("io_read failed: {}", fd_n);
+        fs_close(read_fd);
+        fs_remove(path);
+        return;
+    }
+
+    println("io_read bytes = {}", fd_n);
+
+    fs_close(read_fd);
+    fs_remove(path);
+}

--- a/std/README.md
+++ b/std/README.md
@@ -5,10 +5,13 @@ This is Wave's standard library. This standard library operates independently of
 ## License
 
 The Wave standard library in this directory is licensed under the
+
 [Apache License 2.0](LICENSE). It may be modified, redistributed, and embedded
+
 in other products under the terms of that license.
 
 The Wave compiler and other repository components outside `std/` remain
+
 licensed under the repository's [Mozilla Public License 2.0](../LICENSE).
 
 ## Dependency Policy
@@ -26,6 +29,7 @@ licensed under the repository's [Mozilla Public License 2.0](../LICENSE).
 - `std::buffer`: growable byte buffer built on `std::mem`.
 - `std::io`: fd-level read/write/seek/copy helpers.
 - `std::fs`: basic open/read/write/copy/metadata helpers.
+- `fs_read_all` reads into caller-owned byte storage; it does not allocate or return `str`.
 - `std::bytes`: endian swap/load/store helpers.
 - `std::process`: fork/exec/wait and stdio redirection helpers.
 

--- a/tests/cases/test109.wave
+++ b/tests/cases/test109.wave
@@ -1,0 +1,138 @@
+// wave-test: host-os=linux, host-arch=x86_64
+
+import("std::fs::consts")::{
+    FS_MODE_FILE_DEFAULT,
+};
+
+import("std::fs::file")::{
+    fs_remove,
+    fs_open_read,
+    fs_open_write,
+    fs_close,
+    fs_read_all,
+    fs_write_all,
+};
+
+import("std::io::fd")::{
+    io_read,
+};
+
+fun check_i64(label: str, got: i64, expected: i64) -> i64 {
+    if (got == expected) {
+        println("[OK] {} => {}", label, got);
+        return 1;
+    }
+
+    println("[FAIL] {} => got {}, expected {}", label, got, expected);
+    return 0;
+}
+
+fun main() {
+    var path: str = "/tmp/wave-std-test109.txt";
+    var payload: str = "wave-file-io";
+
+    fs_remove(path);
+
+    var passed: i64 = 0;
+
+    // Open and close a file using std::fs::file.
+    var write_fd: i64 = fs_open_write(
+        path,
+        FS_MODE_FILE_DEFAULT
+    );
+
+    if (write_fd < 0) {
+        println("[FAIL] fs_open_write => {}", write_fd);
+        return;
+    }
+
+    passed += check_i64("fs_open_write", 1, 1);
+
+    var close_n: i64 = fs_close(write_fd);
+    passed += check_i64("fs_close", close_n, 0);
+
+    // Write known bytes so that the returned byte count is measurable.
+    var write_n: i64 = fs_write_all(
+        path,
+        payload as ptr<u8>,
+        12,
+        FS_MODE_FILE_DEFAULT
+    );
+
+    passed += check_i64("fs_write_all byte count", write_n, 12);
+
+    // fs_read_all reads a path into caller-owned storage.
+    var read_buf: array<u8, 64>;
+
+    var read_n: i64 = fs_read_all(
+        path,
+        &read_buf[0],
+        64
+    );
+
+    passed += check_i64(
+        "fs_read_all byte count",
+        read_n,
+        12
+    );
+
+    // Verify that the destination buffer contains the expected bytes.
+    var prefix_ok: i64 = 0;
+
+    if (
+        read_buf[0] == 119 &&
+        read_buf[1] == 97 &&
+        read_buf[2] == 118
+    ) {
+        prefix_ok = 1;
+    }
+
+    passed += check_i64(
+        "fs_read_all buffer contents",
+        prefix_ok,
+        1
+    );
+
+    // io_read works with an already-open descriptor.
+    var read_fd: i64 = fs_open_read(path);
+
+    if (read_fd < 0) {
+        println("[FAIL] fs_open_read => {}", read_fd);
+        fs_remove(path);
+        return;
+    }
+
+    var fd_buf: array<u8, 64>;
+
+    var fd_n: i64 = io_read(
+        read_fd,
+        &fd_buf[0],
+        64
+    );
+
+    passed += check_i64(
+        "io_read byte count",
+        fd_n,
+        13
+    );
+
+    // Negative lengths must produce a negative error result.
+    var invalid_n: i64 = io_read(
+        read_fd,
+        &fd_buf[0],
+        -1
+    );
+
+    if (invalid_n < 0) {
+        println("[OK] io_read negative length => {}", invalid_n);
+        passed += 1;
+    } else {
+        println("[FAIL] io_read negative length => {}", invalid_n);
+    }
+
+    fs_close(read_fd);
+    fs_remove(path);
+
+    println("passed checks = {}", passed);
+    println("expected checks = 7");
+}


### PR DESCRIPTION
# Add runnable file I/O examples

## Summary

Adds focused examples demonstrating the distinction between path-based and descriptor-based file I/O.

## Changes

* Add a runnable file I/O example.
* Demonstrate opening and closing file descriptors.
* Demonstrate `fs_read_all` with caller-owned byte storage.
* Demonstrate `io_read` with an already-open file descriptor.
* Check returned byte counts and negative error results.
* Document that `fs_read_all` does not allocate or return `str`.
* Add a Linux-hosted test case covering the file I/O behavior.

Closes #377.
