### PR TITLE
Preserve pointer depth in semantic validation

### DIFF
--- a/examples/tcp.wave
+++ b/examples/tcp.wave
@@ -113,7 +113,7 @@ fun htons(x: i16) -> i16 {
 fun _setsockopt_reuseaddr(sockfd: i64) {
     // SOL_SOCKET = 1, SO_REUSEADDR = 2
     var one: i32 = 1;
-    syscall5(54, sockfd, 1, 2, &one, 4);
+    syscall5(54, sockfd, 1, 2, &one as ptr<i8>, 4);
 }
 
 struct SockAddrIn {

--- a/front/parser/src/verification.rs
+++ b/front/parser/src/verification.rs
@@ -2492,7 +2492,7 @@ impl<'a> Validator<'a> {
                         is_byte_like_type(inner.as_ref())
                             || matches!(inner.as_ref(), WaveType::String)
                     }
-                    (WaveType::Pointer(_), WaveType::Pointer(_)) => true,
+                    (WaveType::Pointer(actual), WaveType::Pointer(expected)) => actual == expected,
                     _ => false,
                 }
             }

--- a/std/net/socket_base.wave
+++ b/std/net/socket_base.wave
@@ -130,19 +130,19 @@ pub fun net_socket_udp_v4() -> i64 {
 
 pub fun net_bind_v4(fd: i64, addr: NetAddrV4) -> i64 {
     var sa: NetSockAddrIn = net_to_sockaddr_v4(addr);
-    return bind(fd, &sa, 16);
+    return bind(fd, &sa as ptr<i8>, 16);
 }
 
 pub fun net_connect_v4(fd: i64, addr: NetAddrV4) -> i64 {
     var sa: NetSockAddrIn = net_to_sockaddr_v4(addr);
-    return connect(fd, &sa, 16);
+    return connect(fd, &sa as ptr<i8>, 16);
 }
 
 pub fun net_accept_v4(fd: i64, out_addr: ptr<NetAddrV4>) -> i64 {
     var sa: NetSockAddrIn;
     var salen: i32 = 16;
 
-    var cfd: i64 = accept(fd, &sa, &salen);
+    var cfd: i64 = accept(fd, &sa as ptr<i8>, &salen);
     if (cfd >= 0 && out_addr != null) {
         deref out_addr = net_from_sockaddr_v4(sa);
     }
@@ -196,7 +196,7 @@ pub fun net_sendto_v4(
     flags: i32
 ) -> i64 {
     var sa: NetSockAddrIn = net_to_sockaddr_v4(addr);
-    return sendto(fd, buf, len, flags, &sa, 16);
+    return sendto(fd, buf, len, flags, &sa as ptr<i8>, 16);
 }
 
 pub fun net_recvfrom_v4(
@@ -209,7 +209,7 @@ pub fun net_recvfrom_v4(
     var sa: NetSockAddrIn;
     var salen: i32 = 16;
 
-    var n: i64 = recvfrom(fd, buf, len, flags, &sa, &salen);
+    var n: i64 = recvfrom(fd, buf, len, flags, &sa as ptr<i8>, &salen);
     if (n >= 0 && out_addr != null) {
         deref out_addr = net_from_sockaddr_v4(sa);
     }

--- a/tests/cases/test56.wave
+++ b/tests/cases/test56.wave
@@ -114,7 +114,7 @@ fun htons(x: i16) -> i16 {
 fun _setsockopt_reuseaddr(sockfd: i64) {
     // SOL_SOCKET = 1, SO_REUSEADDR = 2
     var one: i32 = 1;
-    syscall5(54, sockfd, 1, 2, &one, 4);
+    syscall5(54, sockfd, 1, 2, &one as ptr<i8>, 4);
 }
 
 struct SockAddrIn {

--- a/tests/codegen_regressions.rs
+++ b/tests/codegen_regressions.rs
@@ -832,6 +832,92 @@ fun main() {
 }
 
 #[test]
+fn semantic_validation_preserves_pointer_depth_for_address_of() {
+    let dir = temp_case_dir("address-of-pointer-depth");
+    let valid = write_wave(
+        &dir,
+        "valid.wave",
+        r#"
+fun main() {
+    var message: str = "Hello";
+    var correct: ptr<str> = &message;
+    var copied: ptr<str> = correct;
+    var converted: ptr<i8> = &message as ptr<i8>;
+}
+"#,
+    );
+
+    run_wavec([OsStr::new("check"), valid.as_os_str()]);
+    run_wavec([
+        OsStr::new("build"),
+        valid.as_os_str(),
+        OsStr::new("--emit=obj"),
+        OsStr::new("--out-dir"),
+        dir.as_os_str(),
+    ]);
+
+    let invalid_cases = [
+        (
+            "string_depth.wave",
+            r#"
+fun main() {
+    var message: str = "Hello";
+    var wrong: ptr<i8> = &message;
+}
+"#,
+            "type mismatch in initializer for `wrong`: expected `ptr<i8>`, found `ptr<str>`",
+        ),
+        (
+            "pointer_pointee.wave",
+            r#"
+fun consume(value: ptr<u8>) {}
+
+fun main() {
+    var number: i32 = 1;
+    consume(&number);
+}
+"#,
+            "type mismatch in argument 1 of function `consume`: expected `ptr<u8>`, found `ptr<i32>`",
+        ),
+    ];
+
+    for (file_name, source, expected) in invalid_cases {
+        let source = write_wave(&dir, file_name, source);
+        for mode in ["check", "build"] {
+            let output = if mode == "check" {
+                run_wavec_raw([OsStr::new("check"), source.as_os_str()])
+            } else {
+                run_wavec_raw([
+                    OsStr::new("build"),
+                    source.as_os_str(),
+                    OsStr::new("--emit=obj"),
+                    OsStr::new("--out-dir"),
+                    dir.as_os_str(),
+                ])
+            };
+            assert!(
+                !output.status.success(),
+                "{} unexpectedly accepted an implicit pointer conversion in {} mode",
+                file_name,
+                mode
+            );
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(stderr.contains("error[E3001]"), "{}: {}", file_name, stderr);
+            assert!(stderr.contains(expected), "{}: {}", file_name, stderr);
+            assert!(
+                !stderr.contains("E9001")
+                    && !stderr.contains("compiler internal error")
+                    && !stderr.contains("panic location"),
+                "{} leaked a backend failure in {} mode: {}",
+                file_name,
+                mode,
+                stderr
+            );
+        }
+    }
+}
+
+#[test]
 fn second_semantic_audit_rejects_unsafe_programs_before_codegen() {
     let dir = temp_case_dir("semantic-audit-two");
     let cases = [


### PR DESCRIPTION
## Summary
- reject implicit pointer-to-pointer conversions when canonical pointee types differ
- preserve `&message` as `ptr<str>` and require an explicit cast for raw `ptr<i8>` access
- make intentional std networking and TCP syscall pointer erasure explicit
- add check/build regressions for #358 and mismatched pointer arguments

## Validation
- `cargo fmt --all --check`
- `cargo test --workspace --locked --jobs 2`
- `cargo clippy --locked --all-targets --jobs 2 -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --jobs 2`
- `./tools/check_std_policy.sh`
- `python3 tools/check_wave_corpus.py --wavec target/debug/wavec` (92 passed)
- `python3 tools/run_tests.py` with the branch std installed in an isolated home (100 passed, 8 platform skips, 0 failed)
- `git diff --check`

Close #358