### PR TITLE
ci: build every minimal LLVM target feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -245,6 +245,16 @@ jobs:
           cargo build --locked --no-default-features
           --features llvm-target-riscv --jobs 2
 
+      - name: Build with the x86-only LLVM feature
+        run: >-
+          cargo build --locked --no-default-features
+          --features llvm-target-x86 --jobs 2
+
+      - name: Build with the AArch64-only LLVM feature
+        run: >-
+          cargo build --locked --no-default-features
+          --features llvm-target-aarch64 --jobs 2
+
       - name: Build with the core 64-bit LLVM feature set
         run: >-
           cargo build --locked --no-default-features


### PR DESCRIPTION
Adds compile-only CI coverage for the independent x86 and AArch64 LLVM target feature configurations while retaining the existing RISC-V-only and core64 checks.

Validation:
- cargo +1.97.1 check --locked --no-default-features --features llvm-target-x86 --jobs 2
- cargo +1.97.1 check --locked --no-default-features --features llvm-target-aarch64 --jobs 2
- cargo +1.97.1 check --locked --no-default-features --features llvm-target-riscv --jobs 2
- cargo +1.97.1 check --locked --no-default-features --features llvm-target-core64 --jobs 2
- git diff --check

Fixes #402