### PR TITLE
feat(std): establish a portable versioned standard library foundation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: "2"
   NO_COLOR: "1"
   PYTHONUNBUFFERED: "1"
   PYTHONUTF8: "1"
@@ -184,7 +185,9 @@ jobs:
           target/release/wavec -V
 
       - name: Check examples and standard library corpus
-        run: python3 tools/check_wave_corpus.py --wavec target/release/wavec
+        run: >-
+          python3 tools/check_wave_corpus.py --wavec target/release/wavec
+          --run-std-examples
 
       - name: Run Wave end-to-end tests
         run: python3 tools/run_tests.py --report-json wave-e2e-report.json

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: "2"
   PYTHONUNBUFFERED: "1"
+  PYTHONUTF8: "1"
+  PYTHONIOENCODING: "utf-8"
 
 permissions:
   contents: read
@@ -78,7 +81,9 @@ jobs:
         run: cargo test --locked --all-targets --verbose
 
       - name: Check examples and standard library corpus
-        run: python3 tools/check_wave_corpus.py --wavec target/release/wavec
+        run: >-
+          python3 tools/check_wave_corpus.py --wavec target/release/wavec
+          --run-std-examples
 
       - name: Run x86_64 SysV ABI contract tests
         if: ${{ always() }}
@@ -146,6 +151,11 @@ jobs:
 
       - name: Build release compiler
         run: cargo build --locked --release --verbose
+
+      - name: Check and run standard library examples
+        run: >-
+          python3 tools/check_wave_corpus.py --wavec target/release/wavec
+          --run-std-examples
 
       - name: Run Rust tests
         run: cargo test --locked --all-targets --verbose
@@ -394,6 +404,11 @@ jobs:
       - name: Build release compiler
         run: cargo build --locked --release --verbose
 
+      - name: Check and run standard library examples
+        run: >-
+          python3 tools/check_wave_corpus.py --wavec target/release/wavec
+          --run-std-examples
+
       - name: Run Rust tests
         run: cargo test --locked --all-targets --verbose
 
@@ -464,6 +479,11 @@ jobs:
 
       - name: Build release compiler
         run: cargo build --locked --release --verbose
+
+      - name: Check and run standard library examples
+        run: >-
+          python3 tools/check_wave_corpus.py --wavec target/release/wavec
+          --run-std-examples
 
       - name: Run Rust tests
         run: cargo test --locked --all-targets --verbose
@@ -596,6 +616,12 @@ jobs:
       - name: Build release compiler
         shell: msys2 {0}
         run: cargo build --locked --release --verbose
+
+      - name: Check and run standard library examples
+        shell: msys2 {0}
+        run: >-
+          python tools/check_wave_corpus.py --wavec target/release/wavec.exe
+          --run-std-examples
 
       - name: Run Rust tests
         shell: msys2 {0}

--- a/examples/file_io.wave
+++ b/examples/file_io.wave
@@ -1,17 +1,13 @@
-import("std::fs::consts")::{
-    FS_MODE_FILE_DEFAULT,
-};
-
 import("std::fs::file")::{
-    fs_remove,
-    fs_open_read,
-    fs_open_write,
-    fs_close,
-    fs_read_all,
-    fs_write_all,
+    remove,
+    open_read,
+    create,
+    read_into,
+    write,
 };
 
 import("std::io::fd")::{
+    io_close,
     io_read,
 };
 
@@ -19,60 +15,55 @@ fun main() {
     var path: str = "/tmp/wave-file-io-example.txt";
     var payload: str = "wave-file-io";
 
-    fs_remove(path);
+    remove(path);
 
-    // Open a file using the path-based std::fs::file API.
-    var write_fd: i64 = fs_open_write(
-        path,
-        FS_MODE_FILE_DEFAULT
-    );
+    // create uses portable default permissions and returns an owned descriptor.
+    var write_fd: i64 = create(path);
 
     if (write_fd < 0) {
-        println("fs_open_write failed: {}", write_fd);
+        println("create failed: {}", write_fd);
         return;
     }
 
-    fs_close(write_fd);
+    io_close(write_fd);
 
-    var write_n: i64 = fs_write_all(
+    var write_n: i64 = write(
         path,
         payload as ptr<u8>,
-        12,
-        FS_MODE_FILE_DEFAULT
+        12
     );
 
     if (write_n < 0) {
-        println("fs_write_all failed: {}", write_n);
-        fs_remove(path);
+        println("write failed: {}", write_n);
+        remove(path);
         return;
     }
 
     println("bytes written = {}", write_n);
 
-    // fs_read_all reads from a path into caller-owned storage.
-    // It does not allocate or return a str.
+    // read_into requires caller-owned storage and does not allocate.
     var read_buf: array<u8, 64>;
 
-    var read_n: i64 = fs_read_all(
+    var read_n: i64 = read_into(
         path,
         &read_buf[0],
         64
     );
 
     if (read_n < 0) {
-        println("fs_read_all failed: {}", read_n);
-        fs_remove(path);
+        println("read_into failed: {}", read_n);
+        remove(path);
         return;
     }
 
-    println("fs_read_all bytes = {}", read_n);
+    println("read_into bytes = {}", read_n);
 
     // io_read works with an already-open file descriptor.
-    var read_fd: i64 = fs_open_read(path);
+    var read_fd: i64 = open_read(path);
 
     if (read_fd < 0) {
-        println("fs_open_read failed: {}", read_fd);
-        fs_remove(path);
+        println("open_read failed: {}", read_fd);
+        remove(path);
         return;
     }
 
@@ -86,13 +77,13 @@ fun main() {
 
     if (fd_n < 0) {
         println("io_read failed: {}", fd_n);
-        fs_close(read_fd);
-        fs_remove(path);
+        io_close(read_fd);
+        remove(path);
         return;
     }
 
     println("io_read bytes = {}", fd_n);
 
-    fs_close(read_fd);
-    fs_remove(path);
+    io_close(read_fd);
+    remove(path);
 }

--- a/examples/observability_gateway.wave
+++ b/examples/observability_gateway.wave
@@ -223,6 +223,16 @@ fun default_data_root() -> str {
     return "/usr/local/var/wave";
 }
 
+#[target(os="windows")]
+fun default_data_root() -> str {
+    return "C:/ProgramData/Wave";
+}
+
+#[target(os="freebsd")]
+fun default_data_root() -> str {
+    return "/var/db/wave";
+}
+
 struct KeyValue<K, V> {
     key: K;
     value: V;

--- a/examples/std/README.md
+++ b/examples/std/README.md
@@ -1,0 +1,11 @@
+# Wave standard library examples
+
+Each `.wave` file is a small, independent program focused on one standard-library area.
+Run one from the repository root with:
+
+```sh
+wavec run examples/std/strings.wave
+```
+
+The filesystem example creates and removes a file in the current directory. The environment,
+I/O, process, and time examples use the host operating-system provider selected by `wavec`.

--- a/examples/std/buffers.wave
+++ b/examples/std/buffers.wave
@@ -1,0 +1,15 @@
+import("std::buffer::alloc")::{Buffer, buffer_free, buffer_new};
+import("std::buffer::read")::{buffer_at};
+import("std::buffer::write")::{buffer_append_str, buffer_push};
+
+fun main() {
+    var buf: Buffer = buffer_new(8);
+    buffer_append_str(&buf, "Wave");
+    buffer_push(&buf, 33);
+
+    println("buffer length: {}", buf.len);
+    println("first byte: {}", buffer_at(buf, 0));
+    println("last byte: {}", buffer_at(buf, buf.len - 1));
+
+    buffer_free(&buf);
+}

--- a/examples/std/bytes.wave
+++ b/examples/std/bytes.wave
@@ -1,0 +1,19 @@
+import("std::bytes::endian")::{
+    bytes_load_be_i32,
+    bytes_load_le_i32,
+    bytes_store_be_i32,
+    bytes_store_le_i32,
+    bytes_swap32,
+};
+
+fun main() {
+    var big: array<u8, 4>;
+    var little: array<u8, 4>;
+
+    bytes_store_be_i32(&big[0], 0x12345678);
+    bytes_store_le_i32(&little[0], 0x12345678);
+
+    println("big-endian round trip: {}", bytes_load_be_i32(&big[0]));
+    println("little-endian round trip: {}", bytes_load_le_i32(&little[0]));
+    println("byte swapped: {}", bytes_swap32(0x12345678));
+}

--- a/examples/std/environment.wave
+++ b/examples/std/environment.wave
@@ -1,0 +1,22 @@
+import("std::env::cwd")::{env_getcwd};
+import("std::env::environ")::{env_exists, env_get};
+
+fun main() {
+    var cwd: array<u8, 1024>;
+    var cwd_len: i64 = env_getcwd(&cwd[0], 1024);
+    if (cwd_len >= 0) {
+        var cwd_text: str = &cwd[0] as str;
+        println("current directory: {}", cwd_text);
+    }
+
+    var home: array<u8, 1024>;
+    var home_len: i64 = env_get("HOME", &home[0], 1024);
+    if (home_len >= 0) {
+        var home_text: str = &home[0] as str;
+        println("HOME: {}", home_text);
+    } else {
+        println("HOME is not set");
+    }
+
+    println("PATH exists: {}", env_exists("PATH"));
+}

--- a/examples/std/filesystem.wave
+++ b/examples/std/filesystem.wave
@@ -1,0 +1,25 @@
+import("std::buffer::alloc")::{Buffer, buffer_free, buffer_new};
+import("std::fs::file")::{
+    exists,
+    read_to_end,
+    remove,
+    size,
+    write,
+};
+
+fun main() {
+    var path: str = "wave-std-example.txt";
+    var message: str = "hello from std::fs";
+
+    var written: i64 = write(path, message as ptr<u8>, 18);
+    println("written bytes: {}", written);
+    println("file exists: {}", exists(path));
+    println("file size: {}", size(path));
+
+    var contents: Buffer = buffer_new(8);
+    var read: i64 = read_to_end(path, &contents);
+    println("read bytes: {}", read);
+
+    buffer_free(&contents);
+    remove(path);
+}

--- a/examples/std/io.wave
+++ b/examples/std/io.wave
@@ -1,0 +1,11 @@
+import("std::io::consts")::{IO_STDOUT_FD};
+import("std::io::fd")::{io_write_all};
+
+fun main() -> i32 {
+    var message: str = "hello through std::io\n";
+    var written: i64 = io_write_all(IO_STDOUT_FD, message as ptr<u8>, 22);
+    println("std::io wrote {} bytes", written);
+
+    if (written != 22) { return 1; }
+    return 0;
+}

--- a/examples/std/math.wave
+++ b/examples/std/math.wave
@@ -1,0 +1,17 @@
+import("std::math::bits")::{align_up, is_pow2, popcount};
+import("std::math::int")::{abs, clamp};
+import("std::math::num")::{gcd, lcm, pow_i32};
+import("std::math::trig")::{cos_f64, sin_f64, sqrt_f64};
+
+fun main() {
+    println("abs(-12): {}", abs(-12));
+    println("clamp(15, 0, 10): {}", clamp(15, 0, 10));
+    println("gcd(84, 30): {}", gcd(84, 30));
+    println("lcm(6, 8): {}", lcm(6, 8));
+    println("3^5: {}", pow_i32(3, 5));
+    println("1024 is a power of two: {}", is_pow2(1024));
+    println("align 19 up to 8: {}", align_up(19, 8));
+    println("set bits in 255: {}", popcount(255));
+    println("sqrt(81): {}", sqrt_f64(81.0));
+    println("sin(0), cos(0): {}, {}", sin_f64(0.0), cos_f64(0.0));
+}

--- a/examples/std/memory.wave
+++ b/examples/std/memory.wave
@@ -1,0 +1,25 @@
+import("std::mem::alloc")::{
+    mem_alloc_zeroed,
+    mem_free,
+    mem_is_aligned,
+    mem_page_size,
+};
+import("std::mem::ops")::{mem_find_byte, mem_set};
+
+fun main() {
+    var size: i64 = 32;
+    var data: ptr<u8> = mem_alloc_zeroed(size);
+    if (data == null) {
+        println("allocation failed");
+        return;
+    }
+
+    mem_set(data, 65, size);
+    deref data[7] = 90;
+
+    println("page size: {}", mem_page_size());
+    println("allocation aligned to 8: {}", mem_is_aligned(data, 8));
+    println("byte Z found at: {}", mem_find_byte(data, size, 90));
+
+    mem_free(data, size);
+}

--- a/examples/std/network.wave
+++ b/examples/std/network.wave
@@ -1,0 +1,26 @@
+import("std::net::address")::{
+    net_addr_any_v4,
+    net_addr_loopback_v4,
+    net_htonl,
+    net_htons,
+    net_ntohl,
+    net_ntohs,
+};
+
+fun main() {
+    var loopback = net_addr_loopback_v4(8080);
+    var any = net_addr_any_v4(3000);
+
+    println(
+        "loopback host-order address: {}:{}",
+        net_ntohl(loopback.ip),
+        net_ntohs(loopback.port) as u16
+    );
+    println(
+        "any host-order address: {}:{}",
+        net_ntohl(any.ip),
+        net_ntohs(any.port) as u16
+    );
+    println("16-bit network round trip: {}", net_ntohs(net_htons(8080)));
+    println("32-bit network round trip: {}", net_ntohl(net_htonl(0x7f000001)));
+}

--- a/examples/std/paths.wave
+++ b/examples/std/paths.wave
@@ -1,0 +1,23 @@
+import("std::path::analyze")::{path_basename_start, path_dirname_len, path_has_ext};
+import("std::path::copy")::{path_basename_copy, path_dirname_copy, path_join2};
+import("std::path::core")::{path_is_abs};
+
+fun main() {
+    var path: str = "/project/src/main.wave";
+    var joined: array<u8, 64>;
+    var basename: array<u8, 32>;
+    var dirname: array<u8, 64>;
+
+    path_join2(&joined[0], 64, "examples", "std");
+    path_basename_copy(&basename[0], 32, path);
+    path_dirname_copy(&dirname[0], 64, path);
+
+    var joined_text: str = &joined[0] as str;
+    var basename_text: str = &basename[0] as str;
+    var dirname_text: str = &dirname[0] as str;
+
+    println("joined: {}", joined_text);
+    println("basename: {} (starts at {})", basename_text, path_basename_start(path));
+    println("dirname: {} (length {})", dirname_text, path_dirname_len(path));
+    println("absolute: {}, has extension: {}", path_is_abs(path), path_has_ext(path));
+}

--- a/examples/std/process.wave
+++ b/examples/std/process.wave
@@ -1,0 +1,6 @@
+import("std::process::core")::{proc_getpid, proc_getppid};
+
+fun main() {
+    println("process id: {}", proc_getpid());
+    println("parent process id: {}", proc_getppid());
+}

--- a/examples/std/strings.wave
+++ b/examples/std/strings.wave
@@ -1,0 +1,23 @@
+import("std::string::ascii")::{is_alnum, to_lower, to_upper};
+import("std::string::cmp")::{ends_with, eq, starts_with};
+import("std::string::find")::{count_char, find_char};
+import("std::string::hash")::{djb2_32, fnv1a_64};
+import("std::string::len")::{is_empty, len};
+import("std::string::trim")::{trim_left_index, trim_right_index};
+
+fun main() {
+    var text: str = "Wave language";
+    var padded: str = "  Wave  ";
+
+    println("length: {}", len(text));
+    println("empty: {}", is_empty(text));
+    println("starts with Wave: {}", starts_with(text, "Wave"));
+    println("ends with language: {}", ends_with(text, "language"));
+    println("equal to Wave: {}", eq(text, "Wave"));
+    println("first a: {}", find_char(text, 97));
+    println("number of a bytes: {}", count_char(text, 97));
+    println("trim range: {}..{}", trim_left_index(padded), trim_right_index(padded));
+    println("W is alphanumeric: {}", is_alnum(87));
+    println("case conversion: {} {}", to_lower(87), to_upper(119));
+    println("hashes: {} {}", djb2_32(text), fnv1a_64(text));
+}

--- a/examples/std/time.wave
+++ b/examples/std/time.wave
@@ -1,0 +1,16 @@
+import("std::time::clock")::{TimeSpec, time_now_monotonic, time_now_realtime_ns};
+import("std::time::diff")::{time_diff_ms, time_diff_ns};
+import("std::time::sleep")::{time_sleep_ms};
+
+fun main() {
+    var start: TimeSpec;
+    var end: TimeSpec;
+
+    time_now_monotonic(&start);
+    time_sleep_ms(10);
+    time_now_monotonic(&end);
+
+    println("realtime nanoseconds: {}", time_now_realtime_ns());
+    println("elapsed nanoseconds: {}", time_diff_ns(start, end));
+    println("elapsed milliseconds: {}", time_diff_ms(start, end));
+}

--- a/front/parser/src/import.rs
+++ b/front/parser/src/import.rs
@@ -19,11 +19,16 @@
 
 use crate::arch;
 use crate::ast::ASTNode;
+use crate::os;
 use crate::{parse_syntax_only, ParseError};
 use error::error::{WaveError, WaveErrorKind};
 use lexer::Lexer;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+
+/// Compiler/standard-library syntax contract understood by this parser.
+/// Bump this together with std/manifest.json when compatibility is broken.
+pub const STD_COMPATIBILITY_REVISION: u64 = 1;
 
 #[derive(Debug, Clone, Default)]
 pub struct TargetConditionContext {
@@ -83,11 +88,7 @@ fn normalize_target_value(key: &str, value: &str) -> String {
     let lower = value.trim().to_ascii_lowercase();
     match key {
         "arch" => arch::canonical_name(&lower),
-        "os" => match lower.as_str() {
-            "darwin" | "apple" => "macos".to_string(),
-            "win32" | "win64" => "windows".to_string(),
-            other => other.to_string(),
-        },
+        "os" => os::canonical_name(&lower),
         "env" => match lower.as_str() {
             "mingw" => "gnu".to_string(),
             other => other.to_string(),
@@ -111,10 +112,10 @@ fn parse_target_attr(line: &str) -> Option<TargetAttrCondition<'_>> {
         let value = parse_attr_string(value.trim())?;
 
         match key {
-            "arch" => condition.arch = Some(value),
-            "os" => condition.os = Some(value),
-            "env" => condition.env = Some(value),
-            "abi" => condition.abi = Some(value),
+            "arch" if condition.arch.is_none() => condition.arch = Some(value),
+            "os" if condition.os.is_none() => condition.os = Some(value),
+            "env" if condition.env.is_none() => condition.env = Some(value),
+            "abi" if condition.abi.is_none() => condition.abi = Some(value),
             _ => return None,
         }
     }
@@ -715,7 +716,66 @@ fn std_import_unit(
         ));
     }
 
+    validate_installed_std(&std_root, &found_path)?;
+
     parse_wave_file(&found_path, path, already_imported, config)
+}
+
+/// Reads and validates the compatibility metadata shared by the compiler and
+/// std installer. Installation and import resolution use the same check.
+pub fn std_compatibility_revision(std_root: &Path) -> Result<u64, String> {
+    let manifest_path = std_root.join("manifest.json");
+    let text = std::fs::read_to_string(&manifest_path)
+        .map_err(|error| format!("failed to read '{}': {}", manifest_path.display(), error))?;
+    let manifest = utils::json::parse(&text)
+        .map_err(|error| format!("invalid '{}': {}", manifest_path.display(), error))?;
+
+    if manifest.get_str("name") != Some("std") {
+        return Err(format!(
+            "invalid '{}': name must be 'std'",
+            manifest_path.display()
+        ));
+    }
+
+    let raw = manifest.get_num("compatibility_revision").ok_or_else(|| {
+        format!(
+            "invalid '{}': compatibility_revision must be an integer",
+            manifest_path.display()
+        )
+    })?;
+    if !raw.is_finite() || raw < 0.0 || raw.fract() != 0.0 || raw > u64::MAX as f64 {
+        return Err(format!(
+            "invalid '{}': compatibility_revision must be a nonnegative integer",
+            manifest_path.display()
+        ));
+    }
+
+    Ok(raw as u64)
+}
+
+fn validate_installed_std(std_root: &Path, imported_file: &Path) -> Result<(), WaveError> {
+    let installed = std_compatibility_revision(std_root);
+    if installed == Ok(STD_COMPATIBILITY_REVISION) {
+        return Ok(());
+    }
+
+    let installed_text = match installed {
+        Ok(revision) => revision.to_string(),
+        Err(error) => format!("unavailable ({})", error),
+    };
+    Err(WaveError::new(
+        WaveErrorKind::SyntaxError("incompatible standard library".to_string()),
+        format!(
+            "installed std compatibility revision {}, but this compiler requires {}",
+            installed_text, STD_COMPATIBILITY_REVISION
+        ),
+        imported_file.display().to_string(),
+        1,
+        1,
+    )
+    .with_code("E1002")
+    .with_context("standard library compatibility")
+    .with_help("run `wavec update std` and retry the build"))
 }
 
 fn std_root_dir(import_path: &str) -> Result<PathBuf, WaveError> {
@@ -837,4 +897,104 @@ fn parse_wave_file(
         ast,
         source: content,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_STD_CASE: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_std_root(name: &str) -> PathBuf {
+        let sequence = NEXT_STD_CASE.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "wave-parser-std-{}-{}-{}",
+            name,
+            std::process::id(),
+            sequence
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    #[test]
+    fn target_attributes_select_canonical_os_and_arch_aliases() {
+        let source = concat!(
+            "#[target(os=\"darwin\", arch=\"arm64\")]\n",
+            "pub fun selected() -> i32 { return 1; }\n",
+            "#[target(os=\"windows\", arch=\"x86_64\")]\n",
+            "pub fun rejected() -> i32 { return 0; }\n",
+        );
+        let target = TargetConditionContext {
+            arch: Some("aarch64".to_string()),
+            os: Some("macos".to_string()),
+            env: None,
+            abi: None,
+        };
+
+        let processed = preprocess_target_attrs(source, &target);
+        assert!(processed.contains("pub fun selected"));
+        assert!(!processed.contains("pub fun rejected"));
+        assert_eq!(processed.lines().count(), source.lines().count());
+    }
+
+    #[test]
+    fn duplicate_target_keys_are_not_silently_overwritten() {
+        let line = "#[target(os=\"linux\", os=\"freebsd\")]";
+        assert!(parse_target_attr(line).is_none());
+    }
+
+    #[test]
+    fn std_manifest_accepts_the_required_compatibility_revision() {
+        let root = temp_std_root("compatible");
+        std::fs::write(
+            root.join("manifest.json"),
+            format!(
+                "{{\"name\":\"std\",\"compatibility_revision\":{}}}",
+                STD_COMPATIBILITY_REVISION
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(
+            std_compatibility_revision(&root),
+            Ok(STD_COMPATIBILITY_REVISION)
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn incompatible_std_diagnostic_names_the_imported_file_and_update_command() {
+        let root = temp_std_root("incompatible");
+        let imported = root.join("fs/file.wave");
+        std::fs::create_dir_all(imported.parent().unwrap()).unwrap();
+        std::fs::write(
+            &imported,
+            "pub fun exists(path: str) -> bool { return false; }",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("manifest.json"),
+            "{\"name\":\"std\",\"compatibility_revision\":0}",
+        )
+        .unwrap();
+
+        let error = validate_installed_std(&root, &imported).unwrap_err();
+        assert_eq!(error.file, imported.display().to_string());
+        assert!(error.message.contains("revision 0"), "{}", error.message);
+        assert!(
+            error
+                .message
+                .contains(&format!("requires {}", STD_COMPATIBILITY_REVISION)),
+            "{}",
+            error.message
+        );
+        assert_eq!(
+            error.help.as_deref(),
+            Some("run `wavec update std` and retry the build")
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
 }

--- a/front/parser/src/lib.rs
+++ b/front/parser/src/lib.rs
@@ -47,6 +47,7 @@ pub mod format;
 pub mod generics;
 pub mod hir;
 pub mod import;
+pub mod os;
 pub mod parser;
 pub mod stdlib;
 pub mod verification;

--- a/front/parser/src/os/mod.rs
+++ b/front/parser/src/os/mod.rs
@@ -1,0 +1,70 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024–2026 Wave Foundation
+// Copyright (c) 2024–2026 LunaStev and contributors
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+
+//! Canonical operating-system names used by target attributes.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperatingSystem {
+    Linux,
+    MacOs,
+    Windows,
+    FreeBsd,
+    None,
+}
+
+impl OperatingSystem {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Linux => "linux",
+            Self::MacOs => "macos",
+            Self::Windows => "windows",
+            Self::FreeBsd => "freebsd",
+            Self::None => "none",
+        }
+    }
+
+    pub fn from_name(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "linux" => Some(Self::Linux),
+            "macos" | "darwin" | "apple" => Some(Self::MacOs),
+            "windows" | "win32" | "win64" => Some(Self::Windows),
+            "freebsd" => Some(Self::FreeBsd),
+            "none" | "freestanding" => Some(Self::None),
+            _ => None,
+        }
+    }
+}
+
+pub fn canonical_name(value: &str) -> String {
+    OperatingSystem::from_name(value)
+        .map(|os| os.name().to_string())
+        .unwrap_or_else(|| value.trim().to_ascii_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operating_system_aliases_have_stable_canonical_names() {
+        for (input, expected) in [
+            ("Linux", "linux"),
+            ("darwin", "macos"),
+            ("unknown-os", "unknown-os"),
+            ("win64", "windows"),
+            ("FreeBSD", "freebsd"),
+            ("freestanding", "none"),
+        ] {
+            assert_eq!(canonical_name(input), expected);
+        }
+    }
+}

--- a/front/parser/src/verification.rs
+++ b/front/parser/src/verification.rs
@@ -3260,6 +3260,10 @@ struct ProgramAnalysis {
     hir_variant_patterns: HashMap<usize, HirVariantPattern>,
 }
 
+fn is_supported_foreign_abi(abi: &str) -> bool {
+    abi.eq_ignore_ascii_case("c") || abi.eq_ignore_ascii_case("system")
+}
+
 fn analyze_program_types(nodes: &[ASTNode]) -> Result<ProgramAnalysis, SemanticDiagnostic> {
     let program = ProgramTypes::collect(nodes).map_err(|(index, message, primary)| {
         semantic_diagnostic_for_top_level(nodes, index, message, primary)
@@ -3272,10 +3276,10 @@ fn analyze_program_types(nodes: &[ASTNode]) -> Result<ProgramAnalysis, SemanticD
         let result = match node {
             ASTNode::Function(function) => {
                 if let Some(export) = &function.export {
-                    if !export.abi.eq_ignore_ascii_case("c") {
+                    if !is_supported_foreign_abi(&export.abi) {
                         validator.mark_span(SemanticSpanKind::Keyword, "export");
                         Err(format!(
-                            "unsupported export ABI '{}' for function '{}': only export(c) is currently supported",
+                            "unsupported export ABI '{}' for function '{}': supported ABIs are export(c) and export(system)",
                             export.abi, function.name
                         ))
                     } else {
@@ -3316,10 +3320,10 @@ fn analyze_program_types(nodes: &[ASTNode]) -> Result<ProgramAnalysis, SemanticD
                 result
             }
             ASTNode::ExternFunction(function) => {
-                if !function.abi.eq_ignore_ascii_case("c") {
+                if !is_supported_foreign_abi(&function.abi) {
                     validator.mark_span(SemanticSpanKind::Keyword, "extern");
                     Err(format!(
-                        "unsupported extern ABI '{}' for function '{}': only extern(c) is currently supported",
+                        "unsupported extern ABI '{}' for function '{}': supported ABIs are extern(c) and extern(system)",
                         function.abi, function.name
                     ))
                 } else {

--- a/llvm/src/backend.rs
+++ b/llvm/src/backend.rs
@@ -40,7 +40,7 @@ pub struct BackendOptions {
 fn is_windows_gnu_target(target: Option<&str>) -> bool {
     target
         .and_then(target_spec_for_triple)
-        .is_some_and(|spec| spec.codegen == CodegenTarget::WindowsX86_64Gnu)
+        .is_some_and(|spec| spec.os == "windows" && spec.env == "gnu")
 }
 
 fn normalize_llvm_opt_flag(opt_flag: &str) -> &str {
@@ -199,7 +199,13 @@ fn append_lld_target_args(cmd: &mut Command, target: &str, backend: &BackendOpti
     }
 
     if is_windows_gnu_target(Some(target)) {
-        cmd.arg("-m").arg("i386pep");
+        let spec = target_spec_for_triple(target)
+            .expect("Windows linker configuration requires a registered target");
+        cmd.arg("-m").arg(if spec.architecture.name() == "aarch64" {
+            "arm64pe"
+        } else {
+            "i386pep"
+        });
         return;
     }
 
@@ -236,7 +242,9 @@ fn is_darwin_target(target: &str) -> bool {
 
 fn elf_lld_emulation(target: &str) -> Option<&'static str> {
     match target_spec_for_triple(target)?.codegen {
-        CodegenTarget::LinuxX86_64 | CodegenTarget::FreestandingX86_64 => Some("elf_x86_64"),
+        CodegenTarget::LinuxX86_64
+        | CodegenTarget::FreeBsdX86_64
+        | CodegenTarget::FreestandingX86_64 => Some("elf_x86_64"),
         CodegenTarget::LinuxArm64 | CodegenTarget::FreestandingArm64 => Some("aarch64elf"),
         CodegenTarget::LinuxRISCV64 | CodegenTarget::FreestandingRISCV64 => Some("elf64lriscv"),
         _ => None,

--- a/llvm/src/codegen/abi_c.rs
+++ b/llvm/src/codegen/abi_c.rs
@@ -93,6 +93,7 @@ fn integer_extension_for_target(target: CodegenTarget, ty: &WaveType) -> Option<
     match target {
         CodegenTarget::LinuxX86_64
         | CodegenTarget::DarwinX86_64
+        | CodegenTarget::FreeBsdX86_64
         | CodegenTarget::FreestandingX86_64
         | CodegenTarget::DarwinArm64 => narrow_extension(),
         CodegenTarget::LinuxRISCV64 | CodegenTarget::FreestandingRISCV64 => match ty {
@@ -105,7 +106,8 @@ fn integer_extension_for_target(target: CodegenTarget, ty: &WaveType) -> Option<
         },
         CodegenTarget::LinuxArm64
         | CodegenTarget::FreestandingArm64
-        | CodegenTarget::WindowsX86_64Gnu => None,
+        | CodegenTarget::WindowsX86_64Gnu
+        | CodegenTarget::WindowsArm64Gnu => None,
     }
 }
 
@@ -692,10 +694,12 @@ fn classify_param<'ctx>(
     match target {
         CodegenTarget::LinuxX86_64
         | CodegenTarget::DarwinX86_64
+        | CodegenTarget::FreeBsdX86_64
         | CodegenTarget::FreestandingX86_64 => classify_param_x86_64_sysv(context, td, t),
         CodegenTarget::WindowsX86_64Gnu => classify_param_x86_64_windows(context, td, t),
         CodegenTarget::LinuxArm64
         | CodegenTarget::DarwinArm64
+        | CodegenTarget::WindowsArm64Gnu
         | CodegenTarget::FreestandingArm64 => classify_param_arm64(context, td, t),
         CodegenTarget::LinuxRISCV64 | CodegenTarget::FreestandingRISCV64 => {
             classify_param_riscv64(context, td, t)
@@ -712,10 +716,12 @@ fn classify_ret<'ctx>(
     match target {
         CodegenTarget::LinuxX86_64
         | CodegenTarget::DarwinX86_64
+        | CodegenTarget::FreeBsdX86_64
         | CodegenTarget::FreestandingX86_64 => classify_ret_x86_64_sysv(context, td, t),
         CodegenTarget::WindowsX86_64Gnu => classify_ret_x86_64_windows(context, td, t),
         CodegenTarget::LinuxArm64
         | CodegenTarget::DarwinArm64
+        | CodegenTarget::WindowsArm64Gnu
         | CodegenTarget::FreestandingArm64 => classify_ret_arm64(context, td, t),
         CodegenTarget::LinuxRISCV64 | CodegenTarget::FreestandingRISCV64 => {
             classify_ret_riscv64(context, td, t)

--- a/llvm/src/codegen/ir.rs
+++ b/llvm/src/codegen/ir.rs
@@ -319,8 +319,13 @@ fn is_implicit_i32_main(name: &str, return_type: &Option<WaveType>) -> bool {
     name == "main" && matches!(return_type, None | Some(WaveType::Void))
 }
 
-fn is_supported_extern_abi(abi: &str) -> bool {
+fn is_supported_extern_abi(abi: &str, target: CodegenTarget) -> bool {
     abi.eq_ignore_ascii_case("c")
+        || (abi.eq_ignore_ascii_case("system")
+            && matches!(
+                target,
+                CodegenTarget::WindowsX86_64Gnu | CodegenTarget::WindowsArm64Gnu
+            ))
 }
 
 fn normalize_opt_flag_for_passes(opt_flag: &str) -> &str {
@@ -803,10 +808,10 @@ fn build_module(
     } in function_nodes.iter().copied()
     {
         if let Some(export) = export {
-            if !is_supported_extern_abi(&export.abi) {
+            if !is_supported_extern_abi(&export.abi, abi_target) {
                 panic!(
-                    "unsupported export ABI '{}' for function '{}': only export(c) is currently supported",
-                    export.abi, name
+                    "unsupported export ABI '{}' for function '{}' on {}: supported ABIs are 'c' and Windows 'system'",
+                    export.abi, name, abi_target.desc()
                 );
             }
         }
@@ -898,10 +903,10 @@ fn build_module(
     }
 
     for ext in &extern_functions {
-        if !is_supported_extern_abi(&ext.abi) {
+        if !is_supported_extern_abi(&ext.abi, abi_target) {
             panic!(
-                "unsupported extern ABI '{}' for function '{}': only extern(c) is currently supported",
-                ext.abi, ext.name
+                "unsupported extern ABI '{}' for function '{}' on {}: supported ABIs are 'c' and Windows 'system'",
+                ext.abi, ext.name, abi_target.desc()
             );
         }
 

--- a/llvm/src/codegen/target.rs
+++ b/llvm/src/codegen/target.rs
@@ -31,6 +31,8 @@ pub enum CodegenTarget {
     DarwinX86_64,
     DarwinArm64,
     WindowsX86_64Gnu,
+    WindowsArm64Gnu,
+    FreeBsdX86_64,
     FreestandingX86_64,
     FreestandingArm64,
     FreestandingRISCV64,
@@ -324,6 +326,24 @@ const WINDOWS_PC_X86_64_GNU: TargetSpec = TargetSpec {
 };
 
 #[cfg(any(feature = "llvm-target-all", feature = "llvm-target-x86"))]
+const FREEBSD_X86_64: TargetSpec = TargetSpec {
+    triple: "x86_64-unknown-freebsd",
+    codegen: CodegenTarget::FreeBsdX86_64,
+    architecture: Architecture::X86_64,
+    vendor: "unknown",
+    os: "freebsd",
+    env: "",
+    object_format: "elf",
+    hosted: true,
+    cpus: arch::x86_64::CPUS,
+    features: arch::x86_64::FEATURES,
+    abis: &[],
+    default_cpu: arch::x86_64::DEFAULT_CPU,
+    default_features: arch::x86_64::DEFAULT_FEATURES,
+    default_abi: None,
+};
+
+#[cfg(any(feature = "llvm-target-all", feature = "llvm-target-x86"))]
 const FREESTANDING_X86_64: TargetSpec = TargetSpec {
     triple: "x86_64-unknown-none-elf",
     codegen: CodegenTarget::FreestandingX86_64,
@@ -370,6 +390,24 @@ const DARWIN_AARCH64: TargetSpec = TargetSpec {
     object_format: "macho",
     hosted: true,
     cpus: arch::aarch64::DARWIN_CPUS,
+    features: arch::aarch64::FEATURES,
+    abis: &[],
+    default_cpu: arch::aarch64::DEFAULT_CPU,
+    default_features: arch::aarch64::DEFAULT_FEATURES,
+    default_abi: None,
+};
+
+#[cfg(any(feature = "llvm-target-all", feature = "llvm-target-aarch64"))]
+const WINDOWS_AARCH64_GNU: TargetSpec = TargetSpec {
+    triple: "aarch64-w64-windows-gnu",
+    codegen: CodegenTarget::WindowsArm64Gnu,
+    architecture: Architecture::Aarch64,
+    vendor: "w64",
+    os: "windows",
+    env: "gnu",
+    object_format: "coff",
+    hosted: true,
+    cpus: arch::aarch64::CPUS,
     features: arch::aarch64::FEATURES,
     abis: &[],
     default_cpu: arch::aarch64::DEFAULT_CPU,
@@ -441,11 +479,17 @@ pub fn supported_target_specs() -> Vec<&'static TargetSpec> {
         &DARWIN_X86_64,
         &WINDOWS_W64_X86_64_GNU,
         &WINDOWS_PC_X86_64_GNU,
+        &FREEBSD_X86_64,
         &FREESTANDING_X86_64,
     ]);
 
     #[cfg(any(feature = "llvm-target-all", feature = "llvm-target-aarch64"))]
-    specs.extend([&LINUX_AARCH64, &DARWIN_AARCH64, &FREESTANDING_AARCH64]);
+    specs.extend([
+        &LINUX_AARCH64,
+        &DARWIN_AARCH64,
+        &WINDOWS_AARCH64_GNU,
+        &FREESTANDING_AARCH64,
+    ]);
 
     #[cfg(any(feature = "llvm-target-all", feature = "llvm-target-riscv"))]
     specs.extend([&LINUX_RISCV64, &FREESTANDING_RISCV64]);
@@ -467,8 +511,12 @@ impl CodegenTarget {
             Self::LinuxX86_64
             | Self::DarwinX86_64
             | Self::WindowsX86_64Gnu
+            | Self::FreeBsdX86_64
             | Self::FreestandingX86_64 => Architecture::X86_64,
-            Self::LinuxArm64 | Self::DarwinArm64 | Self::FreestandingArm64 => Architecture::Aarch64,
+            Self::LinuxArm64
+            | Self::DarwinArm64
+            | Self::WindowsArm64Gnu
+            | Self::FreestandingArm64 => Architecture::Aarch64,
             Self::LinuxRISCV64 | Self::FreestandingRISCV64 => Architecture::Riscv64,
         }
     }
@@ -494,6 +542,8 @@ impl CodegenTarget {
             Self::DarwinX86_64 => "darwin x86_64",
             Self::DarwinArm64 => "darwin arm64",
             Self::WindowsX86_64Gnu => "windows x86_64 gnu",
+            Self::WindowsArm64Gnu => "windows arm64 gnu",
+            Self::FreeBsdX86_64 => "freebsd x86_64",
             Self::FreestandingX86_64 => "freestanding x86_64",
             Self::FreestandingArm64 => "freestanding arm64",
             Self::LinuxRISCV64 => "linux riscv64",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2212,12 +2212,24 @@ fn link_objects(
 ) -> Result<(), CliError> {
     ensure_parent_dir(output)?;
 
+    let target = target_triple_for_global(global);
+    if global.llvm.linker.is_none()
+        && matches!(
+            target_spec_for_triple(&target).map(|spec| spec.codegen),
+            Some(CodegenTarget::WindowsArm64Gnu)
+        )
+    {
+        return Err(CliError::CommandFailed(
+            "Windows arm64 object generation is supported, but native linking requires an arm64 MinGW runtime and an explicit `-C linker=<path>`"
+                .to_string(),
+        ));
+    }
+
     if global.llvm.linker.is_none() {
         validate_default_elf_runtime(global, build)?;
     }
 
     let (bin, args) = build_linker_args(global, build, objects, output);
-    let target = target_triple_for_global(global);
     if matches!(
         target_spec_for_triple(&target).map(|spec| spec.codegen),
         Some(CodegenTarget::LinuxRISCV64 | CodegenTarget::FreestandingRISCV64)
@@ -2256,19 +2268,28 @@ fn link_objects(
 
 fn validate_default_elf_runtime(global: &Global, build: &BuildRequest) -> Result<(), CliError> {
     let target = target_triple_for_global(global);
-    if !is_linux_target(&target) || target == host_target_triple() || global.llvm.no_default_libs {
+    if !is_hosted_elf_target(&target)
+        || target == host_target_triple()
+        || global.llvm.no_default_libs
+    {
         return Ok(());
     }
 
     let mut missing = Vec::new();
     if !build.shared && !build.no_start_files {
         let start_name = elf_start_file_name(build);
-        let has_bundled_crt = [start_name, "crti.o", "crtn.o"].into_iter().all(|name| {
-            llvm::toolchain::find_bundled_linux_crt(&target, global.llvm.abi.as_deref(), name)
-                .is_some()
-        });
-        if !has_bundled_crt {
-            missing.push(format!("Wave CRT ({}, crti.o, crtn.o)", start_name));
+        let has_crt = if is_linux_target(&target) {
+            [start_name, "crti.o", "crtn.o"].into_iter().all(|name| {
+                llvm::toolchain::find_bundled_linux_crt(&target, global.llvm.abi.as_deref(), name)
+                    .is_some()
+            })
+        } else {
+            [start_name, "crti.o", "crtn.o"]
+                .into_iter()
+                .all(|name| find_elf_runtime_file(&target, global, name).is_some())
+        };
+        if !has_crt {
+            missing.push(format!("target CRT ({}, crti.o, crtn.o)", start_name));
         }
     }
     let libc_names: &[&str] = if build.static_link {
@@ -2320,7 +2341,7 @@ fn build_linker_args(
     if is_darwin_target(&target) {
         build_darwin_lld_args(global, build, objects, output, &target)
     } else if is_windows_gnu_target(&target) {
-        build_windows_gnu_linker_args(global, build, objects, output)
+        build_windows_gnu_linker_args(global, build, objects, output, &target)
     } else {
         build_elf_lld_args(global, build, objects, output, &target)
     }
@@ -2403,12 +2424,20 @@ fn build_windows_gnu_linker_args(
     build: &BuildRequest,
     objects: &[String],
     output: &Path,
+    target: &str,
 ) -> (String, Vec<String>) {
     let Some(linker) = resolve_bundled_tool_path("ld.lld") else {
         return build_user_linker_args("gcc", global, build, objects, output);
     };
 
-    let mut args = vec!["-m".to_string(), "i386pep".to_string()];
+    let emulation = if target_spec_for_triple(target)
+        .is_some_and(|spec| spec.architecture.name() == "aarch64")
+    {
+        "arm64pe"
+    } else {
+        "i386pep"
+    };
+    let mut args = vec!["-m".to_string(), emulation.to_string()];
 
     if !global.llvm.no_default_libs && !build.no_start_files {
         args.push(
@@ -2439,6 +2468,7 @@ fn build_windows_gnu_linker_args(
                 "-luser32",
                 "-ladvapi32",
                 "-lshell32",
+                "-lws2_32",
             ]
             .into_iter()
             .map(String::from),
@@ -2468,9 +2498,9 @@ fn build_elf_lld_args(
         args.push(format!("--sysroot={}", sysroot));
     }
     let mut uses_elf_end_files = false;
-    if !global.llvm.no_default_libs && is_linux_target(target) && !build.shared {
+    if !global.llvm.no_default_libs && is_hosted_elf_target(target) && !build.shared {
         if !build.static_link {
-            if let Some(dynamic_linker) = linux_dynamic_linker(target, global.llvm.abi.as_deref()) {
+            if let Some(dynamic_linker) = elf_dynamic_linker(target, global.llvm.abi.as_deref()) {
                 args.push(format!("--dynamic-linker={}", dynamic_linker));
             }
         }
@@ -2480,14 +2510,14 @@ fn build_elf_lld_args(
     for obj in objects {
         args.push(obj.clone());
     }
-    if !global.llvm.no_default_libs && is_linux_target(target) {
+    if !global.llvm.no_default_libs && is_hosted_elf_target(target) {
         append_elf_search_paths(&mut args, target, global);
     }
     append_link_search_and_libs(&mut args, global);
     append_lld_link_args(&mut args, &global.llvm.link_args);
     append_common_link_mode_args(&mut args, build, LinkerDialect::Gnu);
 
-    if !global.llvm.no_default_libs && is_linux_target(target) {
+    if !global.llvm.no_default_libs && is_hosted_elf_target(target) {
         append_elf_default_libs(&mut args, target, global);
         if uses_elf_end_files {
             append_elf_end_files(&mut args, target, global);
@@ -2647,6 +2677,14 @@ fn is_linux_target(target: &str) -> bool {
     target_spec_for_triple(target).is_some_and(|spec| spec.os == "linux")
 }
 
+fn is_freebsd_target(target: &str) -> bool {
+    target_spec_for_triple(target).is_some_and(|spec| spec.os == "freebsd")
+}
+
+fn is_hosted_elf_target(target: &str) -> bool {
+    is_linux_target(target) || is_freebsd_target(target)
+}
+
 fn darwin_arch(target: &str) -> &'static str {
     match target_spec_for_triple(target).map(|spec| spec.codegen) {
         Some(CodegenTarget::DarwinArm64) => "arm64",
@@ -2657,14 +2695,16 @@ fn darwin_arch(target: &str) -> &'static str {
 
 fn elf_lld_emulation(target: &str) -> Option<&'static str> {
     match target_spec_for_triple(target)?.codegen {
-        CodegenTarget::LinuxX86_64 | CodegenTarget::FreestandingX86_64 => Some("elf_x86_64"),
+        CodegenTarget::LinuxX86_64
+        | CodegenTarget::FreeBsdX86_64
+        | CodegenTarget::FreestandingX86_64 => Some("elf_x86_64"),
         CodegenTarget::LinuxArm64 | CodegenTarget::FreestandingArm64 => Some("aarch64elf"),
         CodegenTarget::LinuxRISCV64 | CodegenTarget::FreestandingRISCV64 => Some("elf64lriscv"),
         _ => None,
     }
 }
 
-fn linux_dynamic_linker(target: &str, abi: Option<&str>) -> Option<&'static str> {
+fn elf_dynamic_linker(target: &str, abi: Option<&str>) -> Option<&'static str> {
     match target_spec_for_triple(target)?.codegen {
         CodegenTarget::LinuxX86_64 => Some("/lib64/ld-linux-x86-64.so.2"),
         CodegenTarget::LinuxArm64 => Some("/lib/ld-linux-aarch64.so.1"),
@@ -2674,6 +2714,7 @@ fn linux_dynamic_linker(target: &str, abi: Option<&str>) -> Option<&'static str>
             Some("lp64d") | None => Some("/lib/ld-linux-riscv64-lp64d.so.1"),
             Some(_) => None,
         },
+        CodegenTarget::FreeBsdX86_64 => Some("/libexec/ld-elf.so.1"),
         _ => None,
     }
 }
@@ -2699,6 +2740,17 @@ fn append_elf_start_files(
 
     let start_name = elf_start_file_name(build);
 
+    if is_freebsd_target(target) {
+        args.push(
+            find_elf_runtime_file(target, global, start_name)
+                .unwrap_or_else(|| start_name.to_string()),
+        );
+        args.push(
+            find_elf_runtime_file(target, global, "crti.o").unwrap_or_else(|| "crti.o".to_string()),
+        );
+        return true;
+    }
+
     append_bundled_linux_crt(
         args,
         bundled_linux_crt_path(target, global.llvm.abi.as_deref(), start_name),
@@ -2720,6 +2772,12 @@ fn elf_start_file_name(build: &BuildRequest) -> &'static str {
 }
 
 fn append_elf_end_files(args: &mut Vec<String>, target: &str, global: &Global) {
+    if is_freebsd_target(target) {
+        args.push(
+            find_elf_runtime_file(target, global, "crtn.o").unwrap_or_else(|| "crtn.o".to_string()),
+        );
+        return;
+    }
     args.push(
         bundled_linux_crt_path(target, global.llvm.abi.as_deref(), "crtn.o")
             .to_string_lossy()
@@ -4100,7 +4158,7 @@ fn riscv64_linux_sysroot_is_complete(target: &str, abi: Option<&str>, root: &Pat
         return false;
     }
 
-    let Some(loader_name) = linux_dynamic_linker(target, abi)
+    let Some(loader_name) = elf_dynamic_linker(target, abi)
         .and_then(|path| Path::new(path).file_name())
         .and_then(|name| name.to_str())
     else {

--- a/src/std.rs
+++ b/src/std.rs
@@ -36,10 +36,8 @@ pub fn std_update() -> Result<(), CliError> {
 fn install_or_update_std(is_update: bool) -> Result<(), CliError> {
     let install_dir = resolve_std_install_dir()?;
 
-    if install_dir.exists() {
-        if !is_update {
-            return Err(CliError::StdAlreadyInstalled { path: install_dir });
-        }
+    if install_dir.exists() && !is_update {
+        return Err(CliError::StdAlreadyInstalled { path: install_dir });
     }
 
     let install_parent = install_dir.parent().ok_or_else(|| {

--- a/src/std.rs
+++ b/src/std.rs
@@ -22,6 +22,9 @@ use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{env, fs};
 
+const STD_REPOSITORY: &str = "https://github.com/wavefnd/Wave.git";
+const STD_REFERENCE: &str = "master";
+
 pub fn std_install() -> Result<(), CliError> {
     install_or_update_std(false)
 }
@@ -37,11 +40,45 @@ fn install_or_update_std(is_update: bool) -> Result<(), CliError> {
         if !is_update {
             return Err(CliError::StdAlreadyInstalled { path: install_dir });
         }
-        fs::remove_dir_all(&install_dir)?;
     }
 
-    fs::create_dir_all(&install_dir)?;
-    install_std_from_wave_repo_sparse(&install_dir)?;
+    let install_parent = install_dir.parent().ok_or_else(|| {
+        CliError::CommandFailed(format!(
+            "std installation path '{}' has no parent",
+            install_dir.display()
+        ))
+    })?;
+    fs::create_dir_all(install_parent)?;
+
+    // Keep staging beside the final directory so the final rename stays on one
+    // filesystem. The installed tree is untouched until every check passes.
+    let checkout = make_tmp_dir("wave-std-checkout")?;
+    let stage_home = make_tmp_dir_in(install_parent, ".std-stage")?;
+    let stage_std = stage_home.join(".wave/lib/wave/std");
+
+    let result = (|| {
+        let (src_std, source_revision) = fetch_std_from_wave_repo_sparse(&checkout)?;
+        validate_std_manifest(&src_std)?;
+
+        copy_dir_all(&src_std, &stage_std)?;
+        fs::write(
+            stage_std.join("INSTALL_META"),
+            format!(
+                "repo={}\nref={}\nrevision={}\ncompatibility_revision={}\n",
+                STD_REPOSITORY,
+                STD_REFERENCE,
+                source_revision,
+                parser::import::STD_COMPATIBILITY_REVISION
+            ),
+        )?;
+
+        validate_staged_std(&stage_home, &stage_std)?;
+        replace_std_tree(&stage_std, &install_dir)
+    })();
+
+    let _ = fs::remove_dir_all(&checkout);
+    let _ = fs::remove_dir_all(&stage_home);
+    result?;
 
     if is_update {
         println!("✅ std updated: {}", install_dir.display());
@@ -52,15 +89,10 @@ fn install_or_update_std(is_update: bool) -> Result<(), CliError> {
     Ok(())
 }
 
-fn install_std_from_wave_repo_sparse(stage_dir: &Path) -> Result<(), CliError> {
+fn fetch_std_from_wave_repo_sparse(checkout: &Path) -> Result<(PathBuf, String), CliError> {
     if !tool_exists("git") {
         return Err(CliError::ExternalToolMissing("git".to_string()));
     }
-
-    let repo = "https://github.com/wavefnd/Wave.git";
-    let reference = "master";
-
-    let tmp = make_tmp_dir("wave-std")?;
 
     run_cmd(
         Command::new("git")
@@ -70,49 +102,123 @@ fn install_std_from_wave_repo_sparse(stage_dir: &Path) -> Result<(), CliError> {
             .arg("--filter=blob:none")
             .arg("--sparse")
             .arg("--branch")
-            .arg(reference)
-            .arg(repo)
-            .arg(&tmp),
+            .arg(STD_REFERENCE)
+            .arg(STD_REPOSITORY)
+            .arg(checkout),
         "git clone",
     )?;
 
     run_cmd(
         Command::new("git")
             .arg("-C")
-            .arg(&tmp)
+            .arg(checkout)
             .arg("sparse-checkout")
             .arg("set")
             .arg("std"),
         "git sparse-checkout set std",
     )?;
 
-    let src_std = tmp.join("std");
-
-    let manifest_path = src_std.join("manifest.json");
-    if !manifest_path.exists() {
-        return Err(CliError::CommandFailed(
-            "manifest.json not found in repo/std (add std/manifest.json)".to_string(),
-        ));
-    }
-
-    let text = fs::read_to_string(&manifest_path)?;
-    let manifest = utils::json::parse(&text)
-        .map_err(|e| CliError::CommandFailed(format!("invalid manifest.json: {}", e)))?;
-
-    if manifest.get_str("name") != Some("std") {
-        return Err(CliError::CommandFailed(
-            "manifest.json name != 'std'".to_string(),
-        ));
-    }
-
-    copy_dir_all(&src_std, stage_dir)?;
-
-    fs::write(
-        stage_dir.join("INSTALL_META"),
-        format!("repo={}\nref={}\n", repo, reference),
+    let source_revision = run_cmd_stdout(
+        Command::new("git")
+            .arg("-C")
+            .arg(checkout)
+            .arg("rev-parse")
+            .arg("HEAD"),
+        "git rev-parse HEAD",
     )?;
 
-    let _ = fs::remove_dir_all(&tmp);
+    Ok((checkout.join("std"), source_revision))
+}
+
+fn validate_std_manifest(std_root: &Path) -> Result<(), CliError> {
+    let revision =
+        parser::import::std_compatibility_revision(std_root).map_err(CliError::CommandFailed)?;
+    let required = parser::import::STD_COMPATIBILITY_REVISION;
+    if revision != required {
+        return Err(CliError::CommandFailed(format!(
+            "downloaded std compatibility revision {}, but this compiler requires {}",
+            revision, required
+        )));
+    }
+    Ok(())
+}
+
+fn validate_staged_std(stage_home: &Path, stage_std: &Path) -> Result<(), CliError> {
+    validate_std_manifest(stage_std)?;
+
+    let mut sources = Vec::new();
+    collect_wave_sources(stage_std, &mut sources)?;
+    sources.sort();
+    if sources.is_empty() {
+        return Err(CliError::CommandFailed(
+            "downloaded std contains no Wave source files".to_string(),
+        ));
+    }
+
+    let compiler = env::current_exe()?;
+    for source in sources {
+        let output = Command::new(&compiler)
+            .env("HOME", stage_home)
+            .arg("check")
+            .arg(&source)
+            .output()?;
+        if !output.status.success() {
+            return Err(CliError::CommandFailed(format!(
+                "staged std validation failed for '{}'\nstdout: {}\nstderr: {}",
+                source.display(),
+                String::from_utf8_lossy(&output.stdout).trim(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn collect_wave_sources(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), CliError> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            collect_wave_sources(&path, out)?;
+        } else if ty.is_file() && path.extension().is_some_and(|ext| ext == "wave") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn replace_std_tree(staged: &Path, install_dir: &Path) -> Result<(), CliError> {
+    if !install_dir.exists() {
+        fs::rename(staged, install_dir)?;
+        return Ok(());
+    }
+
+    let parent = install_dir.parent().ok_or_else(|| {
+        CliError::CommandFailed(format!(
+            "std installation path '{}' has no parent",
+            install_dir.display()
+        ))
+    })?;
+    let backup = unique_path_in(parent, ".std-backup");
+    fs::rename(install_dir, &backup)?;
+
+    if let Err(install_error) = fs::rename(staged, install_dir) {
+        return match fs::rename(&backup, install_dir) {
+            Ok(()) => Err(CliError::CommandFailed(format!(
+                "failed to activate staged std; previous installation was restored: {}",
+                install_error
+            ))),
+            Err(restore_error) => Err(CliError::CommandFailed(format!(
+                "failed to activate staged std ({}) and failed to restore '{}' ({})",
+                install_error,
+                backup.display(),
+                restore_error
+            ))),
+        };
+    }
+
+    let _ = fs::remove_dir_all(backup);
     Ok(())
 }
 
@@ -159,12 +265,87 @@ fn run_cmd(cmd: &mut Command, label: &str) -> Result<(), CliError> {
     }
 }
 
+fn run_cmd_stdout(cmd: &mut Command, label: &str) -> Result<String, CliError> {
+    let out = cmd.output()?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        return Err(CliError::CommandFailed(format!(
+            "{} (status={})\nstdout: {}\nstderr: {}",
+            label, out.status, stdout, stderr
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if stdout.is_empty() {
+        return Err(CliError::CommandFailed(format!(
+            "{} returned empty output",
+            label
+        )));
+    }
+    Ok(stdout)
+}
+
 fn make_tmp_dir(prefix: &str) -> Result<PathBuf, CliError> {
-    let t = SystemTime::now()
+    make_tmp_dir_in(&env::temp_dir(), prefix)
+}
+
+fn unique_path_in(parent: &Path, prefix: &str) -> PathBuf {
+    let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_nanos();
-    let p = env::temp_dir().join(format!("{}-{}", prefix, t));
-    fs::create_dir_all(&p)?;
-    Ok(p)
+    parent.join(format!("{}-{}-{}", prefix, std::process::id(), timestamp))
+}
+
+fn make_tmp_dir_in(parent: &Path, prefix: &str) -> Result<PathBuf, CliError> {
+    let path = unique_path_in(parent, prefix);
+    fs::create_dir_all(&path)?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn successful_replacement_exposes_only_the_staged_tree() {
+        let root = make_tmp_dir("wave-std-replace-success").unwrap();
+        let installed = root.join("std");
+        let staged = root.join("staged");
+        fs::create_dir_all(&installed).unwrap();
+        fs::create_dir_all(&staged).unwrap();
+        fs::write(installed.join("old.wave"), "old").unwrap();
+        fs::write(staged.join("new.wave"), "new").unwrap();
+
+        replace_std_tree(&staged, &installed).unwrap();
+
+        assert!(!installed.join("old.wave").exists());
+        assert_eq!(
+            fs::read_to_string(installed.join("new.wave")).unwrap(),
+            "new"
+        );
+        assert!(!staged.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn failed_activation_restores_the_previous_installation() {
+        let root = make_tmp_dir("wave-std-replace-rollback").unwrap();
+        let installed = root.join("std");
+        let missing_stage = root.join("missing-stage");
+        fs::create_dir_all(&installed).unwrap();
+        fs::write(installed.join("old.wave"), "old").unwrap();
+
+        let error = replace_std_tree(&missing_stage, &installed).unwrap_err();
+
+        assert!(error
+            .message()
+            .contains("previous installation was restored"));
+        assert_eq!(
+            fs::read_to_string(installed.join("old.wave")).unwrap(),
+            "old"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
 }

--- a/std/buffer/write.wave
+++ b/std/buffer/write.wave
@@ -77,17 +77,12 @@ pub fun buffer_append(buf: ptr<Buffer>, src: ptr<u8>, size: i64) -> i64 {
 }
 
 pub fun buffer_append_str(buf: ptr<Buffer>, s: str) -> i64 {
-    var i: i64 = 0;
-
-    while (s[i] != 0) {
-        var ret: i64 = buffer_push(buf, s[i]);
-        if (ret < 0) {
-            return ret;
-        }
-        i += 1;
+    var size: i64 = 0;
+    while (s[size] != 0) {
+        size += 1;
     }
 
-    return 0;
+    return buffer_append(buf, s as ptr<u8>, size);
 }
 
 pub fun buffer_set(buf: ptr<Buffer>, index: i64, value: u8) -> bool {
@@ -109,7 +104,8 @@ pub fun tbuffer_push<T>(buf: ptr<TypedBuffer<T>>, value: T) -> i64 {
     }
 
     var offset_bytes: i64 = deref buf.len * deref buf.elem_size;
-    var slot: ptr<T> = (deref buf.data + offset_bytes) as ptr<T>;
+    var data: ptr<u8> = deref buf.data;
+    var slot: ptr<T> = (data + offset_bytes) as ptr<T>;
 
     deref slot = value;
     deref buf.len = needed_len;
@@ -123,7 +119,8 @@ pub fun tbuffer_set<T>(buf: ptr<TypedBuffer<T>>, index: i64, value: T) -> bool {
     }
 
     var offset_bytes: i64 = index * deref buf.elem_size;
-    var slot: ptr<T> = (deref buf.data + offset_bytes) as ptr<T>;
+    var data: ptr<u8> = deref buf.data;
+    var slot: ptr<T> = (data + offset_bytes) as ptr<T>;
     deref slot = value;
 
     return true;

--- a/std/fs/file.wave
+++ b/std/fs/file.wave
@@ -16,6 +16,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Path-oriented filesystem helpers built on std::io and std::sys. Functions
+// that accept buffers never allocate or take ownership of caller storage.
+
 import("std::io::consts")::{
     IO_STDIN_FD,
     IO_STDOUT_FD,
@@ -37,6 +40,16 @@ import("std::io::fd")::{
     io_pipe,
     io_dup,
     io_dup2,
+};
+import("std::buffer::types")::{
+    Buffer,
+};
+import("std::buffer::alloc")::{
+    buffer_reserve,
+};
+import("std::fs::consts")::{
+    FS_MODE_FILE_DEFAULT,
+    FS_MODE_DIR_DEFAULT,
 };
 import("std::sys::fs")::{
     FS_O_RDONLY,
@@ -64,7 +77,6 @@ import("std::sys::fs")::{
     fsync,
     fcntl,
     read,
-    write,
     getcwd,
     chdir,
     access,
@@ -72,11 +84,31 @@ import("std::sys::fs")::{
     unlink,
     mkdir,
     rmdir,
+    rename_path,
     Stat,
     stat,
     fstat,
 };
 
+// Portable metadata returned by metadata(). Native mode bits and Stat layouts
+// stay inside std::sys::fs instead of becoming part of this API.
+pub struct Metadata {
+    size: i64;
+    modified_seconds: i64;
+    is_file: bool;
+    is_directory: bool;
+}
+
+const FS_MODE_TYPE_MASK: i32 = 61440;
+const FS_MODE_REGULAR: i32 = 32768;
+const FS_MODE_DIRECTORY: i32 = 16384;
+
+// Compatibility API: existing fs_* calls keep their signatures and integer
+// errors. New code should prefer the portable path API at the end of this file.
+// A future Result API can wrap these integer results without removing them.
+
+// Returns false for any failed access check, including a missing path.
+// Example: if (fs_exists("notes.txt")) { println("found"); }
 pub fun fs_exists(path: str) -> bool {
     if (access(path, FS_F_OK) == 0) {
         return true;
@@ -85,10 +117,12 @@ pub fun fs_exists(path: str) -> bool {
     return false;
 }
 
+// Opens a path and preserves the raw descriptor-or-negative-error convention.
 pub fun fs_open(path: str, flags: i32, mode: i32) -> i64 {
     return open(path, flags, mode);
 }
 
+// Example: var fd: i64 = fs_open_read("notes.txt");
 pub fun fs_open_read(path: str) -> i64 {
     return fs_open(path, FS_O_RDONLY, 0);
 }
@@ -109,6 +143,7 @@ pub fun fs_close(fd: i64) -> i64 {
     return io_close(fd);
 }
 
+// Returns the size of a path without leaving its temporary descriptor open.
 pub fun fs_file_size(path: str) -> i64 {
     var fd: i64 = fs_open_read(path);
     if (fd < 0) {
@@ -129,6 +164,7 @@ pub fun fs_file_size(path: str) -> i64 {
     return sz;
 }
 
+// Returns the size of an open descriptor and restores its original position.
 pub fun fs_file_size_fd(fd: i64) -> i64 {
     var cur: i64 = lseek(fd, 0, FS_SEEK_CUR);
     if (cur < 0) {
@@ -161,6 +197,13 @@ pub fun fs_rmdir(path: str) -> i64 {
     return rmdir(path);
 }
 
+pub fun fs_rename(old_path: str, new_path: str) -> i64 {
+    return rename_path(old_path, new_path);
+}
+
+// Reads the complete file into caller-owned storage. IO_ERR_NO_SPACE means the
+// file is larger than dst_cap; this function does not allocate or return str.
+// Example: var n: i64 = fs_read_all("notes.txt", &buf[0], 256);
 pub fun fs_read_all(path: str, dst: ptr<u8>, dst_cap: i64) -> i64 {
     if (dst_cap < 0) {
         return IO_ERR_INVALID;
@@ -196,6 +239,8 @@ pub fun fs_read_all(path: str, dst: ptr<u8>, dst_cap: i64) -> i64 {
     return n;
 }
 
+// Replaces a file with len bytes from caller-owned storage.
+// Example: fs_write_all("notes.txt", text as ptr<u8>, 4, FS_MODE_FILE_DEFAULT);
 pub fun fs_write_all(path: str, src: ptr<u8>, len: i64, mode: i32) -> i64 {
     if (len < 0) {
         return IO_ERR_INVALID;
@@ -220,6 +265,7 @@ pub fun fs_write_all(path: str, src: ptr<u8>, len: i64, mode: i32) -> i64 {
     return n;
 }
 
+// Appends len bytes from caller-owned storage, creating the file if needed.
 pub fun fs_append_all(path: str, src: ptr<u8>, len: i64, mode: i32) -> i64 {
     if (len < 0) {
         return IO_ERR_INVALID;
@@ -244,6 +290,8 @@ pub fun fs_append_all(path: str, src: ptr<u8>, len: i64, mode: i32) -> i64 {
     return n;
 }
 
+// Copies a path using caller-owned scratch storage and returns bytes copied.
+// Example: fs_copy("from.txt", "to.txt", &scratch[0], 4096, FS_MODE_FILE_DEFAULT);
 pub fun fs_copy(
     src_path: str,
     dst_path: str,
@@ -284,4 +332,184 @@ pub fun fs_copy(
     }
 
     return copied;
+}
+
+// Portable path API. It hides target flags and default permission bits. Every
+// function below consumes paths except the caller-owned buffers passed to
+// read_into, read_to_end, write, and append.
+
+// Tests whether path is accessible. Errors, including a missing path, are false.
+// Example: if (exists("notes.txt")) { println("found"); }
+pub fun exists(path: str) -> bool {
+    return fs_exists(path);
+}
+
+// Opens path for reading and returns an owned descriptor or a negative error.
+// Close the returned descriptor with std::io::fd::io_close.
+pub fun open_read(path: str) -> i64 {
+    return fs_open_read(path);
+}
+
+// Creates or truncates path with portable default permissions. The returned
+// descriptor is caller-owned and must be closed with std::io::fd::io_close.
+pub fun create(path: str) -> i64 {
+    return fs_open_write(path, FS_MODE_FILE_DEFAULT);
+}
+
+// Opens or creates path for appending and returns a caller-owned descriptor.
+pub fun open_append(path: str) -> i64 {
+    return fs_open_append(path, FS_MODE_FILE_DEFAULT);
+}
+
+// Opens or creates path for reading and writing with default permissions.
+pub fun open_read_write(path: str) -> i64 {
+    return fs_open_rw(path, FS_MODE_FILE_DEFAULT);
+}
+
+// Reads portable metadata for path into caller-owned info storage.
+// Example: var result: i64 = metadata("notes.txt", &info);
+pub fun metadata(path: str, info: ptr<Metadata>) -> i64 {
+    if (info == null) {
+        return IO_ERR_INVALID;
+    }
+
+    var native: Stat;
+    var result: i64 = stat(path, &native);
+    if (result < 0) {
+        return result;
+    }
+
+    var kind: i32 = (native.mode as i32) & FS_MODE_TYPE_MASK;
+    deref info.size = native.size;
+    deref info.modified_seconds = native.mtime;
+    deref info.is_file = kind == FS_MODE_REGULAR;
+    deref info.is_directory = kind == FS_MODE_DIRECTORY;
+    return 0;
+}
+
+// Returns the size of path, or a negative integer error.
+pub fun size(path: str) -> i64 {
+    var info: Metadata;
+    var result: i64 = metadata(path, &info);
+    if (result < 0) {
+        return result;
+    }
+    return info.size;
+}
+
+// Reads the complete path into fixed caller-owned storage. It does not allocate;
+// IO_ERR_NO_SPACE means dst_cap cannot hold the entire file.
+// Example: var n: i64 = read_into("notes.txt", &buf[0], 256);
+pub fun read_into(path: str, dst: ptr<u8>, dst_cap: i64) -> i64 {
+    return fs_read_all(path, dst, dst_cap);
+}
+
+// Appends the complete path to a caller-owned Buffer, growing its allocation.
+// The caller remains responsible for buffer_free; failures restore its old len.
+// Example: var n: i64 = read_to_end("notes.txt", &buf);
+pub fun read_to_end(path: str, dst_buffer: ptr<Buffer>) -> i64 {
+    if (dst_buffer == null) {
+        return IO_ERR_INVALID;
+    }
+
+    var initial_data: ptr<u8> = deref dst_buffer.data;
+
+    if (
+        deref dst_buffer.len < 0 ||
+        deref dst_buffer.cap < 0 ||
+        deref dst_buffer.len > deref dst_buffer.cap ||
+        (deref dst_buffer.cap > 0 && initial_data == null)
+    ) {
+        return IO_ERR_INVALID;
+    }
+
+    var fd: i64 = fs_open_read(path);
+    if (fd < 0) {
+        return fd;
+    }
+
+    var original_len: i64 = deref dst_buffer.len;
+    var total: i64 = 0;
+
+    while (true) {
+        if (deref dst_buffer.len == deref dst_buffer.cap) {
+            var next_cap: i64 = deref dst_buffer.cap * 2;
+            if (next_cap < 4096) {
+                next_cap = 4096;
+            }
+
+            var reserve_result: i64 = buffer_reserve(dst_buffer, next_cap);
+            if (reserve_result < 0) {
+                deref dst_buffer.len = original_len;
+                io_close(fd);
+                return reserve_result;
+            }
+        }
+
+        var data: ptr<u8> = deref dst_buffer.data;
+        var available: i64 = deref dst_buffer.cap - deref dst_buffer.len;
+        var read_n: i64 = io_read(fd, data + deref dst_buffer.len, available);
+
+        if (read_n < 0) {
+            deref dst_buffer.len = original_len;
+            io_close(fd);
+            return read_n;
+        }
+
+        if (read_n == 0) {
+            var close_result: i64 = io_close(fd);
+            if (close_result < 0) {
+                deref dst_buffer.len = original_len;
+                return close_result;
+            }
+            return total;
+        }
+
+        deref dst_buffer.len = deref dst_buffer.len + read_n;
+        total += read_n;
+    }
+
+    return total;
+}
+
+// Replaces path with len bytes from caller-owned storage using default modes.
+pub fun write(path: str, src: ptr<u8>, len: i64) -> i64 {
+    return fs_write_all(path, src, len, FS_MODE_FILE_DEFAULT);
+}
+
+// Appends len bytes from caller-owned storage, creating path when necessary.
+pub fun append(path: str, src: ptr<u8>, len: i64) -> i64 {
+    return fs_append_all(path, src, len, FS_MODE_FILE_DEFAULT);
+}
+
+// Copies src_path to dst_path with internal scratch storage and default modes.
+pub fun copy(src_path: str, dst_path: str) -> i64 {
+    var scratch: array<u8, 8192>;
+    return fs_copy(
+        src_path,
+        dst_path,
+        &scratch[0],
+        8192,
+        FS_MODE_FILE_DEFAULT
+    );
+}
+
+// Renames old_path to new_path without exposing a target syscall number.
+pub fun rename(old_path: str, new_path: str) -> i64 {
+    return fs_rename(old_path, new_path);
+}
+
+// Removes the file at path.
+pub fun remove(path: str) -> i64 {
+    return fs_remove(path);
+}
+
+// Creates one directory at path with portable default permissions.
+pub fun create_dir(path: str) -> i64 {
+    return fs_mkdir(path, FS_MODE_DIR_DEFAULT);
+}
+
+// Removes the empty directory at path.
+pub fun remove_dir(path: str) -> i64 {
+    return fs_rmdir(path);
 }

--- a/std/io/fd.wave
+++ b/std/io/fd.wave
@@ -16,6 +16,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Descriptor-level byte I/O built on std::sys::fs. Buffers stay owned by the
+// caller, successful operations return byte counts, and failures stay negative.
+
 import("std::io::consts")::{
     IO_STDIN_FD,
     IO_STDOUT_FD,
@@ -72,6 +75,8 @@ pub fun io_seek(fd: i64, offset: i64, whence: i32) -> i64 {
     return lseek(fd, offset, whence);
 }
 
+// Reads up to len bytes and retries an interrupted system call.
+// Example: var n: i64 = io_read(fd, &buf[0], 64);
 pub fun io_read(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
     if (len < 0) {
         return IO_ERR_INVALID;
@@ -104,6 +109,8 @@ pub fun io_write(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
     return 0;
 }
 
+// Writes the complete caller-owned buffer or returns the first negative error.
+// Example: var n: i64 = io_write_all(fd, text as ptr<u8>, 4);
 pub fun io_write_all(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
     if (len < 0) {
         return IO_ERR_INVALID;
@@ -130,6 +137,8 @@ pub fun io_write_all(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
     return written;
 }
 
+// Fills len bytes of caller-owned storage; an early EOF is IO_ERR_EOF.
+// Example: var n: i64 = io_read_exact(fd, &header[0], 8);
 pub fun io_read_exact(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
     if (len < 0) {
         return IO_ERR_INVALID;
@@ -156,6 +165,7 @@ pub fun io_read_exact(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
     return total;
 }
 
+// Reads until dst is full or EOF is reached, without allocating storage.
 pub fun io_read_at_most(fd: i64, dst: ptr<u8>, dst_cap: i64) -> i64 {
     if (dst_cap < 0) {
         return IO_ERR_INVALID;
@@ -182,6 +192,8 @@ pub fun io_read_at_most(fd: i64, dst: ptr<u8>, dst_cap: i64) -> i64 {
     return total;
 }
 
+// Copies bytes between descriptors using caller-owned scratch storage.
+// Example: var n: i64 = io_copy(src_fd, dst_fd, &scratch[0], 4096);
 pub fun io_copy(src_fd: i64, dst_fd: i64, scratch: ptr<u8>, scratch_cap: i64) -> i64 {
     if (scratch_cap <= 0) {
         return IO_ERR_INVALID;
@@ -208,6 +220,7 @@ pub fun io_copy(src_fd: i64, dst_fd: i64, scratch: ptr<u8>, scratch_cap: i64) ->
     return total;
 }
 
+// Writes two newly created descriptors into caller-owned out_fds storage.
 pub fun io_pipe(out_fds: ptr<i32>) -> i64 {
     return pipe(out_fds);
 }

--- a/std/libc/arpa.wave
+++ b/std/libc/arpa.wave
@@ -16,6 +16,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Direct C networking declarations for explicit interoperability. Portable
+// std modules use std::sys and std::net instead of importing this module.
+
 extern(c) {
     fun inet_addr(cp: ptr<i8>) -> i32;
     fun inet_ntoa(addr: i32) -> ptr<i8>;

--- a/std/libc/errno.wave
+++ b/std/libc/errno.wave
@@ -16,4 +16,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Direct C errno declarations for explicit interoperability. Portable std
+// modules preserve negative errors through std::sys instead of using this API.
+
 extern(c) fun __errno_location() -> ptr<i32>;

--- a/std/libc/netinet.wave
+++ b/std/libc/netinet.wave
@@ -16,6 +16,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Direct C internet-address declarations for explicit interoperability.
+// Portable std modules use the address types provided by std::net.
+
 // sockaddr_in (IPv4)
 pub struct SockAddrIn {
     family: i16;        // AF_INET

--- a/std/libc/poll.wave
+++ b/std/libc/poll.wave
@@ -16,6 +16,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Direct C polling declarations for explicit interoperability. Portable std
+// modules use the target-selected polling operations under std::sys.
+
 // poll events
 pub const POLLIN: i16  = 0x001;
 pub const POLLOUT: i16 = 0x004;

--- a/std/libc/socket.wave
+++ b/std/libc/socket.wave
@@ -16,6 +16,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Direct C socket declarations for explicit interoperability. Portable std
+// modules use std::sys and std::net instead of importing this module.
+
 // address families
 pub const AF_INET: i32 = 2;
 pub const AF_INET6: i32 = 10;

--- a/std/libc/stdio.wave
+++ b/std/libc/stdio.wave
@@ -16,6 +16,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Direct C stdio declarations for explicit interoperability. Portable Wave
+// I/O is implemented by std::io rather than this module.
+
 extern(c) {
     fun puts(s: ptr<i8>) -> i32;
     fun getchar() -> i32;

--- a/std/libc/stdlib.wave
+++ b/std/libc/stdlib.wave
@@ -16,6 +16,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Direct C runtime declarations for explicit interoperability. Portable std
+// modules use Wave implementations and std::sys instead of this module.
+
 extern(c) fun malloc(size: i64) -> ptr<i8>;
 extern(c) fun calloc(count: i64, size: i64) -> ptr<i8>;
 extern(c) fun realloc(ptr: ptr<i8>, size: i64) -> ptr<i8>;

--- a/std/libc/string.wave
+++ b/std/libc/string.wave
@@ -16,6 +16,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Direct C memory and string declarations for explicit interoperability.
+// Portable std modules use Wave implementations under std::mem and std::string.
+
 extern(c) fun strlen(s: ptr<i8>) -> i64;
 extern(c) fun strcmp(a: ptr<i8>, b: ptr<i8>) -> i32;
 extern(c) fun strcpy(dst: ptr<i8>, src: ptr<i8>) -> ptr<i8>;

--- a/std/libc/time.wave
+++ b/std/libc/time.wave
@@ -16,6 +16,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Direct C time declarations for explicit interoperability. Portable clock
+// and sleep helpers are provided by std::time.
+
 pub struct TimeSpec {
     sec: i64;
     nsec: i64;

--- a/std/libc/unistd.wave
+++ b/std/libc/unistd.wave
@@ -16,6 +16,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Direct C POSIX declarations for explicit interoperability. Portable std
+// modules use target-selected std::sys operations instead of this module.
+
 extern(c) fun read(fd: i32, buf: ptr<u8>, count: i64) -> i64;
 extern(c) fun write(fd: i32, buf: ptr<u8>, count: i64) -> i64;
 extern(c) fun close(fd: i32) -> i32;

--- a/std/manifest.json
+++ b/std/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "std",
   "format": 1,
+  "compatibility_revision": 1,
   "license": "Apache-2.0",
   "modules": ["string", "math", "sys", "net", "libc", "time", "env", "path", "mem", "buffer", "io", "fs", "bytes", "process"]
 }

--- a/std/sys/env.wave
+++ b/std/sys/env.wave
@@ -16,17 +16,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// Environment sys dispatcher
-// =======================================================
+// Selects the target environment ABI. std::env adds caller-buffer validation
+// and value parsing on top of this raw environment reader.
 
 #[target(os="linux")]
 pub import("std::sys::linux::env")::{
     env_read,
 };
 
-#[target(os="macos", arch="x86_64")]
+#[target(os="macos")]
 pub import("std::sys::macos::env")::{
     ERR_NOT_IMPLEMENTED,
     env_read,
 };
+
+#[target(os="windows")]
+pub import("std::sys::windows::env")::{env_read};
+
+#[target(os="freebsd")]
+pub import("std::sys::freebsd::env")::{env_read};

--- a/std/sys/freebsd/amd64/env.wave
+++ b/std/sys/freebsd/amd64/env.wave
@@ -1,0 +1,28 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ENOSYS-style return for not implemented path.
+pub const ERR_NOT_IMPLEMENTED: i64 = -78;
+
+pub fun env_read(buf: ptr<u8>, cap: i64) -> i64 {
+    if (buf == null || cap <= 0) {
+        return -22;
+    }
+
+    return ERR_NOT_IMPLEMENTED;
+}

--- a/std/sys/freebsd/amd64/fs.wave
+++ b/std/sys/freebsd/amd64/fs.wave
@@ -1,0 +1,160 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// FreeBSD amd64 filesystem syscalls.
+// =======================================================
+
+import("std::sys::freebsd::amd64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+// open flags
+pub const FS_O_RDONLY: i32 = 0;
+pub const FS_O_WRONLY: i32 = 1;
+pub const FS_O_RDWR: i32 = 2;
+pub const FS_O_NONBLOCK: i32 = 4;
+pub const FS_O_APPEND: i32 = 8;
+pub const FS_O_CREAT: i32 = 512;
+pub const FS_O_TRUNC: i32 = 1024;
+pub const FS_O_EXCL: i32 = 2048;
+
+// access modes
+pub const FS_F_OK: i32 = 0;
+pub const FS_X_OK: i32 = 1;
+pub const FS_W_OK: i32 = 2;
+pub const FS_R_OK: i32 = 4;
+
+// seek modes
+pub const FS_SEEK_SET: i32 = 0;
+pub const FS_SEEK_CUR: i32 = 1;
+pub const FS_SEEK_END: i32 = 2;
+
+// fcntl modes
+pub const FS_F_GETFL: i32 = 3;
+pub const FS_F_SETFL: i32 = 4;
+
+// FreeBSD 14 amd64 struct stat layout used by fstatat(2) and fstat(2).
+pub struct Stat {
+    dev: u64;
+    ino: u64;
+    nlink: u64;
+    mode: u16;
+    bsdflags: i16;
+    uid: u32;
+    gid: u32;
+    padding1: i32;
+    rdev: u64;
+    atime: i64;
+    atime_nsec: i64;
+    mtime: i64;
+    mtime_nsec: i64;
+    ctime: i64;
+    ctime_nsec: i64;
+    birthtime: i64;
+    birthtime_nsec: i64;
+    size: i64;
+    blocks: i64;
+    blksize: i32;
+    flags: u32;
+    generation: u64;
+    file_revision: u64;
+    spare: array<u64, 9>;
+}
+
+pub fun open(path: str, flags: i32, mode: i32) -> i64 {
+    return syscall3(5, path as i64, flags as i64, mode as i64);
+}
+
+pub fun close(fd: i64) -> i64 {
+    return syscall1(6, fd);
+}
+
+pub fun dup(fd: i64) -> i64 {
+    return syscall1(41, fd);
+}
+
+pub fun pipe(fds: ptr<i32>) -> i64 {
+    return syscall2(542, fds as i64, 0);
+}
+
+pub fun dup2(oldfd: i64, newfd: i64) -> i64 {
+    return syscall2(90, oldfd, newfd);
+}
+
+pub fun fsync(fd: i64) -> i64 {
+    return syscall1(95, fd);
+}
+
+pub fun fcntl(fd: i64, cmd: i32, arg: i64) -> i64 {
+    return syscall3(92, fd, cmd as i64, arg);
+}
+
+pub fun read(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
+    return syscall3(3, fd, buf as i64, len);
+}
+
+pub fun write(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
+    return syscall3(4, fd, buf as i64, len);
+}
+
+pub fun getcwd(buf: ptr<u8>, size: i64) -> i64 {
+    return syscall2(326, buf as i64, size);
+}
+
+pub fun chdir(path: str) -> i64 {
+    return syscall1(12, path as i64);
+}
+
+pub fun access(path: str, mode: i32) -> i64 {
+    return syscall2(33, path as i64, mode as i64);
+}
+
+pub fun lseek(fd: i64, offset: i64, whence: i32) -> i64 {
+    return syscall3(478, fd, offset, whence as i64);
+}
+
+pub fun unlink(path: str) -> i64 {
+    return syscall1(10, path as i64);
+}
+
+pub fun mkdir(path: str, mode: i32) -> i64 {
+    return syscall2(136, path as i64, mode as i64);
+}
+
+pub fun rmdir(path: str) -> i64 {
+    return syscall1(137, path as i64);
+}
+
+pub fun rename_path(old_path: str, new_path: str) -> i64 {
+    return syscall2(128, old_path as i64, new_path as i64);
+}
+
+pub fun stat(path: str, st: ptr<Stat>) -> i64 {
+    return syscall4(552, -100, path as i64, st as i64, 0);
+}
+
+pub fun fstat(fd: i64, st: ptr<Stat>) -> i64 {
+    return syscall2(551, fd, st as i64);
+}

--- a/std/sys/freebsd/amd64/memory.wave
+++ b/std/sys/freebsd/amd64/memory.wave
@@ -1,0 +1,93 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// FreeBSD memory syscalls
+// =======================================================
+
+import("std::sys::freebsd::amd64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub const PROT_READ: i32 = 1;
+pub const PROT_WRITE: i32 = 2;
+pub const MAP_PRIVATE: i32 = 2;
+pub const MAP_ANON: i32 = 0x1000;
+pub const MAP_ANONYMOUS: i32 = MAP_ANON;
+
+pub fun mmap(
+    addr: ptr<i8>,
+    length: i64,
+    prot: i32,
+    flags: i32,
+    fd: i64,
+    offset: i64
+) -> ptr<i8> {
+    return syscall6(
+        477,
+        addr as i64,
+        length,
+        prot as i64,
+        flags as i64,
+        fd,
+        offset
+    ) as ptr<i8>;
+}
+
+pub fun munmap(addr: ptr<i8>, length: i64) -> i64 {
+    return syscall2(73, addr as i64, length);
+}
+
+pub fun brk(addr: ptr<i8>) -> ptr<i8> {
+    return syscall1(17, addr as i64) as ptr<i8>;
+}
+
+pub fun sys_alloc(size: i64) -> ptr<u8> {
+    if (size <= 0) {
+        return null;
+    }
+
+    var p: ptr<i8> = mmap(
+        null,
+        size,
+        PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANON,
+        -1,
+        0
+    );
+
+    if ((p as i64) < 0) {
+        return null;
+    }
+
+    return p as ptr<u8>;
+}
+
+pub fun sys_free(p: ptr<u8>, size: i64) -> i64 {
+    if (p == null || size <= 0) {
+        return 0;
+    }
+
+    return munmap(p as ptr<i8>, size);
+}

--- a/std/sys/freebsd/amd64/process.wave
+++ b/std/sys/freebsd/amd64/process.wave
@@ -1,0 +1,64 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// FreeBSD process syscalls
+// =======================================================
+
+import("std::sys::freebsd::amd64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub fun exit(code: i32) -> ! {
+    syscall1(1, code as i64);
+    while (true) { }
+}
+
+pub fun getpid() -> i64 {
+    return syscall0(20);
+}
+
+pub fun getppid() -> i64 {
+    return syscall0(39);
+}
+
+pub fun fork() -> i64 {
+    return syscall0(2);
+}
+
+pub fun execve(
+    path: str,
+    argv: ptr<ptr<i8>>,
+    envp: ptr<ptr<i8>>
+) -> i64 {
+    return syscall3(59, path as i64, argv as i64, envp as i64);
+}
+
+pub fun waitpid(pid: i64, status: ptr<i32>, options: i32) -> i64 {
+    return syscall4(7, pid, status as i64, options as i64, 0);
+}
+
+pub fun kill(pid: i64, sig: i32) -> i64 {
+    return syscall2(37, pid, sig as i64);
+}

--- a/std/sys/freebsd/amd64/socket.wave
+++ b/std/sys/freebsd/amd64/socket.wave
@@ -1,0 +1,172 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// FreeBSD socket syscalls
+// =======================================================
+//
+// Raw socket layer for FreeBSD built on syscall.wave.
+// =======================================================
+
+import("std::sys::freebsd::amd64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub const AF_INET: i32 = 2;
+pub const AF_INET6: i32 = 28;
+
+pub const SOCK_STREAM: i32 = 1;
+pub const SOCK_DGRAM: i32 = 2;
+
+pub const IPPROTO_IP: i32 = 0;
+pub const IPPROTO_TCP: i32 = 6;
+pub const IPPROTO_UDP: i32 = 17;
+
+pub const SHUT_RD: i32 = 0;
+pub const SHUT_WR: i32 = 1;
+pub const SHUT_RDWR: i32 = 2;
+
+pub const SOL_SOCKET: i32 = 0xFFFF;
+pub const SO_REUSEADDR: i32 = 0x0004;
+pub const SO_REUSEPORT: i32 = 0x0200;
+
+pub const POLLIN: i16 = 0x001;
+pub const POLLOUT: i16 = 0x004;
+pub const POLLERR: i16 = 0x008;
+pub const POLLHUP: i16 = 0x010;
+pub const POLLNVAL: i16 = 0x020;
+
+pub struct PollFd {
+    fd: i32;
+    events: i16;
+    revents: i16;
+}
+
+pub fun socket(domain: i32, ty: i32, protocol: i32) -> i64 {
+    return syscall3(97, domain as i64, ty as i64, protocol as i64);
+}
+
+pub fun bind(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
+    return syscall3(104, fd, addr as i64, len as i64);
+}
+
+pub fun listen(fd: i64, backlog: i32) -> i64 {
+    return syscall2(106, fd, backlog as i64);
+}
+
+pub fun accept(fd: i64, addr: ptr<i8>, len: ptr<i32>) -> i64 {
+    return syscall3(30, fd, addr as i64, len as i64);
+}
+
+pub fun connect(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
+    return syscall3(98, fd, addr as i64, len as i64);
+}
+
+pub fun shutdown(fd: i64, how: i32) -> i64 {
+    return syscall2(134, fd, how as i64);
+}
+
+pub fun setsockopt(
+    fd: i64,
+    level: i32,
+    optname: i32,
+    optval: ptr<i8>,
+    optlen: i32
+) -> i64 {
+    return syscall5(
+        105,
+        fd,
+        level as i64,
+        optname as i64,
+        optval as i64,
+        optlen as i64
+    );
+}
+
+pub fun getsockopt(
+    fd: i64,
+    level: i32,
+    optname: i32,
+    optval: ptr<i8>,
+    optlen: ptr<i32>
+) -> i64 {
+    return syscall5(
+        118,
+        fd,
+        level as i64,
+        optname as i64,
+        optval as i64,
+        optlen as i64
+    );
+}
+
+pub fun poll(fds: ptr<PollFd>, nfds: i64, timeout_ms: i32) -> i64 {
+    return syscall3(209, fds as i64, nfds, timeout_ms as i64);
+}
+
+pub fun send(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
+    return sendto(fd, buf, len, flags, null, 0);
+}
+
+pub fun recv(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
+    return recvfrom(fd, buf, len, flags, null, null);
+}
+
+pub fun sendto(
+    fd: i64,
+    buf: ptr<u8>,
+    len: i64,
+    flags: i32,
+    addr: ptr<i8>,
+    addrlen: i32
+) -> i64 {
+    return syscall6(
+        133,
+        fd,
+        buf as i64,
+        len,
+        flags as i64,
+        addr as i64,
+        addrlen as i64
+    );
+}
+
+pub fun recvfrom(
+    fd: i64,
+    buf: ptr<u8>,
+    len: i64,
+    flags: i32,
+    addr: ptr<i8>,
+    addrlen: ptr<i32>
+) -> i64 {
+    return syscall6(
+        29,
+        fd,
+        buf as i64,
+        len,
+        flags as i64,
+        addr as i64,
+        addrlen as i64
+    );
+}

--- a/std/sys/freebsd/amd64/syscall.wave
+++ b/std/sys/freebsd/amd64/syscall.wave
@@ -1,0 +1,43 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// FreeBSD amd64 uses the SysV syscall registers. Kernel failures set carry and
+// return a positive errno; the trailing instructions normalize it to -errno.
+
+pub fun syscall0(id: i64) -> i64 {
+    var ret: i64;
+    asm { "syscall\njnc 1f\nneg rax\n1:" in("rax") id out("rax") ret }
+    return ret;
+}
+pub fun syscall1(id: i64, a1: i64) -> i64 {
+    var ret: i64;
+    asm { "syscall\njnc 1f\nneg rax\n1:" in("rax") id in("rdi") a1 out("rax") ret }
+    return ret;
+}
+pub fun syscall2(id: i64, a1: i64, a2: i64) -> i64 {
+    var ret: i64;
+    asm { "syscall\njnc 1f\nneg rax\n1:" in("rax") id in("rdi") a1 in("rsi") a2 out("rax") ret }
+    return ret;
+}
+pub fun syscall3(id: i64, a1: i64, a2: i64, a3: i64) -> i64 {
+    var ret: i64;
+    asm { "syscall\njnc 1f\nneg rax\n1:" in("rax") id in("rdi") a1 in("rsi") a2 in("rdx") a3 out("rax") ret }
+    return ret;
+}
+pub fun syscall4(id: i64, a1: i64, a2: i64, a3: i64, a4: i64) -> i64 {
+    var ret: i64;
+    asm { "syscall\njnc 1f\nneg rax\n1:" in("rax") id in("rdi") a1 in("rsi") a2 in("rdx") a3 in("r10") a4 out("rax") ret }
+    return ret;
+}
+pub fun syscall5(id: i64, a1: i64, a2: i64, a3: i64, a4: i64, a5: i64) -> i64 {
+    var ret: i64;
+    asm { "syscall\njnc 1f\nneg rax\n1:" in("rax") id in("rdi") a1 in("rsi") a2 in("rdx") a3 in("r10") a4 in("r8") a5 out("rax") ret }
+    return ret;
+}
+pub fun syscall6(id: i64, a1: i64, a2: i64, a3: i64, a4: i64, a5: i64, a6: i64) -> i64 {
+    var ret: i64;
+    asm { "syscall\njnc 1f\nneg rax\n1:" in("rax") id in("rdi") a1 in("rsi") a2 in("rdx") a3 in("r10") a4 in("r8") a5 in("r9") a6 out("rax") ret }
+    return ret;
+}

--- a/std/sys/freebsd/amd64/time.wave
+++ b/std/sys/freebsd/amd64/time.wave
@@ -1,0 +1,44 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// FreeBSD time syscalls
+// =======================================================
+
+import("std::sys::freebsd::amd64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub struct TimeSpec {
+    sec: i64;
+    nsec: i64;
+}
+
+pub fun nanosleep(req: ptr<TimeSpec>, rem: ptr<TimeSpec>) -> i64 {
+    return syscall2(240, req as i64, rem as i64);
+}
+
+pub fun clock_gettime(clock_id: i32, tp: ptr<TimeSpec>) -> i64 {
+    return syscall2(232, clock_id as i64, tp as i64);
+}

--- a/std/sys/freebsd/amd64/tty.wave
+++ b/std/sys/freebsd/amd64/tty.wave
@@ -1,0 +1,139 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// FreeBSD tty helpers
+// =======================================================
+
+import("std::sys::freebsd::amd64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub const TTY_SYS_IOCTL: i64 = 54;
+pub const TTY_SYS_FCNTL: i64 = 92;
+
+pub const TTY_TCGETS: i64 = 0x402c7413;
+pub const TTY_TCSETS: i64 = 0x802c7414;
+pub const TTY_TCSETSW: i64 = 0x802c7415;
+pub const TTY_TCSETSF: i64 = 0x802c7416;
+
+pub const TTY_TCSANOW: i32 = 0;
+pub const TTY_TCSADRAIN: i32 = 1;
+pub const TTY_TCSAFLUSH: i32 = 2;
+
+pub const TTY_F_GETFL: i32 = 3;
+pub const TTY_F_SETFL: i32 = 4;
+pub const TTY_O_NONBLOCK: i32 = 4;
+
+pub const TTY_ICANON: u32 = 0x00000100;
+pub const TTY_ECHO: u32 = 0x00000008;
+pub const TTY_VMIN_IDX: i32 = 16;
+pub const TTY_VTIME_IDX: i32 = 17;
+
+pub struct Termios {
+    c_iflag: u32;
+    c_oflag: u32;
+    c_cflag: u32;
+    c_lflag: u32;
+    c_cc: array<u8, 20>;
+    c_ispeed: u32;
+    c_ospeed: u32;
+}
+
+pub struct TtyRawState {
+    term: Termios;
+    flags: i32;
+    active: i32;
+}
+
+pub fun tty_getattr(fd: i32, t: ptr<Termios>) -> i64 {
+    return syscall3(TTY_SYS_IOCTL, fd as i64, TTY_TCGETS, t as i64);
+}
+
+pub fun tty_setattr(fd: i32, action: i32, t: ptr<Termios>) -> i64 {
+    var req: i64 = TTY_TCSETS;
+
+    if (action == TTY_TCSADRAIN) {
+        req = TTY_TCSETSW;
+    } else if (action == TTY_TCSAFLUSH) {
+        req = TTY_TCSETSF;
+    }
+
+    return syscall3(TTY_SYS_IOCTL, fd as i64, req, t as i64);
+}
+
+pub fun tty_getfl(fd: i32) -> i64 {
+    return syscall3(TTY_SYS_FCNTL, fd as i64, TTY_F_GETFL as i64, 0);
+}
+
+pub fun tty_setfl(fd: i32, flags: i32) -> i64 {
+    return syscall3(TTY_SYS_FCNTL, fd as i64, TTY_F_SETFL as i64, flags as i64);
+}
+
+pub fun tty_enable_raw_nonblock(fd: i32, st: ptr<TtyRawState>) -> i64 {
+    deref st.active = 0;
+    var vmin_idx: i32 = 16;
+    var vtime_idx: i32 = 17;
+
+    var orig: Termios;
+    if (tty_getattr(fd, &orig) < 0) {
+        return -1;
+    }
+
+    var raw: Termios = orig;
+    raw.c_lflag = raw.c_lflag & ~(TTY_ICANON | TTY_ECHO);
+    raw.c_cc[vmin_idx] = 0;
+    raw.c_cc[vtime_idx] = 0;
+
+    if (tty_setattr(fd, TTY_TCSANOW, &raw) < 0) {
+        return -1;
+    }
+
+    var flags_raw: i64 = tty_getfl(fd);
+    if (flags_raw < 0) {
+        tty_setattr(fd, TTY_TCSANOW, &orig);
+        return -1;
+    }
+
+    var old_flags: i32 = flags_raw as i32;
+    if (tty_setfl(fd, old_flags | TTY_O_NONBLOCK) < 0) {
+        tty_setattr(fd, TTY_TCSANOW, &orig);
+        return -1;
+    }
+
+    deref st.term = orig;
+    deref st.flags = old_flags;
+    deref st.active = 1;
+    return 0;
+}
+
+pub fun tty_restore(fd: i32, st: ptr<TtyRawState>) {
+    if (deref st.active == 0) {
+        return;
+    }
+
+    var orig: Termios = deref st.term;
+    tty_setattr(fd, TTY_TCSANOW, &orig);
+    tty_setfl(fd, deref st.flags);
+}

--- a/std/sys/freebsd/env.wave
+++ b/std/sys/freebsd/env.wave
@@ -1,0 +1,8 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// FreeBSD environment provider selected by target architecture.
+
+#[target(arch="x86_64")]
+pub import("std::sys::freebsd::amd64::env")::{env_read};

--- a/std/sys/freebsd/fs.wave
+++ b/std/sys/freebsd/fs.wave
@@ -1,0 +1,15 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// FreeBSD filesystem provider selected by target architecture.
+
+#[target(arch="x86_64")]
+pub import("std::sys::freebsd::amd64::fs")::{
+    FS_O_RDONLY, FS_O_WRONLY, FS_O_RDWR, FS_O_CREAT, FS_O_EXCL,
+    FS_O_TRUNC, FS_O_APPEND, FS_O_NONBLOCK,
+    FS_F_OK, FS_X_OK, FS_W_OK, FS_R_OK,
+    FS_SEEK_SET, FS_SEEK_CUR, FS_SEEK_END, FS_F_GETFL, FS_F_SETFL,
+    open, close, dup, dup2, pipe, fsync, fcntl, read, write, getcwd,
+    chdir, access, lseek, unlink, mkdir, rmdir, rename_path, Stat, stat, fstat,
+};

--- a/std/sys/freebsd/memory.wave
+++ b/std/sys/freebsd/memory.wave
@@ -1,0 +1,11 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// FreeBSD virtual-memory provider selected by target architecture.
+
+#[target(arch="x86_64")]
+pub import("std::sys::freebsd::amd64::memory")::{
+    PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS,
+    mmap, munmap, brk, sys_alloc, sys_free,
+};

--- a/std/sys/freebsd/process.wave
+++ b/std/sys/freebsd/process.wave
@@ -1,0 +1,10 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// FreeBSD process provider selected by target architecture.
+
+#[target(arch="x86_64")]
+pub import("std::sys::freebsd::amd64::process")::{
+    exit, getpid, getppid, fork, execve, waitpid, kill,
+};

--- a/std/sys/freebsd/socket.wave
+++ b/std/sys/freebsd/socket.wave
@@ -1,0 +1,15 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// FreeBSD socket provider selected by target architecture.
+
+#[target(arch="x86_64")]
+pub import("std::sys::freebsd::amd64::socket")::{
+    AF_INET, AF_INET6, SOCK_STREAM, SOCK_DGRAM,
+    IPPROTO_IP, IPPROTO_TCP, IPPROTO_UDP,
+    SHUT_RD, SHUT_WR, SHUT_RDWR, SOL_SOCKET, SO_REUSEADDR, SO_REUSEPORT,
+    POLLIN, POLLOUT, POLLERR, POLLHUP, POLLNVAL, PollFd,
+    socket, bind, listen, accept, connect, shutdown, setsockopt, getsockopt,
+    poll, send, recv, sendto, recvfrom,
+};

--- a/std/sys/freebsd/time.wave
+++ b/std/sys/freebsd/time.wave
@@ -1,0 +1,8 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// FreeBSD clock provider selected by target architecture.
+
+#[target(arch="x86_64")]
+pub import("std::sys::freebsd::amd64::time")::{TimeSpec, nanosleep, clock_gettime};

--- a/std/sys/freebsd/tty.wave
+++ b/std/sys/freebsd/tty.wave
@@ -1,0 +1,15 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// FreeBSD terminal provider selected by target architecture.
+
+#[target(arch="x86_64")]
+pub import("std::sys::freebsd::amd64::tty")::{
+    TTY_SYS_IOCTL, TTY_SYS_FCNTL, TTY_TCGETS, TTY_TCSETS, TTY_TCSETSW,
+    TTY_TCSETSF, TTY_TCSANOW, TTY_TCSADRAIN, TTY_TCSAFLUSH,
+    TTY_F_GETFL, TTY_F_SETFL, TTY_O_NONBLOCK, TTY_ICANON, TTY_ECHO,
+    TTY_VTIME_IDX, TTY_VMIN_IDX, Termios, TtyRawState,
+    tty_getattr, tty_setattr, tty_getfl, tty_setfl,
+    tty_enable_raw_nonblock, tty_restore,
+};

--- a/std/sys/fs.wave
+++ b/std/sys/fs.wave
@@ -16,13 +16,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// Filesystem sys dispatcher
-// =======================================================
-//
-// This layer selects the OS-specific fs implementation.
-// Keep target attributes only in this dispatch module.
-// =======================================================
+// Selects the target filesystem ABI. These raw operations return nonnegative
+// results on success and negative -errno values on failure.
 
 #[target(os="linux")]
 pub import("std::sys::linux::fs")::{
@@ -59,12 +54,13 @@ pub import("std::sys::linux::fs")::{
     unlink,
     mkdir,
     rmdir,
+    rename_path,
     Stat,
     stat,
     fstat,
 };
 
-#[target(os="macos", arch="x86_64")]
+#[target(os="macos")]
 pub import("std::sys::macos::fs")::{
     FS_O_RDONLY,
     FS_O_WRONLY,
@@ -100,6 +96,27 @@ pub import("std::sys::macos::fs")::{
     unlink,
     mkdir,
     rmdir,
+    rename_path,
     stat,
     fstat,
+};
+
+#[target(os="windows")]
+pub import("std::sys::windows::fs")::{
+    FS_O_RDONLY, FS_O_WRONLY, FS_O_RDWR, FS_O_CREAT, FS_O_EXCL,
+    FS_O_TRUNC, FS_O_APPEND, FS_O_NONBLOCK,
+    FS_F_OK, FS_X_OK, FS_W_OK, FS_R_OK,
+    FS_SEEK_SET, FS_SEEK_CUR, FS_SEEK_END, FS_F_GETFL, FS_F_SETFL,
+    open, close, dup, dup2, pipe, fsync, fcntl, read, write, getcwd,
+    chdir, access, lseek, unlink, mkdir, rmdir, rename_path, Stat, stat, fstat,
+};
+
+#[target(os="freebsd")]
+pub import("std::sys::freebsd::fs")::{
+    FS_O_RDONLY, FS_O_WRONLY, FS_O_RDWR, FS_O_CREAT, FS_O_EXCL,
+    FS_O_TRUNC, FS_O_APPEND, FS_O_NONBLOCK,
+    FS_F_OK, FS_X_OK, FS_W_OK, FS_R_OK,
+    FS_SEEK_SET, FS_SEEK_CUR, FS_SEEK_END, FS_F_GETFL, FS_F_SETFL,
+    open, close, dup, dup2, pipe, fsync, fcntl, read, write, getcwd,
+    chdir, access, lseek, unlink, mkdir, rmdir, rename_path, Stat, stat, fstat,
 };

--- a/std/sys/linux/amd64/env.wave
+++ b/std/sys/linux/amd64/env.wave
@@ -1,0 +1,71 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import("std::sys::linux::amd64::fs")::{
+    FS_O_RDONLY,
+    FS_O_WRONLY,
+    FS_O_RDWR,
+    FS_O_CREAT,
+    FS_O_EXCL,
+    FS_O_TRUNC,
+    FS_O_APPEND,
+    FS_O_NONBLOCK,
+    FS_F_OK,
+    FS_X_OK,
+    FS_W_OK,
+    FS_R_OK,
+    FS_SEEK_SET,
+    FS_SEEK_CUR,
+    FS_SEEK_END,
+    FS_F_GETFL,
+    FS_F_SETFL,
+    open,
+    close,
+    dup,
+    dup2,
+    pipe,
+    fsync,
+    fcntl,
+    read,
+    write,
+    getcwd,
+    chdir,
+    access,
+    lseek,
+    unlink,
+    mkdir,
+    rmdir,
+    Stat,
+    stat,
+    fstat,
+};
+
+pub fun env_read(buf: ptr<u8>, cap: i64) -> i64 {
+    if (cap <= 0) {
+        return -22;
+    }
+
+    var fd: i64 = open("/proc/self/environ", 0, 0);
+    if (fd < 0) {
+        return fd;
+    }
+
+    var n: i64 = read(fd, buf, cap);
+    close(fd);
+    return n;
+}

--- a/std/sys/linux/amd64/fs.wave
+++ b/std/sys/linux/amd64/fs.wave
@@ -1,0 +1,206 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// Linux x86_64 filesystem syscalls
+// =======================================================
+//
+// This layer provides minimal filesystem operations
+// built directly on top of syscall.wave.
+//
+// All functions return raw syscall results.
+// Negative values indicate -errno.
+// =======================================================
+
+import("std::sys::linux::amd64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+// open flags
+pub const FS_O_RDONLY: i32 = 0;
+pub const FS_O_WRONLY: i32 = 1;
+pub const FS_O_RDWR: i32 = 2;
+pub const FS_O_CREAT: i32 = 64;
+pub const FS_O_EXCL: i32 = 128;
+pub const FS_O_TRUNC: i32 = 512;
+pub const FS_O_APPEND: i32 = 1024;
+pub const FS_O_NONBLOCK: i32 = 2048;
+
+// access modes
+pub const FS_F_OK: i32 = 0;
+pub const FS_X_OK: i32 = 1;
+pub const FS_W_OK: i32 = 2;
+pub const FS_R_OK: i32 = 4;
+
+// seek modes
+pub const FS_SEEK_SET: i32 = 0;
+pub const FS_SEEK_CUR: i32 = 1;
+pub const FS_SEEK_END: i32 = 2;
+
+// fcntl modes
+pub const FS_F_GETFL: i32 = 3;
+pub const FS_F_SETFL: i32 = 4;
+
+// -----------------------
+// open / close
+// -----------------------
+
+pub fun open(path: str, flags: i32, mode: i32) -> i64 {
+    // syscall: open (2)
+    return syscall3(2, path as i64, flags as i64, mode as i64);
+}
+
+pub fun close(fd: i64) -> i64 {
+    // syscall: close (3)
+    return syscall1(3, fd);
+}
+
+pub fun dup(fd: i64) -> i64 {
+    // syscall: dup (32)
+    return syscall1(32, fd);
+}
+
+pub fun dup2(oldfd: i64, newfd: i64) -> i64 {
+    // syscall: dup2 (33)
+    return syscall2(33, oldfd, newfd);
+}
+
+pub fun pipe(fds: ptr<i32>) -> i64 {
+    // syscall: pipe (22)
+    return syscall1(22, fds as i64);
+}
+
+pub fun fsync(fd: i64) -> i64 {
+    // syscall: fsync (74)
+    return syscall1(74, fd);
+}
+
+pub fun fcntl(fd: i64, cmd: i32, arg: i64) -> i64 {
+    // syscall: fcntl (72)
+    return syscall3(72, fd, cmd as i64, arg);
+}
+
+
+// -----------------------
+// read / write
+// -----------------------
+
+pub fun read(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
+    // syscall: read (0)
+    return syscall3(0, fd, buf as i64, len);
+}
+
+pub fun write(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
+    // syscall: write (1)
+    return syscall3(1, fd, buf as i64, len);
+}
+
+pub fun getcwd(buf: ptr<u8>, size: i64) -> i64 {
+    // syscall: getcwd (79)
+    return syscall2(79, buf as i64, size);
+}
+
+pub fun chdir(path: str) -> i64 {
+    // syscall: chdir (80)
+    return syscall1(80, path as i64);
+}
+
+pub fun access(path: str, mode: i32) -> i64 {
+    // syscall: access (21)
+    return syscall2(21, path as i64, mode as i64);
+}
+
+
+// -----------------------
+// seek
+// -----------------------
+
+pub fun lseek(fd: i64, offset: i64, whence: i32) -> i64 {
+    // syscall: lseek (8)
+    return syscall3(8, fd, offset, whence as i64);
+}
+
+
+// -----------------------
+// file operations
+// -----------------------
+
+pub fun unlink(path: str) -> i64 {
+    // syscall: unlink (87)
+    return syscall1(87, path as i64);
+}
+
+pub fun mkdir(path: str, mode: i32) -> i64 {
+    // syscall: mkdir (83)
+    return syscall2(83, path as i64, mode as i64);
+}
+
+pub fun rmdir(path: str) -> i64 {
+    // syscall: rmdir (84)
+    return syscall1(84, path as i64);
+}
+
+pub fun rename_path(old_path: str, new_path: str) -> i64 {
+    // syscall: rename (82)
+    return syscall2(82, old_path as i64, new_path as i64);
+}
+
+
+// -----------------------
+// metadata
+// -----------------------
+
+// Linux x86_64 struct stat, including nanoseconds and the reserved tail.
+pub struct Stat {
+    dev: i64;
+    ino: i64;
+    nlink: i64;
+    mode: i32;
+    uid: i32;
+    gid: i32;
+    pad0: i32;
+    rdev: i64;
+    size: i64;
+    blksize: i64;
+    blocks: i64;
+    atime: i64;
+    atime_nsec: i64;
+    mtime: i64;
+    mtime_nsec: i64;
+    ctime: i64;
+    ctime_nsec: i64;
+    unused0: i64;
+    unused1: i64;
+    unused2: i64;
+}
+
+pub fun stat(path: str, st: ptr<Stat>) -> i64 {
+    // syscall: stat (4)
+    return syscall2(4, path as i64, st as i64);
+}
+
+pub fun fstat(fd: i64, st: ptr<Stat>) -> i64 {
+    // syscall: fstat (5)
+    return syscall2(5, fd, st as i64);
+}

--- a/std/sys/linux/amd64/memory.wave
+++ b/std/sys/linux/amd64/memory.wave
@@ -1,0 +1,110 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// Linux x86_64 memory syscalls
+// =======================================================
+//
+// Low-level virtual memory management.
+// All functions return raw syscall values.
+// Negative values indicate -errno.
+// =======================================================
+
+import("std::sys::linux::amd64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub const PROT_READ: i32 = 1;
+pub const PROT_WRITE: i32 = 2;
+pub const MAP_PRIVATE: i32 = 2;
+pub const MAP_ANONYMOUS: i32 = 32;
+
+
+// -----------------------
+// mmap / munmap
+// -----------------------
+// 3b1b9d23-75fc-4c50-87a4-11865458c2ba
+pub fun mmap(
+    addr: ptr<i8>,
+    length: i64,
+    prot: i32,
+    flags: i32,
+    fd: i64,
+    offset: i64
+) -> ptr<i8> {
+    // syscall: mmap (9)
+    return syscall6(
+        9,
+        addr as i64,
+        length,
+        prot as i64,
+        flags as i64,
+        fd,
+        offset
+    ) as ptr<i8>;
+}
+
+pub fun munmap(addr: ptr<i8>, length: i64) -> i64 {
+    // syscall: munmap (11)
+    return syscall2(11, addr as i64, length);
+}
+
+
+// -----------------------
+// brk
+// -----------------------
+
+pub fun brk(addr: ptr<i8>) -> ptr<i8> {
+    // syscall: brk (12)
+    return syscall1(12, addr as i64) as ptr<i8>;
+}
+
+pub fun sys_alloc(size: i64) -> ptr<u8> {
+    if (size <= 0) {
+        return null;
+    }
+
+    var p: ptr<i8> = mmap(
+        null,
+        size,
+        PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANONYMOUS,
+        -1,
+        0
+    );
+
+    if ((p as i64) < 0) {
+        return null;
+    }
+
+    return p as ptr<u8>;
+}
+
+pub fun sys_free(p: ptr<u8>, size: i64) -> i64 {
+    if (p == null || size <= 0) {
+        return 0;
+    }
+
+    return munmap(p as ptr<i8>, size);
+}

--- a/std/sys/linux/amd64/process.wave
+++ b/std/sys/linux/amd64/process.wave
@@ -1,0 +1,97 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// Linux x86_64 process syscalls
+// =======================================================
+//
+// Minimal process-related system calls.
+// All return raw syscall values.
+// Negative values indicate -errno.
+// =======================================================
+
+import("std::sys::linux::amd64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+
+// -----------------------
+// process lifecycle
+// -----------------------
+
+pub fun exit(code: i32) -> ! {
+    // syscall: exit (60)
+    syscall1(60, code as i64);
+    while (true) { }
+}
+
+pub fun getpid() -> i64 {
+    // syscall: getpid (39)
+    return syscall0(39);
+}
+
+pub fun getppid() -> i64 {
+    // syscall: getppid (110)
+    return syscall0(110);
+}
+
+
+// -----------------------
+// process creation
+// -----------------------
+
+pub fun fork() -> i64 {
+    // syscall: fork (57)
+    return syscall0(57);
+}
+
+pub fun execve(
+    path: str,
+    argv: ptr<ptr<i8>>,
+    envp: ptr<ptr<i8>>
+) -> i64 {
+    // syscall: execve (59)
+    return syscall3(59, path as i64, argv as i64, envp as i64);
+}
+
+
+// -----------------------
+// waiting
+// -----------------------
+
+pub fun waitpid(pid: i64, status: ptr<i32>, options: i32) -> i64 {
+    // syscall: wait4 (61)
+    // waitpid is implemented via wait4
+    return syscall4(61, pid, status as i64, options as i64, 0);
+}
+
+
+// -----------------------
+// signals
+// -----------------------
+
+pub fun kill(pid: i64, sig: i32) -> i64 {
+    // syscall: kill (62)
+    return syscall2(62, pid, sig as i64);
+}

--- a/std/sys/linux/amd64/socket.wave
+++ b/std/sys/linux/amd64/socket.wave
@@ -1,0 +1,206 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// Linux x86_64 socket syscalls
+// =======================================================
+//
+// Raw socket interface built on top of syscall.wave.
+// This layer exposes OS-level socket APIs only.
+// No protocol abstraction (TCP/UDP) here.
+// =======================================================
+
+import("std::sys::linux::amd64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+
+// -----------------------
+// constants (minimal)
+// -----------------------
+
+// address families
+pub const AF_INET: i32 = 2;
+pub const AF_INET6: i32 = 10;
+
+// socket types
+pub const SOCK_STREAM: i32 = 1;
+pub const SOCK_DGRAM: i32 = 2;
+
+// protocol
+pub const IPPROTO_IP: i32 = 0;
+pub const IPPROTO_TCP: i32 = 6;
+pub const IPPROTO_UDP: i32 = 17;
+
+// shutdown how
+pub const SHUT_RD: i32 = 0;
+pub const SHUT_WR: i32 = 1;
+pub const SHUT_RDWR: i32 = 2;
+
+// socket options
+pub const SOL_SOCKET: i32 = 1;
+pub const SO_REUSEADDR: i32 = 2;
+pub const SO_REUSEPORT: i32 = 15;
+
+// poll events
+pub const POLLIN: i16 = 0x001;
+pub const POLLOUT: i16 = 0x004;
+pub const POLLERR: i16 = 0x008;
+pub const POLLHUP: i16 = 0x010;
+pub const POLLNVAL: i16 = 0x020;
+
+pub struct PollFd {
+    fd: i32;
+    events: i16;
+    revents: i16;
+}
+
+
+// -----------------------
+// basic socket syscalls
+// -----------------------
+
+pub fun socket(domain: i32, ty: i32, protocol: i32) -> i64 {
+    // syscall: socket (41)
+    return syscall3(41, domain as i64, ty as i64, protocol as i64);
+}
+
+pub fun bind(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
+    // syscall: bind (49)
+    return syscall3(49, fd, addr as i64, len as i64);
+}
+
+pub fun listen(fd: i64, backlog: i32) -> i64 {
+    // syscall: listen (50)
+    return syscall2(50, fd, backlog as i64);
+}
+
+pub fun accept(fd: i64, addr: ptr<i8>, len: ptr<i32>) -> i64 {
+    // syscall: accept (43)
+    return syscall3(43, fd, addr as i64, len as i64);
+}
+
+pub fun connect(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
+    // syscall: connect (42)
+    return syscall3(42, fd, addr as i64, len as i64);
+}
+
+pub fun shutdown(fd: i64, how: i32) -> i64 {
+    // syscall: shutdown (48)
+    return syscall2(48, fd, how as i64);
+}
+
+pub fun setsockopt(
+    fd: i64,
+    level: i32,
+    optname: i32,
+    optval: ptr<i8>,
+    optlen: i32
+) -> i64 {
+    // syscall: setsockopt (54)
+    return syscall5(
+        54,
+        fd,
+        level as i64,
+        optname as i64,
+        optval as i64,
+        optlen as i64
+    );
+}
+
+pub fun getsockopt(
+    fd: i64,
+    level: i32,
+    optname: i32,
+    optval: ptr<i8>,
+    optlen: ptr<i32>
+) -> i64 {
+    // syscall: getsockopt (55)
+    return syscall5(
+        55,
+        fd,
+        level as i64,
+        optname as i64,
+        optval as i64,
+        optlen as i64
+    );
+}
+
+pub fun poll(fds: ptr<PollFd>, nfds: i64, timeout_ms: i32) -> i64 {
+    // syscall: poll (7)
+    return syscall3(7, fds as i64, nfds, timeout_ms as i64);
+}
+
+
+// -----------------------
+// send / recv
+// -----------------------
+
+pub fun send(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
+    return sendto(fd, buf, len, flags, null, 0);
+}
+
+pub fun recv(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
+    return recvfrom(fd, buf, len, flags, null, null);
+}
+
+pub fun sendto(
+    fd: i64,
+    buf: ptr<u8>,
+    len: i64,
+    flags: i32,
+    addr: ptr<i8>,
+    addrlen: i32
+) -> i64 {
+    // syscall: sendto (44)
+    return syscall6(
+        44,
+        fd,
+        buf as i64,
+        len,
+        flags as i64,
+        addr as i64,
+        addrlen as i64
+    );
+}
+
+pub fun recvfrom(
+    fd: i64,
+    buf: ptr<u8>,
+    len: i64,
+    flags: i32,
+    addr: ptr<i8>,
+    addrlen: ptr<i32>
+) -> i64 {
+    // syscall: recvfrom (45)
+    return syscall6(
+        45,
+        fd,
+        buf as i64,
+        len,
+        flags as i64,
+        addr as i64,
+        addrlen as i64
+    );
+}

--- a/std/sys/linux/amd64/syscall.wave
+++ b/std/sys/linux/amd64/syscall.wave
@@ -1,0 +1,156 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// Linux x86_64 syscall interface for Wave
+// =======================================================
+// Calling convention:
+//   rax = syscall number
+//   rdi, rsi, rdx, r10, r8, r9 = arguments
+//   return value in rax
+//
+// Error handling:
+//   negative return value = -errno
+// =======================================================
+
+
+// -----------------------
+// syscall with 0 args
+// -----------------------
+pub fun syscall0(id: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "syscall"
+        in("rax") id
+        out("rax") ret
+    }
+    return ret;
+}
+
+
+// -----------------------
+// syscall with 1 arg
+// -----------------------
+pub fun syscall1(id: i64, a1: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "syscall"
+        in("rax") id
+        in("rdi") a1
+        out("rax") ret
+    }
+    return ret;
+}
+
+
+// -----------------------
+// syscall with 2 args
+// -----------------------
+pub fun syscall2(id: i64, a1: i64, a2: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "syscall"
+        in("rax") id
+        in("rdi") a1
+        in("rsi") a2
+        out("rax") ret
+    }
+    return ret;
+}
+
+
+// -----------------------
+// syscall with 3 args
+// -----------------------
+pub fun syscall3(id: i64, a1: i64, a2: i64, a3: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "syscall"
+        in("rax") id
+        in("rdi") a1
+        in("rsi") a2
+        in("rdx") a3
+        out("rax") ret
+    }
+    return ret;
+}
+
+
+// -----------------------
+// syscall with 4 args
+// -----------------------
+pub fun syscall4(id: i64, a1: i64, a2: i64, a3: i64, a4: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "syscall"
+        in("rax") id
+        in("rdi") a1
+        in("rsi") a2
+        in("rdx") a3
+        in("r10") a4
+        out("rax") ret
+    }
+    return ret;
+}
+
+
+// -----------------------
+// syscall with 5 args
+// -----------------------
+pub fun syscall5(id: i64, a1: i64, a2: i64, a3: i64, a4: i64, a5: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "syscall"
+        in("rax") id
+        in("rdi") a1
+        in("rsi") a2
+        in("rdx") a3
+        in("r10") a4
+        in("r8")  a5
+        out("rax") ret
+    }
+    return ret;
+}
+
+
+// -----------------------
+// syscall with 6 args
+// -----------------------
+pub fun syscall6(
+    id: i64,
+    a1: i64,
+    a2: i64,
+    a3: i64,
+    a4: i64,
+    a5: i64,
+    a6: i64
+) -> i64 {
+    var ret: i64;
+    asm {
+        "syscall"
+        in("rax") id
+        in("rdi") a1
+        in("rsi") a2
+        in("rdx") a3
+        in("r10") a4
+        in("r8")  a5
+        in("r9")  a6
+        out("rax") ret
+    }
+    return ret;
+}

--- a/std/sys/linux/amd64/time.wave
+++ b/std/sys/linux/amd64/time.wave
@@ -1,0 +1,66 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// Linux x86_64 time-related syscalls
+// =======================================================
+//
+// Raw time and sleep syscalls.
+// All functions return raw syscall values.
+// Negative values indicate -errno.
+// =======================================================
+
+import("std::sys::linux::amd64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+
+// -----------------------
+// timespec
+// -----------------------
+
+pub struct TimeSpec {
+    sec: i64;
+    nsec: i64;
+}
+
+
+// -----------------------
+// nanosleep
+// -----------------------
+
+pub fun nanosleep(req: ptr<TimeSpec>, rem: ptr<TimeSpec>) -> i64 {
+    // syscall: nanosleep (35)
+    return syscall2(35, req as i64, rem as i64);
+}
+
+
+// -----------------------
+// clock_gettime
+// -----------------------
+
+pub fun clock_gettime(clock_id: i32, tp: ptr<TimeSpec>) -> i64 {
+    // syscall: clock_gettime (228)
+    return syscall2(228, clock_id as i64, tp as i64);
+}

--- a/std/sys/linux/amd64/tty.wave
+++ b/std/sys/linux/amd64/tty.wave
@@ -1,0 +1,140 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// Linux x86_64 tty helpers
+// =======================================================
+//
+// Raw terminal helpers built on top of syscall.wave.
+// No libc dependency.
+// =======================================================
+
+import("std::sys::linux::amd64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub const TTY_SYS_IOCTL: i64 = 16;
+pub const TTY_SYS_FCNTL: i64 = 72;
+
+pub const TTY_TCGETS: i64 = 0x5401;
+pub const TTY_TCSETS: i64 = 0x5402;
+pub const TTY_TCSETSW: i64 = 0x5403;
+pub const TTY_TCSETSF: i64 = 0x5404;
+
+pub const TTY_TCSANOW: i32 = 0;
+pub const TTY_TCSADRAIN: i32 = 1;
+pub const TTY_TCSAFLUSH: i32 = 2;
+
+pub const TTY_F_GETFL: i32 = 3;
+pub const TTY_F_SETFL: i32 = 4;
+pub const TTY_O_NONBLOCK: i32 = 2048;
+
+pub const TTY_ICANON: u32 = 2;
+pub const TTY_ECHO: u32 = 8;
+pub const TTY_VTIME_IDX: i32 = 5;
+pub const TTY_VMIN_IDX: i32 = 6;
+
+pub struct Termios {
+    c_iflag: u32;
+    c_oflag: u32;
+    c_cflag: u32;
+    c_lflag: u32;
+    c_line: u8;
+    c_cc: array<u8, 19>;
+}
+
+pub struct TtyRawState {
+    term: Termios;
+    flags: i32;
+    active: i32;
+}
+
+pub fun tty_getattr(fd: i32, t: ptr<Termios>) -> i64 {
+    return syscall3(TTY_SYS_IOCTL, fd as i64, TTY_TCGETS, t as i64);
+}
+
+pub fun tty_setattr(fd: i32, action: i32, t: ptr<Termios>) -> i64 {
+    var req: i64 = TTY_TCSETS;
+
+    if (action == TTY_TCSADRAIN) {
+        req = TTY_TCSETSW;
+    } else if (action == TTY_TCSAFLUSH) {
+        req = TTY_TCSETSF;
+    }
+
+    return syscall3(TTY_SYS_IOCTL, fd as i64, req, t as i64);
+}
+
+pub fun tty_getfl(fd: i32) -> i64 {
+    return syscall3(TTY_SYS_FCNTL, fd as i64, TTY_F_GETFL as i64, 0);
+}
+
+pub fun tty_setfl(fd: i32, flags: i32) -> i64 {
+    return syscall3(TTY_SYS_FCNTL, fd as i64, TTY_F_SETFL as i64, flags as i64);
+}
+
+pub fun tty_enable_raw_nonblock(fd: i32, st: ptr<TtyRawState>) -> i64 {
+    deref st.active = 0;
+
+    var orig: Termios;
+    if (tty_getattr(fd, &orig) < 0) {
+        return -1;
+    }
+
+    var raw: Termios = orig;
+    raw.c_lflag = raw.c_lflag & ~(TTY_ICANON | TTY_ECHO);
+    raw.c_cc[6] = 0;
+    raw.c_cc[5] = 0;
+
+    if (tty_setattr(fd, TTY_TCSANOW, &raw) < 0) {
+        return -1;
+    }
+
+    var flags_raw: i64 = tty_getfl(fd);
+    if (flags_raw < 0) {
+        tty_setattr(fd, TTY_TCSANOW, &orig);
+        return -1;
+    }
+
+    var old_flags: i32 = flags_raw as i32;
+    if (tty_setfl(fd, old_flags | TTY_O_NONBLOCK) < 0) {
+        tty_setattr(fd, TTY_TCSANOW, &orig);
+        return -1;
+    }
+
+    deref st.term = orig;
+    deref st.flags = old_flags;
+    deref st.active = 1;
+    return 0;
+}
+
+pub fun tty_restore(fd: i32, st: ptr<TtyRawState>) {
+    if (deref st.active == 0) {
+        return;
+    }
+
+    var orig: Termios = deref st.term;
+    tty_setattr(fd, TTY_TCSANOW, &orig);
+    tty_setfl(fd, deref st.flags);
+}

--- a/std/sys/linux/arm64/env.wave
+++ b/std/sys/linux/arm64/env.wave
@@ -1,0 +1,71 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import("std::sys::linux::arm64::fs")::{
+    FS_O_RDONLY,
+    FS_O_WRONLY,
+    FS_O_RDWR,
+    FS_O_CREAT,
+    FS_O_EXCL,
+    FS_O_TRUNC,
+    FS_O_APPEND,
+    FS_O_NONBLOCK,
+    FS_F_OK,
+    FS_X_OK,
+    FS_W_OK,
+    FS_R_OK,
+    FS_SEEK_SET,
+    FS_SEEK_CUR,
+    FS_SEEK_END,
+    FS_F_GETFL,
+    FS_F_SETFL,
+    open,
+    close,
+    dup,
+    dup2,
+    pipe,
+    fsync,
+    fcntl,
+    read,
+    write,
+    getcwd,
+    chdir,
+    access,
+    lseek,
+    unlink,
+    mkdir,
+    rmdir,
+    Stat,
+    stat,
+    fstat,
+};
+
+pub fun env_read(buf: ptr<u8>, cap: i64) -> i64 {
+    if (cap <= 0) {
+        return -22;
+    }
+
+    var fd: i64 = open("/proc/self/environ", 0, 0);
+    if (fd < 0) {
+        return fd;
+    }
+
+    var n: i64 = read(fd, buf, cap);
+    close(fd);
+    return n;
+}

--- a/std/sys/linux/arm64/fs.wave
+++ b/std/sys/linux/arm64/fs.wave
@@ -1,0 +1,190 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Linux generic 64-bit filesystem ABI used by AArch64 and RV64.
+
+import("std::sys::linux::arm64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+// open flags
+pub const FS_O_RDONLY: i32 = 0;
+pub const FS_O_WRONLY: i32 = 1;
+pub const FS_O_RDWR: i32 = 2;
+pub const FS_O_CREAT: i32 = 64;
+pub const FS_O_EXCL: i32 = 128;
+pub const FS_O_TRUNC: i32 = 512;
+pub const FS_O_APPEND: i32 = 1024;
+pub const FS_O_NONBLOCK: i32 = 2048;
+
+// access modes
+pub const FS_F_OK: i32 = 0;
+pub const FS_X_OK: i32 = 1;
+pub const FS_W_OK: i32 = 2;
+pub const FS_R_OK: i32 = 4;
+
+// seek modes
+pub const FS_SEEK_SET: i32 = 0;
+pub const FS_SEEK_CUR: i32 = 1;
+pub const FS_SEEK_END: i32 = 2;
+
+// fcntl modes
+pub const FS_F_GETFL: i32 = 3;
+pub const FS_F_SETFL: i32 = 4;
+
+const FS_AT_FDCWD: i64 = -100;
+const FS_AT_REMOVEDIR: i32 = 512;
+
+// -----------------------
+// open / close
+// -----------------------
+
+pub fun open(path: str, flags: i32, mode: i32) -> i64 {
+    return syscall4(56, FS_AT_FDCWD, path as i64, flags as i64, mode as i64);
+}
+
+pub fun close(fd: i64) -> i64 {
+    return syscall1(57, fd);
+}
+
+pub fun dup(fd: i64) -> i64 {
+    return syscall1(23, fd);
+}
+
+pub fun dup2(oldfd: i64, newfd: i64) -> i64 {
+    if (oldfd == newfd) {
+        return newfd;
+    }
+    return syscall3(24, oldfd, newfd, 0);
+}
+
+pub fun pipe(fds: ptr<i32>) -> i64 {
+    return syscall2(59, fds as i64, 0);
+}
+
+pub fun fsync(fd: i64) -> i64 {
+    return syscall1(82, fd);
+}
+
+pub fun fcntl(fd: i64, cmd: i32, arg: i64) -> i64 {
+    return syscall3(25, fd, cmd as i64, arg);
+}
+
+
+// -----------------------
+// read / write
+// -----------------------
+
+pub fun read(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
+    return syscall3(63, fd, buf as i64, len);
+}
+
+pub fun write(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
+    return syscall3(64, fd, buf as i64, len);
+}
+
+pub fun getcwd(buf: ptr<u8>, size: i64) -> i64 {
+    return syscall2(17, buf as i64, size);
+}
+
+pub fun chdir(path: str) -> i64 {
+    return syscall1(49, path as i64);
+}
+
+pub fun access(path: str, mode: i32) -> i64 {
+    return syscall4(48, FS_AT_FDCWD, path as i64, mode as i64, 0);
+}
+
+
+// -----------------------
+// seek
+// -----------------------
+
+pub fun lseek(fd: i64, offset: i64, whence: i32) -> i64 {
+    return syscall3(62, fd, offset, whence as i64);
+}
+
+
+// -----------------------
+// file operations
+// -----------------------
+
+pub fun unlink(path: str) -> i64 {
+    return syscall3(35, FS_AT_FDCWD, path as i64, 0);
+}
+
+pub fun mkdir(path: str, mode: i32) -> i64 {
+    return syscall3(34, FS_AT_FDCWD, path as i64, mode as i64);
+}
+
+pub fun rmdir(path: str) -> i64 {
+    return syscall3(35, FS_AT_FDCWD, path as i64, FS_AT_REMOVEDIR as i64);
+}
+
+pub fun rename_path(old_path: str, new_path: str) -> i64 {
+    return syscall4(
+        38,
+        FS_AT_FDCWD,
+        old_path as i64,
+        FS_AT_FDCWD,
+        new_path as i64
+    );
+}
+
+
+// -----------------------
+// metadata
+// -----------------------
+
+// Linux asm-generic 64-bit struct stat.
+pub struct Stat {
+    dev: i64;
+    ino: i64;
+    mode: i32;
+    nlink: i32;
+    uid: i32;
+    gid: i32;
+    rdev: i64;
+    pad1: i64;
+    size: i64;
+    blksize: i32;
+    pad2: i32;
+    blocks: i64;
+    atime: i64;
+    atime_nsec: i64;
+    mtime: i64;
+    mtime_nsec: i64;
+    ctime: i64;
+    ctime_nsec: i64;
+    unused0: i32;
+    unused1: i32;
+}
+
+pub fun stat(path: str, st: ptr<Stat>) -> i64 {
+    return syscall4(79, FS_AT_FDCWD, path as i64, st as i64, 0);
+}
+
+pub fun fstat(fd: i64, st: ptr<Stat>) -> i64 {
+    return syscall2(80, fd, st as i64);
+}

--- a/std/sys/linux/arm64/memory.wave
+++ b/std/sys/linux/arm64/memory.wave
@@ -1,0 +1,100 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Linux generic 64-bit virtual-memory syscalls used by AArch64 and RV64.
+
+import("std::sys::linux::arm64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub const PROT_READ: i32 = 1;
+pub const PROT_WRITE: i32 = 2;
+pub const MAP_PRIVATE: i32 = 2;
+pub const MAP_ANONYMOUS: i32 = 32;
+
+
+// -----------------------
+// mmap / munmap
+// -----------------------
+// 3b1b9d23-75fc-4c50-87a4-11865458c2ba
+pub fun mmap(
+    addr: ptr<i8>,
+    length: i64,
+    prot: i32,
+    flags: i32,
+    fd: i64,
+    offset: i64
+) -> ptr<i8> {
+    return syscall6(
+        222,
+        addr as i64,
+        length,
+        prot as i64,
+        flags as i64,
+        fd,
+        offset
+    ) as ptr<i8>;
+}
+
+pub fun munmap(addr: ptr<i8>, length: i64) -> i64 {
+    return syscall2(215, addr as i64, length);
+}
+
+
+// -----------------------
+// brk
+// -----------------------
+
+pub fun brk(addr: ptr<i8>) -> ptr<i8> {
+    return syscall1(214, addr as i64) as ptr<i8>;
+}
+
+pub fun sys_alloc(size: i64) -> ptr<u8> {
+    if (size <= 0) {
+        return null;
+    }
+
+    var p: ptr<i8> = mmap(
+        null,
+        size,
+        PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANONYMOUS,
+        -1,
+        0
+    );
+
+    if ((p as i64) < 0) {
+        return null;
+    }
+
+    return p as ptr<u8>;
+}
+
+pub fun sys_free(p: ptr<u8>, size: i64) -> i64 {
+    if (p == null || size <= 0) {
+        return 0;
+    }
+
+    return munmap(p as ptr<i8>, size);
+}

--- a/std/sys/linux/arm64/process.wave
+++ b/std/sys/linux/arm64/process.wave
@@ -1,0 +1,83 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Linux generic 64-bit process syscalls used by AArch64 and RV64.
+
+import("std::sys::linux::arm64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+
+// -----------------------
+// process lifecycle
+// -----------------------
+
+pub fun exit(code: i32) -> ! {
+    syscall1(93, code as i64);
+    while (true) { }
+}
+
+pub fun getpid() -> i64 {
+    return syscall0(172);
+}
+
+pub fun getppid() -> i64 {
+    return syscall0(173);
+}
+
+
+// -----------------------
+// process creation
+// -----------------------
+
+pub fun fork() -> i64 {
+    // clone(SIGCHLD, null, null, null, null)
+    return syscall5(220, 17, 0, 0, 0, 0);
+}
+
+pub fun execve(
+    path: str,
+    argv: ptr<ptr<i8>>,
+    envp: ptr<ptr<i8>>
+) -> i64 {
+    return syscall3(221, path as i64, argv as i64, envp as i64);
+}
+
+
+// -----------------------
+// waiting
+// -----------------------
+
+pub fun waitpid(pid: i64, status: ptr<i32>, options: i32) -> i64 {
+    return syscall4(260, pid, status as i64, options as i64, 0);
+}
+
+
+// -----------------------
+// signals
+// -----------------------
+
+pub fun kill(pid: i64, sig: i32) -> i64 {
+    return syscall2(129, pid, sig as i64);
+}

--- a/std/sys/linux/arm64/socket.wave
+++ b/std/sys/linux/arm64/socket.wave
@@ -1,0 +1,200 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Linux generic 64-bit socket syscalls used by AArch64 and RV64.
+
+import("std::sys::linux::arm64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+
+// -----------------------
+// constants (minimal)
+// -----------------------
+
+// address families
+pub const AF_INET: i32 = 2;
+pub const AF_INET6: i32 = 10;
+
+// socket types
+pub const SOCK_STREAM: i32 = 1;
+pub const SOCK_DGRAM: i32 = 2;
+
+// protocol
+pub const IPPROTO_IP: i32 = 0;
+pub const IPPROTO_TCP: i32 = 6;
+pub const IPPROTO_UDP: i32 = 17;
+
+// shutdown how
+pub const SHUT_RD: i32 = 0;
+pub const SHUT_WR: i32 = 1;
+pub const SHUT_RDWR: i32 = 2;
+
+// socket options
+pub const SOL_SOCKET: i32 = 1;
+pub const SO_REUSEADDR: i32 = 2;
+pub const SO_REUSEPORT: i32 = 15;
+
+// poll events
+pub const POLLIN: i16 = 0x001;
+pub const POLLOUT: i16 = 0x004;
+pub const POLLERR: i16 = 0x008;
+pub const POLLHUP: i16 = 0x010;
+pub const POLLNVAL: i16 = 0x020;
+
+pub struct PollFd {
+    fd: i32;
+    events: i16;
+    revents: i16;
+}
+
+struct PollTimeSpec {
+    sec: i64;
+    nsec: i64;
+}
+
+
+// -----------------------
+// basic socket syscalls
+// -----------------------
+
+pub fun socket(domain: i32, ty: i32, protocol: i32) -> i64 {
+    return syscall3(198, domain as i64, ty as i64, protocol as i64);
+}
+
+pub fun bind(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
+    return syscall3(200, fd, addr as i64, len as i64);
+}
+
+pub fun listen(fd: i64, backlog: i32) -> i64 {
+    return syscall2(201, fd, backlog as i64);
+}
+
+pub fun accept(fd: i64, addr: ptr<i8>, len: ptr<i32>) -> i64 {
+    return syscall3(202, fd, addr as i64, len as i64);
+}
+
+pub fun connect(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
+    return syscall3(203, fd, addr as i64, len as i64);
+}
+
+pub fun shutdown(fd: i64, how: i32) -> i64 {
+    return syscall2(210, fd, how as i64);
+}
+
+pub fun setsockopt(
+    fd: i64,
+    level: i32,
+    optname: i32,
+    optval: ptr<i8>,
+    optlen: i32
+) -> i64 {
+    return syscall5(
+        208,
+        fd,
+        level as i64,
+        optname as i64,
+        optval as i64,
+        optlen as i64
+    );
+}
+
+pub fun getsockopt(
+    fd: i64,
+    level: i32,
+    optname: i32,
+    optval: ptr<i8>,
+    optlen: ptr<i32>
+) -> i64 {
+    return syscall5(
+        209,
+        fd,
+        level as i64,
+        optname as i64,
+        optval as i64,
+        optlen as i64
+    );
+}
+
+pub fun poll(fds: ptr<PollFd>, nfds: i64, timeout_ms: i32) -> i64 {
+    if (timeout_ms < 0) {
+        return syscall5(73, fds as i64, nfds, 0, 0, 0);
+    }
+
+    var timeout: PollTimeSpec;
+    timeout.sec = (timeout_ms / 1000) as i64;
+    timeout.nsec = ((timeout_ms % 1000) * 1000000) as i64;
+    return syscall5(73, fds as i64, nfds, &timeout as i64, 0, 0);
+}
+
+
+// -----------------------
+// send / recv
+// -----------------------
+
+pub fun send(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
+    return sendto(fd, buf, len, flags, null, 0);
+}
+
+pub fun recv(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
+    return recvfrom(fd, buf, len, flags, null, null);
+}
+
+pub fun sendto(
+    fd: i64,
+    buf: ptr<u8>,
+    len: i64,
+    flags: i32,
+    addr: ptr<i8>,
+    addrlen: i32
+) -> i64 {
+    return syscall6(
+        206,
+        fd,
+        buf as i64,
+        len,
+        flags as i64,
+        addr as i64,
+        addrlen as i64
+    );
+}
+
+pub fun recvfrom(
+    fd: i64,
+    buf: ptr<u8>,
+    len: i64,
+    flags: i32,
+    addr: ptr<i8>,
+    addrlen: ptr<i32>
+) -> i64 {
+    return syscall6(
+        207,
+        fd,
+        buf as i64,
+        len,
+        flags as i64,
+        addr as i64,
+        addrlen as i64
+    );
+}

--- a/std/sys/linux/arm64/syscall.wave
+++ b/std/sys/linux/arm64/syscall.wave
@@ -1,0 +1,119 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Linux AArch64 syscall ABI: x8 holds the number, x0-x5 hold arguments,
+// and x0 returns either a result or negative -errno.
+
+pub fun syscall0(id: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "svc #0"
+        in("x8") id
+        out("x0") ret
+    }
+    return ret;
+}
+
+pub fun syscall1(id: i64, a1: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "svc #0"
+        in("x8") id
+        in("x0") a1
+        out("x0") ret
+    }
+    return ret;
+}
+
+pub fun syscall2(id: i64, a1: i64, a2: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "svc #0"
+        in("x8") id
+        in("x0") a1
+        in("x1") a2
+        out("x0") ret
+    }
+    return ret;
+}
+
+pub fun syscall3(id: i64, a1: i64, a2: i64, a3: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "svc #0"
+        in("x8") id
+        in("x0") a1
+        in("x1") a2
+        in("x2") a3
+        out("x0") ret
+    }
+    return ret;
+}
+
+pub fun syscall4(id: i64, a1: i64, a2: i64, a3: i64, a4: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "svc #0"
+        in("x8") id
+        in("x0") a1
+        in("x1") a2
+        in("x2") a3
+        in("x3") a4
+        out("x0") ret
+    }
+    return ret;
+}
+
+pub fun syscall5(id: i64, a1: i64, a2: i64, a3: i64, a4: i64, a5: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "svc #0"
+        in("x8") id
+        in("x0") a1
+        in("x1") a2
+        in("x2") a3
+        in("x3") a4
+        in("x4") a5
+        out("x0") ret
+    }
+    return ret;
+}
+
+pub fun syscall6(
+    id: i64,
+    a1: i64,
+    a2: i64,
+    a3: i64,
+    a4: i64,
+    a5: i64,
+    a6: i64
+) -> i64 {
+    var ret: i64;
+    asm {
+        "svc #0"
+        in("x8") id
+        in("x0") a1
+        in("x1") a2
+        in("x2") a3
+        in("x3") a4
+        in("x4") a5
+        in("x5") a6
+        out("x0") ret
+    }
+    return ret;
+}

--- a/std/sys/linux/arm64/time.wave
+++ b/std/sys/linux/arm64/time.wave
@@ -1,0 +1,57 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Linux generic 64-bit clock syscalls used by AArch64 and RV64.
+
+import("std::sys::linux::arm64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+
+// -----------------------
+// timespec
+// -----------------------
+
+pub struct TimeSpec {
+    sec: i64;
+    nsec: i64;
+}
+
+
+// -----------------------
+// nanosleep
+// -----------------------
+
+pub fun nanosleep(req: ptr<TimeSpec>, rem: ptr<TimeSpec>) -> i64 {
+    return syscall2(101, req as i64, rem as i64);
+}
+
+
+// -----------------------
+// clock_gettime
+// -----------------------
+
+pub fun clock_gettime(clock_id: i32, tp: ptr<TimeSpec>) -> i64 {
+    return syscall2(113, clock_id as i64, tp as i64);
+}

--- a/std/sys/linux/arm64/tty.wave
+++ b/std/sys/linux/arm64/tty.wave
@@ -1,0 +1,134 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Linux generic 64-bit terminal operations used by AArch64 and RV64.
+
+import("std::sys::linux::arm64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub const TTY_SYS_IOCTL: i64 = 29;
+pub const TTY_SYS_FCNTL: i64 = 25;
+
+pub const TTY_TCGETS: i64 = 0x5401;
+pub const TTY_TCSETS: i64 = 0x5402;
+pub const TTY_TCSETSW: i64 = 0x5403;
+pub const TTY_TCSETSF: i64 = 0x5404;
+
+pub const TTY_TCSANOW: i32 = 0;
+pub const TTY_TCSADRAIN: i32 = 1;
+pub const TTY_TCSAFLUSH: i32 = 2;
+
+pub const TTY_F_GETFL: i32 = 3;
+pub const TTY_F_SETFL: i32 = 4;
+pub const TTY_O_NONBLOCK: i32 = 2048;
+
+pub const TTY_ICANON: u32 = 2;
+pub const TTY_ECHO: u32 = 8;
+pub const TTY_VTIME_IDX: i32 = 5;
+pub const TTY_VMIN_IDX: i32 = 6;
+
+pub struct Termios {
+    c_iflag: u32;
+    c_oflag: u32;
+    c_cflag: u32;
+    c_lflag: u32;
+    c_line: u8;
+    c_cc: array<u8, 19>;
+}
+
+pub struct TtyRawState {
+    term: Termios;
+    flags: i32;
+    active: i32;
+}
+
+pub fun tty_getattr(fd: i32, t: ptr<Termios>) -> i64 {
+    return syscall3(TTY_SYS_IOCTL, fd as i64, TTY_TCGETS, t as i64);
+}
+
+pub fun tty_setattr(fd: i32, action: i32, t: ptr<Termios>) -> i64 {
+    var req: i64 = TTY_TCSETS;
+
+    if (action == TTY_TCSADRAIN) {
+        req = TTY_TCSETSW;
+    } else if (action == TTY_TCSAFLUSH) {
+        req = TTY_TCSETSF;
+    }
+
+    return syscall3(TTY_SYS_IOCTL, fd as i64, req, t as i64);
+}
+
+pub fun tty_getfl(fd: i32) -> i64 {
+    return syscall3(TTY_SYS_FCNTL, fd as i64, TTY_F_GETFL as i64, 0);
+}
+
+pub fun tty_setfl(fd: i32, flags: i32) -> i64 {
+    return syscall3(TTY_SYS_FCNTL, fd as i64, TTY_F_SETFL as i64, flags as i64);
+}
+
+pub fun tty_enable_raw_nonblock(fd: i32, st: ptr<TtyRawState>) -> i64 {
+    deref st.active = 0;
+
+    var orig: Termios;
+    if (tty_getattr(fd, &orig) < 0) {
+        return -1;
+    }
+
+    var raw: Termios = orig;
+    raw.c_lflag = raw.c_lflag & ~(TTY_ICANON | TTY_ECHO);
+    raw.c_cc[6] = 0;
+    raw.c_cc[5] = 0;
+
+    if (tty_setattr(fd, TTY_TCSANOW, &raw) < 0) {
+        return -1;
+    }
+
+    var flags_raw: i64 = tty_getfl(fd);
+    if (flags_raw < 0) {
+        tty_setattr(fd, TTY_TCSANOW, &orig);
+        return -1;
+    }
+
+    var old_flags: i32 = flags_raw as i32;
+    if (tty_setfl(fd, old_flags | TTY_O_NONBLOCK) < 0) {
+        tty_setattr(fd, TTY_TCSANOW, &orig);
+        return -1;
+    }
+
+    deref st.term = orig;
+    deref st.flags = old_flags;
+    deref st.active = 1;
+    return 0;
+}
+
+pub fun tty_restore(fd: i32, st: ptr<TtyRawState>) {
+    if (deref st.active == 0) {
+        return;
+    }
+
+    var orig: Termios = deref st.term;
+    tty_setattr(fd, TTY_TCSANOW, &orig);
+    tty_setfl(fd, deref st.flags);
+}

--- a/std/sys/linux/env.wave
+++ b/std/sys/linux/env.wave
@@ -1,71 +1,14 @@
 // This file is part of the Wave language project.
-// Copyright (c) 2024-2026 Wave Foundation
-// Copyright (c) 2024-2026 LunaStev and contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// Copyright (c) 2024-2026 Wave Foundation and contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import("std::sys::linux::fs")::{
-    FS_O_RDONLY,
-    FS_O_WRONLY,
-    FS_O_RDWR,
-    FS_O_CREAT,
-    FS_O_EXCL,
-    FS_O_TRUNC,
-    FS_O_APPEND,
-    FS_O_NONBLOCK,
-    FS_F_OK,
-    FS_X_OK,
-    FS_W_OK,
-    FS_R_OK,
-    FS_SEEK_SET,
-    FS_SEEK_CUR,
-    FS_SEEK_END,
-    FS_F_GETFL,
-    FS_F_SETFL,
-    open,
-    close,
-    dup,
-    dup2,
-    pipe,
-    fsync,
-    fcntl,
-    read,
-    write,
-    getcwd,
-    chdir,
-    access,
-    lseek,
-    unlink,
-    mkdir,
-    rmdir,
-    Stat,
-    stat,
-    fstat,
-};
+// Linux environment provider selected by target architecture.
 
-pub fun env_read(buf: ptr<u8>, cap: i64) -> i64 {
-    if (cap <= 0) {
-        return -22;
-    }
+#[target(arch="x86_64")]
+pub import("std::sys::linux::amd64::env")::{env_read};
 
-    var fd: i64 = open("/proc/self/environ", 0, 0);
-    if (fd < 0) {
-        return fd;
-    }
+#[target(arch="aarch64")]
+pub import("std::sys::linux::arm64::env")::{env_read};
 
-    var n: i64 = read(fd, buf, cap);
-    close(fd);
-    return n;
-}
+#[target(arch="riscv64")]
+pub import("std::sys::linux::riscv64::env")::{env_read};

--- a/std/sys/linux/fs.wave
+++ b/std/sys/linux/fs.wave
@@ -1,194 +1,35 @@
 // This file is part of the Wave language project.
-// Copyright (c) 2024-2026 Wave Foundation
-// Copyright (c) 2024-2026 LunaStev and contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// Copyright (c) 2024-2026 Wave Foundation and contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// Linux x86_64 filesystem syscalls
-// =======================================================
-//
-// This layer provides minimal filesystem operations
-// built directly on top of syscall.wave.
-//
-// All functions return raw syscall results.
-// Negative values indicate -errno.
-// =======================================================
+// Linux filesystem provider selected by target architecture.
 
-import("std::sys::linux::syscall")::{
-    syscall0,
-    syscall1,
-    syscall2,
-    syscall3,
-    syscall4,
-    syscall5,
-    syscall6,
+#[target(arch="x86_64")]
+pub import("std::sys::linux::amd64::fs")::{
+    FS_O_RDONLY, FS_O_WRONLY, FS_O_RDWR, FS_O_CREAT, FS_O_EXCL,
+    FS_O_TRUNC, FS_O_APPEND, FS_O_NONBLOCK,
+    FS_F_OK, FS_X_OK, FS_W_OK, FS_R_OK,
+    FS_SEEK_SET, FS_SEEK_CUR, FS_SEEK_END, FS_F_GETFL, FS_F_SETFL,
+    open, close, dup, dup2, pipe, fsync, fcntl, read, write, getcwd,
+    chdir, access, lseek, unlink, mkdir, rmdir, rename_path, Stat, stat, fstat,
 };
 
-// open flags
-pub const FS_O_RDONLY: i32 = 0;
-pub const FS_O_WRONLY: i32 = 1;
-pub const FS_O_RDWR: i32 = 2;
-pub const FS_O_CREAT: i32 = 64;
-pub const FS_O_EXCL: i32 = 128;
-pub const FS_O_TRUNC: i32 = 512;
-pub const FS_O_APPEND: i32 = 1024;
-pub const FS_O_NONBLOCK: i32 = 2048;
+#[target(arch="aarch64")]
+pub import("std::sys::linux::arm64::fs")::{
+    FS_O_RDONLY, FS_O_WRONLY, FS_O_RDWR, FS_O_CREAT, FS_O_EXCL,
+    FS_O_TRUNC, FS_O_APPEND, FS_O_NONBLOCK,
+    FS_F_OK, FS_X_OK, FS_W_OK, FS_R_OK,
+    FS_SEEK_SET, FS_SEEK_CUR, FS_SEEK_END, FS_F_GETFL, FS_F_SETFL,
+    open, close, dup, dup2, pipe, fsync, fcntl, read, write, getcwd,
+    chdir, access, lseek, unlink, mkdir, rmdir, rename_path, Stat, stat, fstat,
+};
 
-// access modes
-pub const FS_F_OK: i32 = 0;
-pub const FS_X_OK: i32 = 1;
-pub const FS_W_OK: i32 = 2;
-pub const FS_R_OK: i32 = 4;
-
-// seek modes
-pub const FS_SEEK_SET: i32 = 0;
-pub const FS_SEEK_CUR: i32 = 1;
-pub const FS_SEEK_END: i32 = 2;
-
-// fcntl modes
-pub const FS_F_GETFL: i32 = 3;
-pub const FS_F_SETFL: i32 = 4;
-
-// -----------------------
-// open / close
-// -----------------------
-
-pub fun open(path: str, flags: i32, mode: i32) -> i64 {
-    // syscall: open (2)
-    return syscall3(2, path as i64, flags as i64, mode as i64);
-}
-
-pub fun close(fd: i64) -> i64 {
-    // syscall: close (3)
-    return syscall1(3, fd);
-}
-
-pub fun dup(fd: i64) -> i64 {
-    // syscall: dup (32)
-    return syscall1(32, fd);
-}
-
-pub fun dup2(oldfd: i64, newfd: i64) -> i64 {
-    // syscall: dup2 (33)
-    return syscall2(33, oldfd, newfd);
-}
-
-pub fun pipe(fds: ptr<i32>) -> i64 {
-    // syscall: pipe (22)
-    return syscall1(22, fds as i64);
-}
-
-pub fun fsync(fd: i64) -> i64 {
-    // syscall: fsync (74)
-    return syscall1(74, fd);
-}
-
-pub fun fcntl(fd: i64, cmd: i32, arg: i64) -> i64 {
-    // syscall: fcntl (72)
-    return syscall3(72, fd, cmd as i64, arg);
-}
-
-
-// -----------------------
-// read / write
-// -----------------------
-
-pub fun read(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
-    // syscall: read (0)
-    return syscall3(0, fd, buf as i64, len);
-}
-
-pub fun write(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
-    // syscall: write (1)
-    return syscall3(1, fd, buf as i64, len);
-}
-
-pub fun getcwd(buf: ptr<u8>, size: i64) -> i64 {
-    // syscall: getcwd (79)
-    return syscall2(79, buf as i64, size);
-}
-
-pub fun chdir(path: str) -> i64 {
-    // syscall: chdir (80)
-    return syscall1(80, path as i64);
-}
-
-pub fun access(path: str, mode: i32) -> i64 {
-    // syscall: access (21)
-    return syscall2(21, path as i64, mode as i64);
-}
-
-
-// -----------------------
-// seek
-// -----------------------
-
-pub fun lseek(fd: i64, offset: i64, whence: i32) -> i64 {
-    // syscall: lseek (8)
-    return syscall3(8, fd, offset, whence as i64);
-}
-
-
-// -----------------------
-// file operations
-// -----------------------
-
-pub fun unlink(path: str) -> i64 {
-    // syscall: unlink (87)
-    return syscall1(87, path as i64);
-}
-
-pub fun mkdir(path: str, mode: i32) -> i64 {
-    // syscall: mkdir (83)
-    return syscall2(83, path as i64, mode as i64);
-}
-
-pub fun rmdir(path: str) -> i64 {
-    // syscall: rmdir (84)
-    return syscall1(84, path as i64);
-}
-
-
-// -----------------------
-// metadata
-// -----------------------
-
-pub struct Stat {
-    dev: i64;
-    ino: i64;
-    nlink: i64;
-    mode: i32;
-    uid: i32;
-    gid: i32;
-    pad0: i32;
-    rdev: i64;
-    size: i64;
-    blksize: i64;
-    blocks: i64;
-    atime: i64;
-    mtime: i64;
-    ctime: i64;
-}
-
-pub fun stat(path: str, st: ptr<Stat>) -> i64 {
-    // syscall: stat (4)
-    return syscall2(4, path as i64, st as i64);
-}
-
-pub fun fstat(fd: i64, st: ptr<Stat>) -> i64 {
-    // syscall: fstat (5)
-    return syscall2(5, fd, st as i64);
-}
+#[target(arch="riscv64")]
+pub import("std::sys::linux::riscv64::fs")::{
+    FS_O_RDONLY, FS_O_WRONLY, FS_O_RDWR, FS_O_CREAT, FS_O_EXCL,
+    FS_O_TRUNC, FS_O_APPEND, FS_O_NONBLOCK,
+    FS_F_OK, FS_X_OK, FS_W_OK, FS_R_OK,
+    FS_SEEK_SET, FS_SEEK_CUR, FS_SEEK_END, FS_F_GETFL, FS_F_SETFL,
+    open, close, dup, dup2, pipe, fsync, fcntl, read, write, getcwd,
+    chdir, access, lseek, unlink, mkdir, rmdir, rename_path, Stat, stat, fstat,
+};

--- a/std/sys/linux/memory.wave
+++ b/std/sys/linux/memory.wave
@@ -1,110 +1,23 @@
 // This file is part of the Wave language project.
-// Copyright (c) 2024-2026 Wave Foundation
-// Copyright (c) 2024-2026 LunaStev and contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// Copyright (c) 2024-2026 Wave Foundation and contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// Linux x86_64 memory syscalls
-// =======================================================
-//
-// Low-level virtual memory management.
-// All functions return raw syscall values.
-// Negative values indicate -errno.
-// =======================================================
+// Linux virtual-memory provider selected by target architecture.
 
-import("std::sys::linux::syscall")::{
-    syscall0,
-    syscall1,
-    syscall2,
-    syscall3,
-    syscall4,
-    syscall5,
-    syscall6,
+#[target(arch="x86_64")]
+pub import("std::sys::linux::amd64::memory")::{
+    PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS,
+    mmap, munmap, brk, sys_alloc, sys_free,
 };
 
-pub const PROT_READ: i32 = 1;
-pub const PROT_WRITE: i32 = 2;
-pub const MAP_PRIVATE: i32 = 2;
-pub const MAP_ANONYMOUS: i32 = 32;
+#[target(arch="aarch64")]
+pub import("std::sys::linux::arm64::memory")::{
+    PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS,
+    mmap, munmap, brk, sys_alloc, sys_free,
+};
 
-
-// -----------------------
-// mmap / munmap
-// -----------------------
-// 3b1b9d23-75fc-4c50-87a4-11865458c2ba
-pub fun mmap(
-    addr: ptr<i8>,
-    length: i64,
-    prot: i32,
-    flags: i32,
-    fd: i64,
-    offset: i64
-) -> ptr<i8> {
-    // syscall: mmap (9)
-    return syscall6(
-        9,
-        addr as i64,
-        length,
-        prot as i64,
-        flags as i64,
-        fd,
-        offset
-    ) as ptr<i8>;
-}
-
-pub fun munmap(addr: ptr<i8>, length: i64) -> i64 {
-    // syscall: munmap (11)
-    return syscall2(11, addr as i64, length);
-}
-
-
-// -----------------------
-// brk
-// -----------------------
-
-pub fun brk(addr: ptr<i8>) -> ptr<i8> {
-    // syscall: brk (12)
-    return syscall1(12, addr as i64) as ptr<i8>;
-}
-
-pub fun sys_alloc(size: i64) -> ptr<u8> {
-    if (size <= 0) {
-        return null;
-    }
-
-    var p: ptr<i8> = mmap(
-        null,
-        size,
-        PROT_READ | PROT_WRITE,
-        MAP_PRIVATE | MAP_ANONYMOUS,
-        -1,
-        0
-    );
-
-    if ((p as i64) < 0) {
-        return null;
-    }
-
-    return p as ptr<u8>;
-}
-
-pub fun sys_free(p: ptr<u8>, size: i64) -> i64 {
-    if (p == null || size <= 0) {
-        return 0;
-    }
-
-    return munmap(p as ptr<i8>, size);
-}
+#[target(arch="riscv64")]
+pub import("std::sys::linux::riscv64::memory")::{
+    PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS,
+    mmap, munmap, brk, sys_alloc, sys_free,
+};

--- a/std/sys/linux/process.wave
+++ b/std/sys/linux/process.wave
@@ -1,97 +1,20 @@
 // This file is part of the Wave language project.
-// Copyright (c) 2024-2026 Wave Foundation
-// Copyright (c) 2024-2026 LunaStev and contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// Copyright (c) 2024-2026 Wave Foundation and contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// Linux x86_64 process syscalls
-// =======================================================
-//
-// Minimal process-related system calls.
-// All return raw syscall values.
-// Negative values indicate -errno.
-// =======================================================
+// Linux process provider selected by target architecture.
 
-import("std::sys::linux::syscall")::{
-    syscall0,
-    syscall1,
-    syscall2,
-    syscall3,
-    syscall4,
-    syscall5,
-    syscall6,
+#[target(arch="x86_64")]
+pub import("std::sys::linux::amd64::process")::{
+    exit, getpid, getppid, fork, execve, waitpid, kill,
 };
 
+#[target(arch="aarch64")]
+pub import("std::sys::linux::arm64::process")::{
+    exit, getpid, getppid, fork, execve, waitpid, kill,
+};
 
-// -----------------------
-// process lifecycle
-// -----------------------
-
-pub fun exit(code: i32) -> ! {
-    // syscall: exit (60)
-    syscall1(60, code as i64);
-    while (true) { }
-}
-
-pub fun getpid() -> i64 {
-    // syscall: getpid (39)
-    return syscall0(39);
-}
-
-pub fun getppid() -> i64 {
-    // syscall: getppid (110)
-    return syscall0(110);
-}
-
-
-// -----------------------
-// process creation
-// -----------------------
-
-pub fun fork() -> i64 {
-    // syscall: fork (57)
-    return syscall0(57);
-}
-
-pub fun execve(
-    path: str,
-    argv: ptr<ptr<i8>>,
-    envp: ptr<ptr<i8>>
-) -> i64 {
-    // syscall: execve (59)
-    return syscall3(59, path as i64, argv as i64, envp as i64);
-}
-
-
-// -----------------------
-// waiting
-// -----------------------
-
-pub fun waitpid(pid: i64, status: ptr<i32>, options: i32) -> i64 {
-    // syscall: wait4 (61)
-    // waitpid is implemented via wait4
-    return syscall4(61, pid, status as i64, options as i64, 0);
-}
-
-
-// -----------------------
-// signals
-// -----------------------
-
-pub fun kill(pid: i64, sig: i32) -> i64 {
-    // syscall: kill (62)
-    return syscall2(62, pid, sig as i64);
-}
+#[target(arch="riscv64")]
+pub import("std::sys::linux::riscv64::process")::{
+    exit, getpid, getppid, fork, execve, waitpid, kill,
+};

--- a/std/sys/linux/riscv64/env.wave
+++ b/std/sys/linux/riscv64/env.wave
@@ -1,0 +1,71 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import("std::sys::linux::riscv64::fs")::{
+    FS_O_RDONLY,
+    FS_O_WRONLY,
+    FS_O_RDWR,
+    FS_O_CREAT,
+    FS_O_EXCL,
+    FS_O_TRUNC,
+    FS_O_APPEND,
+    FS_O_NONBLOCK,
+    FS_F_OK,
+    FS_X_OK,
+    FS_W_OK,
+    FS_R_OK,
+    FS_SEEK_SET,
+    FS_SEEK_CUR,
+    FS_SEEK_END,
+    FS_F_GETFL,
+    FS_F_SETFL,
+    open,
+    close,
+    dup,
+    dup2,
+    pipe,
+    fsync,
+    fcntl,
+    read,
+    write,
+    getcwd,
+    chdir,
+    access,
+    lseek,
+    unlink,
+    mkdir,
+    rmdir,
+    Stat,
+    stat,
+    fstat,
+};
+
+pub fun env_read(buf: ptr<u8>, cap: i64) -> i64 {
+    if (cap <= 0) {
+        return -22;
+    }
+
+    var fd: i64 = open("/proc/self/environ", 0, 0);
+    if (fd < 0) {
+        return fd;
+    }
+
+    var n: i64 = read(fd, buf, cap);
+    close(fd);
+    return n;
+}

--- a/std/sys/linux/riscv64/fs.wave
+++ b/std/sys/linux/riscv64/fs.wave
@@ -1,0 +1,190 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Linux generic 64-bit filesystem ABI used by AArch64 and RV64.
+
+import("std::sys::linux::riscv64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+// open flags
+pub const FS_O_RDONLY: i32 = 0;
+pub const FS_O_WRONLY: i32 = 1;
+pub const FS_O_RDWR: i32 = 2;
+pub const FS_O_CREAT: i32 = 64;
+pub const FS_O_EXCL: i32 = 128;
+pub const FS_O_TRUNC: i32 = 512;
+pub const FS_O_APPEND: i32 = 1024;
+pub const FS_O_NONBLOCK: i32 = 2048;
+
+// access modes
+pub const FS_F_OK: i32 = 0;
+pub const FS_X_OK: i32 = 1;
+pub const FS_W_OK: i32 = 2;
+pub const FS_R_OK: i32 = 4;
+
+// seek modes
+pub const FS_SEEK_SET: i32 = 0;
+pub const FS_SEEK_CUR: i32 = 1;
+pub const FS_SEEK_END: i32 = 2;
+
+// fcntl modes
+pub const FS_F_GETFL: i32 = 3;
+pub const FS_F_SETFL: i32 = 4;
+
+const FS_AT_FDCWD: i64 = -100;
+const FS_AT_REMOVEDIR: i32 = 512;
+
+// -----------------------
+// open / close
+// -----------------------
+
+pub fun open(path: str, flags: i32, mode: i32) -> i64 {
+    return syscall4(56, FS_AT_FDCWD, path as i64, flags as i64, mode as i64);
+}
+
+pub fun close(fd: i64) -> i64 {
+    return syscall1(57, fd);
+}
+
+pub fun dup(fd: i64) -> i64 {
+    return syscall1(23, fd);
+}
+
+pub fun dup2(oldfd: i64, newfd: i64) -> i64 {
+    if (oldfd == newfd) {
+        return newfd;
+    }
+    return syscall3(24, oldfd, newfd, 0);
+}
+
+pub fun pipe(fds: ptr<i32>) -> i64 {
+    return syscall2(59, fds as i64, 0);
+}
+
+pub fun fsync(fd: i64) -> i64 {
+    return syscall1(82, fd);
+}
+
+pub fun fcntl(fd: i64, cmd: i32, arg: i64) -> i64 {
+    return syscall3(25, fd, cmd as i64, arg);
+}
+
+
+// -----------------------
+// read / write
+// -----------------------
+
+pub fun read(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
+    return syscall3(63, fd, buf as i64, len);
+}
+
+pub fun write(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
+    return syscall3(64, fd, buf as i64, len);
+}
+
+pub fun getcwd(buf: ptr<u8>, size: i64) -> i64 {
+    return syscall2(17, buf as i64, size);
+}
+
+pub fun chdir(path: str) -> i64 {
+    return syscall1(49, path as i64);
+}
+
+pub fun access(path: str, mode: i32) -> i64 {
+    return syscall4(48, FS_AT_FDCWD, path as i64, mode as i64, 0);
+}
+
+
+// -----------------------
+// seek
+// -----------------------
+
+pub fun lseek(fd: i64, offset: i64, whence: i32) -> i64 {
+    return syscall3(62, fd, offset, whence as i64);
+}
+
+
+// -----------------------
+// file operations
+// -----------------------
+
+pub fun unlink(path: str) -> i64 {
+    return syscall3(35, FS_AT_FDCWD, path as i64, 0);
+}
+
+pub fun mkdir(path: str, mode: i32) -> i64 {
+    return syscall3(34, FS_AT_FDCWD, path as i64, mode as i64);
+}
+
+pub fun rmdir(path: str) -> i64 {
+    return syscall3(35, FS_AT_FDCWD, path as i64, FS_AT_REMOVEDIR as i64);
+}
+
+pub fun rename_path(old_path: str, new_path: str) -> i64 {
+    return syscall4(
+        38,
+        FS_AT_FDCWD,
+        old_path as i64,
+        FS_AT_FDCWD,
+        new_path as i64
+    );
+}
+
+
+// -----------------------
+// metadata
+// -----------------------
+
+// Linux asm-generic 64-bit struct stat.
+pub struct Stat {
+    dev: i64;
+    ino: i64;
+    mode: i32;
+    nlink: i32;
+    uid: i32;
+    gid: i32;
+    rdev: i64;
+    pad1: i64;
+    size: i64;
+    blksize: i32;
+    pad2: i32;
+    blocks: i64;
+    atime: i64;
+    atime_nsec: i64;
+    mtime: i64;
+    mtime_nsec: i64;
+    ctime: i64;
+    ctime_nsec: i64;
+    unused0: i32;
+    unused1: i32;
+}
+
+pub fun stat(path: str, st: ptr<Stat>) -> i64 {
+    return syscall4(79, FS_AT_FDCWD, path as i64, st as i64, 0);
+}
+
+pub fun fstat(fd: i64, st: ptr<Stat>) -> i64 {
+    return syscall2(80, fd, st as i64);
+}

--- a/std/sys/linux/riscv64/memory.wave
+++ b/std/sys/linux/riscv64/memory.wave
@@ -1,0 +1,100 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Linux generic 64-bit virtual-memory syscalls used by AArch64 and RV64.
+
+import("std::sys::linux::riscv64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub const PROT_READ: i32 = 1;
+pub const PROT_WRITE: i32 = 2;
+pub const MAP_PRIVATE: i32 = 2;
+pub const MAP_ANONYMOUS: i32 = 32;
+
+
+// -----------------------
+// mmap / munmap
+// -----------------------
+// 3b1b9d23-75fc-4c50-87a4-11865458c2ba
+pub fun mmap(
+    addr: ptr<i8>,
+    length: i64,
+    prot: i32,
+    flags: i32,
+    fd: i64,
+    offset: i64
+) -> ptr<i8> {
+    return syscall6(
+        222,
+        addr as i64,
+        length,
+        prot as i64,
+        flags as i64,
+        fd,
+        offset
+    ) as ptr<i8>;
+}
+
+pub fun munmap(addr: ptr<i8>, length: i64) -> i64 {
+    return syscall2(215, addr as i64, length);
+}
+
+
+// -----------------------
+// brk
+// -----------------------
+
+pub fun brk(addr: ptr<i8>) -> ptr<i8> {
+    return syscall1(214, addr as i64) as ptr<i8>;
+}
+
+pub fun sys_alloc(size: i64) -> ptr<u8> {
+    if (size <= 0) {
+        return null;
+    }
+
+    var p: ptr<i8> = mmap(
+        null,
+        size,
+        PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANONYMOUS,
+        -1,
+        0
+    );
+
+    if ((p as i64) < 0) {
+        return null;
+    }
+
+    return p as ptr<u8>;
+}
+
+pub fun sys_free(p: ptr<u8>, size: i64) -> i64 {
+    if (p == null || size <= 0) {
+        return 0;
+    }
+
+    return munmap(p as ptr<i8>, size);
+}

--- a/std/sys/linux/riscv64/process.wave
+++ b/std/sys/linux/riscv64/process.wave
@@ -1,0 +1,83 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Linux generic 64-bit process syscalls used by AArch64 and RV64.
+
+import("std::sys::linux::riscv64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+
+// -----------------------
+// process lifecycle
+// -----------------------
+
+pub fun exit(code: i32) -> ! {
+    syscall1(93, code as i64);
+    while (true) { }
+}
+
+pub fun getpid() -> i64 {
+    return syscall0(172);
+}
+
+pub fun getppid() -> i64 {
+    return syscall0(173);
+}
+
+
+// -----------------------
+// process creation
+// -----------------------
+
+pub fun fork() -> i64 {
+    // clone(SIGCHLD, null, null, null, null)
+    return syscall5(220, 17, 0, 0, 0, 0);
+}
+
+pub fun execve(
+    path: str,
+    argv: ptr<ptr<i8>>,
+    envp: ptr<ptr<i8>>
+) -> i64 {
+    return syscall3(221, path as i64, argv as i64, envp as i64);
+}
+
+
+// -----------------------
+// waiting
+// -----------------------
+
+pub fun waitpid(pid: i64, status: ptr<i32>, options: i32) -> i64 {
+    return syscall4(260, pid, status as i64, options as i64, 0);
+}
+
+
+// -----------------------
+// signals
+// -----------------------
+
+pub fun kill(pid: i64, sig: i32) -> i64 {
+    return syscall2(129, pid, sig as i64);
+}

--- a/std/sys/linux/riscv64/socket.wave
+++ b/std/sys/linux/riscv64/socket.wave
@@ -1,0 +1,200 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Linux generic 64-bit socket syscalls used by AArch64 and RV64.
+
+import("std::sys::linux::riscv64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+
+// -----------------------
+// constants (minimal)
+// -----------------------
+
+// address families
+pub const AF_INET: i32 = 2;
+pub const AF_INET6: i32 = 10;
+
+// socket types
+pub const SOCK_STREAM: i32 = 1;
+pub const SOCK_DGRAM: i32 = 2;
+
+// protocol
+pub const IPPROTO_IP: i32 = 0;
+pub const IPPROTO_TCP: i32 = 6;
+pub const IPPROTO_UDP: i32 = 17;
+
+// shutdown how
+pub const SHUT_RD: i32 = 0;
+pub const SHUT_WR: i32 = 1;
+pub const SHUT_RDWR: i32 = 2;
+
+// socket options
+pub const SOL_SOCKET: i32 = 1;
+pub const SO_REUSEADDR: i32 = 2;
+pub const SO_REUSEPORT: i32 = 15;
+
+// poll events
+pub const POLLIN: i16 = 0x001;
+pub const POLLOUT: i16 = 0x004;
+pub const POLLERR: i16 = 0x008;
+pub const POLLHUP: i16 = 0x010;
+pub const POLLNVAL: i16 = 0x020;
+
+pub struct PollFd {
+    fd: i32;
+    events: i16;
+    revents: i16;
+}
+
+struct PollTimeSpec {
+    sec: i64;
+    nsec: i64;
+}
+
+
+// -----------------------
+// basic socket syscalls
+// -----------------------
+
+pub fun socket(domain: i32, ty: i32, protocol: i32) -> i64 {
+    return syscall3(198, domain as i64, ty as i64, protocol as i64);
+}
+
+pub fun bind(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
+    return syscall3(200, fd, addr as i64, len as i64);
+}
+
+pub fun listen(fd: i64, backlog: i32) -> i64 {
+    return syscall2(201, fd, backlog as i64);
+}
+
+pub fun accept(fd: i64, addr: ptr<i8>, len: ptr<i32>) -> i64 {
+    return syscall3(202, fd, addr as i64, len as i64);
+}
+
+pub fun connect(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
+    return syscall3(203, fd, addr as i64, len as i64);
+}
+
+pub fun shutdown(fd: i64, how: i32) -> i64 {
+    return syscall2(210, fd, how as i64);
+}
+
+pub fun setsockopt(
+    fd: i64,
+    level: i32,
+    optname: i32,
+    optval: ptr<i8>,
+    optlen: i32
+) -> i64 {
+    return syscall5(
+        208,
+        fd,
+        level as i64,
+        optname as i64,
+        optval as i64,
+        optlen as i64
+    );
+}
+
+pub fun getsockopt(
+    fd: i64,
+    level: i32,
+    optname: i32,
+    optval: ptr<i8>,
+    optlen: ptr<i32>
+) -> i64 {
+    return syscall5(
+        209,
+        fd,
+        level as i64,
+        optname as i64,
+        optval as i64,
+        optlen as i64
+    );
+}
+
+pub fun poll(fds: ptr<PollFd>, nfds: i64, timeout_ms: i32) -> i64 {
+    if (timeout_ms < 0) {
+        return syscall5(73, fds as i64, nfds, 0, 0, 0);
+    }
+
+    var timeout: PollTimeSpec;
+    timeout.sec = (timeout_ms / 1000) as i64;
+    timeout.nsec = ((timeout_ms % 1000) * 1000000) as i64;
+    return syscall5(73, fds as i64, nfds, &timeout as i64, 0, 0);
+}
+
+
+// -----------------------
+// send / recv
+// -----------------------
+
+pub fun send(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
+    return sendto(fd, buf, len, flags, null, 0);
+}
+
+pub fun recv(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
+    return recvfrom(fd, buf, len, flags, null, null);
+}
+
+pub fun sendto(
+    fd: i64,
+    buf: ptr<u8>,
+    len: i64,
+    flags: i32,
+    addr: ptr<i8>,
+    addrlen: i32
+) -> i64 {
+    return syscall6(
+        206,
+        fd,
+        buf as i64,
+        len,
+        flags as i64,
+        addr as i64,
+        addrlen as i64
+    );
+}
+
+pub fun recvfrom(
+    fd: i64,
+    buf: ptr<u8>,
+    len: i64,
+    flags: i32,
+    addr: ptr<i8>,
+    addrlen: ptr<i32>
+) -> i64 {
+    return syscall6(
+        207,
+        fd,
+        buf as i64,
+        len,
+        flags as i64,
+        addr as i64,
+        addrlen as i64
+    );
+}

--- a/std/sys/linux/riscv64/syscall.wave
+++ b/std/sys/linux/riscv64/syscall.wave
@@ -1,0 +1,119 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Linux RV64 syscall ABI: a7 holds the number, a0-a5 hold arguments,
+// and a0 returns either a result or negative -errno.
+
+pub fun syscall0(id: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "ecall"
+        in("a7") id
+        out("a0") ret
+    }
+    return ret;
+}
+
+pub fun syscall1(id: i64, a1: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "ecall"
+        in("a7") id
+        in("a0") a1
+        out("a0") ret
+    }
+    return ret;
+}
+
+pub fun syscall2(id: i64, a1: i64, a2: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "ecall"
+        in("a7") id
+        in("a0") a1
+        in("a1") a2
+        out("a0") ret
+    }
+    return ret;
+}
+
+pub fun syscall3(id: i64, a1: i64, a2: i64, a3: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "ecall"
+        in("a7") id
+        in("a0") a1
+        in("a1") a2
+        in("a2") a3
+        out("a0") ret
+    }
+    return ret;
+}
+
+pub fun syscall4(id: i64, a1: i64, a2: i64, a3: i64, a4: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "ecall"
+        in("a7") id
+        in("a0") a1
+        in("a1") a2
+        in("a2") a3
+        in("a3") a4
+        out("a0") ret
+    }
+    return ret;
+}
+
+pub fun syscall5(id: i64, a1: i64, a2: i64, a3: i64, a4: i64, a5: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "ecall"
+        in("a7") id
+        in("a0") a1
+        in("a1") a2
+        in("a2") a3
+        in("a3") a4
+        in("a4") a5
+        out("a0") ret
+    }
+    return ret;
+}
+
+pub fun syscall6(
+    id: i64,
+    a1: i64,
+    a2: i64,
+    a3: i64,
+    a4: i64,
+    a5: i64,
+    a6: i64
+) -> i64 {
+    var ret: i64;
+    asm {
+        "ecall"
+        in("a7") id
+        in("a0") a1
+        in("a1") a2
+        in("a2") a3
+        in("a3") a4
+        in("a4") a5
+        in("a5") a6
+        out("a0") ret
+    }
+    return ret;
+}

--- a/std/sys/linux/riscv64/time.wave
+++ b/std/sys/linux/riscv64/time.wave
@@ -1,0 +1,57 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Linux generic 64-bit clock syscalls used by AArch64 and RV64.
+
+import("std::sys::linux::riscv64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+
+// -----------------------
+// timespec
+// -----------------------
+
+pub struct TimeSpec {
+    sec: i64;
+    nsec: i64;
+}
+
+
+// -----------------------
+// nanosleep
+// -----------------------
+
+pub fun nanosleep(req: ptr<TimeSpec>, rem: ptr<TimeSpec>) -> i64 {
+    return syscall2(101, req as i64, rem as i64);
+}
+
+
+// -----------------------
+// clock_gettime
+// -----------------------
+
+pub fun clock_gettime(clock_id: i32, tp: ptr<TimeSpec>) -> i64 {
+    return syscall2(113, clock_id as i64, tp as i64);
+}

--- a/std/sys/linux/riscv64/tty.wave
+++ b/std/sys/linux/riscv64/tty.wave
@@ -1,0 +1,134 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Linux generic 64-bit terminal operations used by AArch64 and RV64.
+
+import("std::sys::linux::riscv64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub const TTY_SYS_IOCTL: i64 = 29;
+pub const TTY_SYS_FCNTL: i64 = 25;
+
+pub const TTY_TCGETS: i64 = 0x5401;
+pub const TTY_TCSETS: i64 = 0x5402;
+pub const TTY_TCSETSW: i64 = 0x5403;
+pub const TTY_TCSETSF: i64 = 0x5404;
+
+pub const TTY_TCSANOW: i32 = 0;
+pub const TTY_TCSADRAIN: i32 = 1;
+pub const TTY_TCSAFLUSH: i32 = 2;
+
+pub const TTY_F_GETFL: i32 = 3;
+pub const TTY_F_SETFL: i32 = 4;
+pub const TTY_O_NONBLOCK: i32 = 2048;
+
+pub const TTY_ICANON: u32 = 2;
+pub const TTY_ECHO: u32 = 8;
+pub const TTY_VTIME_IDX: i32 = 5;
+pub const TTY_VMIN_IDX: i32 = 6;
+
+pub struct Termios {
+    c_iflag: u32;
+    c_oflag: u32;
+    c_cflag: u32;
+    c_lflag: u32;
+    c_line: u8;
+    c_cc: array<u8, 19>;
+}
+
+pub struct TtyRawState {
+    term: Termios;
+    flags: i32;
+    active: i32;
+}
+
+pub fun tty_getattr(fd: i32, t: ptr<Termios>) -> i64 {
+    return syscall3(TTY_SYS_IOCTL, fd as i64, TTY_TCGETS, t as i64);
+}
+
+pub fun tty_setattr(fd: i32, action: i32, t: ptr<Termios>) -> i64 {
+    var req: i64 = TTY_TCSETS;
+
+    if (action == TTY_TCSADRAIN) {
+        req = TTY_TCSETSW;
+    } else if (action == TTY_TCSAFLUSH) {
+        req = TTY_TCSETSF;
+    }
+
+    return syscall3(TTY_SYS_IOCTL, fd as i64, req, t as i64);
+}
+
+pub fun tty_getfl(fd: i32) -> i64 {
+    return syscall3(TTY_SYS_FCNTL, fd as i64, TTY_F_GETFL as i64, 0);
+}
+
+pub fun tty_setfl(fd: i32, flags: i32) -> i64 {
+    return syscall3(TTY_SYS_FCNTL, fd as i64, TTY_F_SETFL as i64, flags as i64);
+}
+
+pub fun tty_enable_raw_nonblock(fd: i32, st: ptr<TtyRawState>) -> i64 {
+    deref st.active = 0;
+
+    var orig: Termios;
+    if (tty_getattr(fd, &orig) < 0) {
+        return -1;
+    }
+
+    var raw: Termios = orig;
+    raw.c_lflag = raw.c_lflag & ~(TTY_ICANON | TTY_ECHO);
+    raw.c_cc[6] = 0;
+    raw.c_cc[5] = 0;
+
+    if (tty_setattr(fd, TTY_TCSANOW, &raw) < 0) {
+        return -1;
+    }
+
+    var flags_raw: i64 = tty_getfl(fd);
+    if (flags_raw < 0) {
+        tty_setattr(fd, TTY_TCSANOW, &orig);
+        return -1;
+    }
+
+    var old_flags: i32 = flags_raw as i32;
+    if (tty_setfl(fd, old_flags | TTY_O_NONBLOCK) < 0) {
+        tty_setattr(fd, TTY_TCSANOW, &orig);
+        return -1;
+    }
+
+    deref st.term = orig;
+    deref st.flags = old_flags;
+    deref st.active = 1;
+    return 0;
+}
+
+pub fun tty_restore(fd: i32, st: ptr<TtyRawState>) {
+    if (deref st.active == 0) {
+        return;
+    }
+
+    var orig: Termios = deref st.term;
+    tty_setattr(fd, TTY_TCSANOW, &orig);
+    tty_setfl(fd, deref st.flags);
+}

--- a/std/sys/linux/socket.wave
+++ b/std/sys/linux/socket.wave
@@ -1,206 +1,35 @@
 // This file is part of the Wave language project.
-// Copyright (c) 2024-2026 Wave Foundation
-// Copyright (c) 2024-2026 LunaStev and contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// Copyright (c) 2024-2026 Wave Foundation and contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// Linux x86_64 socket syscalls
-// =======================================================
-//
-// Raw socket interface built on top of syscall.wave.
-// This layer exposes OS-level socket APIs only.
-// No protocol abstraction (TCP/UDP) here.
-// =======================================================
+// Linux socket provider selected by target architecture.
 
-import("std::sys::linux::syscall")::{
-    syscall0,
-    syscall1,
-    syscall2,
-    syscall3,
-    syscall4,
-    syscall5,
-    syscall6,
+#[target(arch="x86_64")]
+pub import("std::sys::linux::amd64::socket")::{
+    AF_INET, AF_INET6, SOCK_STREAM, SOCK_DGRAM,
+    IPPROTO_IP, IPPROTO_TCP, IPPROTO_UDP,
+    SHUT_RD, SHUT_WR, SHUT_RDWR, SOL_SOCKET, SO_REUSEADDR, SO_REUSEPORT,
+    POLLIN, POLLOUT, POLLERR, POLLHUP, POLLNVAL, PollFd,
+    socket, bind, listen, accept, connect, shutdown, setsockopt, getsockopt,
+    poll, send, recv, sendto, recvfrom,
 };
 
+#[target(arch="aarch64")]
+pub import("std::sys::linux::arm64::socket")::{
+    AF_INET, AF_INET6, SOCK_STREAM, SOCK_DGRAM,
+    IPPROTO_IP, IPPROTO_TCP, IPPROTO_UDP,
+    SHUT_RD, SHUT_WR, SHUT_RDWR, SOL_SOCKET, SO_REUSEADDR, SO_REUSEPORT,
+    POLLIN, POLLOUT, POLLERR, POLLHUP, POLLNVAL, PollFd,
+    socket, bind, listen, accept, connect, shutdown, setsockopt, getsockopt,
+    poll, send, recv, sendto, recvfrom,
+};
 
-// -----------------------
-// constants (minimal)
-// -----------------------
-
-// address families
-pub const AF_INET: i32 = 2;
-pub const AF_INET6: i32 = 10;
-
-// socket types
-pub const SOCK_STREAM: i32 = 1;
-pub const SOCK_DGRAM: i32 = 2;
-
-// protocol
-pub const IPPROTO_IP: i32 = 0;
-pub const IPPROTO_TCP: i32 = 6;
-pub const IPPROTO_UDP: i32 = 17;
-
-// shutdown how
-pub const SHUT_RD: i32 = 0;
-pub const SHUT_WR: i32 = 1;
-pub const SHUT_RDWR: i32 = 2;
-
-// socket options
-pub const SOL_SOCKET: i32 = 1;
-pub const SO_REUSEADDR: i32 = 2;
-pub const SO_REUSEPORT: i32 = 15;
-
-// poll events
-pub const POLLIN: i16 = 0x001;
-pub const POLLOUT: i16 = 0x004;
-pub const POLLERR: i16 = 0x008;
-pub const POLLHUP: i16 = 0x010;
-pub const POLLNVAL: i16 = 0x020;
-
-pub struct PollFd {
-    fd: i32;
-    events: i16;
-    revents: i16;
-}
-
-
-// -----------------------
-// basic socket syscalls
-// -----------------------
-
-pub fun socket(domain: i32, ty: i32, protocol: i32) -> i64 {
-    // syscall: socket (41)
-    return syscall3(41, domain as i64, ty as i64, protocol as i64);
-}
-
-pub fun bind(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
-    // syscall: bind (49)
-    return syscall3(49, fd, addr as i64, len as i64);
-}
-
-pub fun listen(fd: i64, backlog: i32) -> i64 {
-    // syscall: listen (50)
-    return syscall2(50, fd, backlog as i64);
-}
-
-pub fun accept(fd: i64, addr: ptr<i8>, len: ptr<i32>) -> i64 {
-    // syscall: accept (43)
-    return syscall3(43, fd, addr as i64, len as i64);
-}
-
-pub fun connect(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
-    // syscall: connect (42)
-    return syscall3(42, fd, addr as i64, len as i64);
-}
-
-pub fun shutdown(fd: i64, how: i32) -> i64 {
-    // syscall: shutdown (48)
-    return syscall2(48, fd, how as i64);
-}
-
-pub fun setsockopt(
-    fd: i64,
-    level: i32,
-    optname: i32,
-    optval: ptr<i8>,
-    optlen: i32
-) -> i64 {
-    // syscall: setsockopt (54)
-    return syscall5(
-        54,
-        fd,
-        level as i64,
-        optname as i64,
-        optval as i64,
-        optlen as i64
-    );
-}
-
-pub fun getsockopt(
-    fd: i64,
-    level: i32,
-    optname: i32,
-    optval: ptr<i8>,
-    optlen: ptr<i32>
-) -> i64 {
-    // syscall: getsockopt (55)
-    return syscall5(
-        55,
-        fd,
-        level as i64,
-        optname as i64,
-        optval as i64,
-        optlen as i64
-    );
-}
-
-pub fun poll(fds: ptr<PollFd>, nfds: i64, timeout_ms: i32) -> i64 {
-    // syscall: poll (7)
-    return syscall3(7, fds as i64, nfds, timeout_ms as i64);
-}
-
-
-// -----------------------
-// send / recv
-// -----------------------
-
-pub fun send(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
-    return sendto(fd, buf, len, flags, null, 0);
-}
-
-pub fun recv(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
-    return recvfrom(fd, buf, len, flags, null, null);
-}
-
-pub fun sendto(
-    fd: i64,
-    buf: ptr<u8>,
-    len: i64,
-    flags: i32,
-    addr: ptr<i8>,
-    addrlen: i32
-) -> i64 {
-    // syscall: sendto (44)
-    return syscall6(
-        44,
-        fd,
-        buf as i64,
-        len,
-        flags as i64,
-        addr as i64,
-        addrlen as i64
-    );
-}
-
-pub fun recvfrom(
-    fd: i64,
-    buf: ptr<u8>,
-    len: i64,
-    flags: i32,
-    addr: ptr<i8>,
-    addrlen: ptr<i32>
-) -> i64 {
-    // syscall: recvfrom (45)
-    return syscall6(
-        45,
-        fd,
-        buf as i64,
-        len,
-        flags as i64,
-        addr as i64,
-        addrlen as i64
-    );
-}
+#[target(arch="riscv64")]
+pub import("std::sys::linux::riscv64::socket")::{
+    AF_INET, AF_INET6, SOCK_STREAM, SOCK_DGRAM,
+    IPPROTO_IP, IPPROTO_TCP, IPPROTO_UDP,
+    SHUT_RD, SHUT_WR, SHUT_RDWR, SOL_SOCKET, SO_REUSEADDR, SO_REUSEPORT,
+    POLLIN, POLLOUT, POLLERR, POLLHUP, POLLNVAL, PollFd,
+    socket, bind, listen, accept, connect, shutdown, setsockopt, getsockopt,
+    poll, send, recv, sendto, recvfrom,
+};

--- a/std/sys/linux/syscall.wave
+++ b/std/sys/linux/syscall.wave
@@ -1,156 +1,20 @@
 // This file is part of the Wave language project.
-// Copyright (c) 2024-2026 Wave Foundation
-// Copyright (c) 2024-2026 LunaStev and contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// Copyright (c) 2024-2026 Wave Foundation and contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// Linux x86_64 syscall interface for Wave
-// =======================================================
-// Calling convention:
-//   rax = syscall number
-//   rdi, rsi, rdx, r10, r8, r9 = arguments
-//   return value in rax
-//
-// Error handling:
-//   negative return value = -errno
-// =======================================================
+// Linux syscall entry selected by target architecture.
 
+#[target(arch="x86_64")]
+pub import("std::sys::linux::amd64::syscall")::{
+    syscall0, syscall1, syscall2, syscall3, syscall4, syscall5, syscall6,
+};
 
-// -----------------------
-// syscall with 0 args
-// -----------------------
-pub fun syscall0(id: i64) -> i64 {
-    var ret: i64;
-    asm {
-        "syscall"
-        in("rax") id
-        out("rax") ret
-    }
-    return ret;
-}
+#[target(arch="aarch64")]
+pub import("std::sys::linux::arm64::syscall")::{
+    syscall0, syscall1, syscall2, syscall3, syscall4, syscall5, syscall6,
+};
 
-
-// -----------------------
-// syscall with 1 arg
-// -----------------------
-pub fun syscall1(id: i64, a1: i64) -> i64 {
-    var ret: i64;
-    asm {
-        "syscall"
-        in("rax") id
-        in("rdi") a1
-        out("rax") ret
-    }
-    return ret;
-}
-
-
-// -----------------------
-// syscall with 2 args
-// -----------------------
-pub fun syscall2(id: i64, a1: i64, a2: i64) -> i64 {
-    var ret: i64;
-    asm {
-        "syscall"
-        in("rax") id
-        in("rdi") a1
-        in("rsi") a2
-        out("rax") ret
-    }
-    return ret;
-}
-
-
-// -----------------------
-// syscall with 3 args
-// -----------------------
-pub fun syscall3(id: i64, a1: i64, a2: i64, a3: i64) -> i64 {
-    var ret: i64;
-    asm {
-        "syscall"
-        in("rax") id
-        in("rdi") a1
-        in("rsi") a2
-        in("rdx") a3
-        out("rax") ret
-    }
-    return ret;
-}
-
-
-// -----------------------
-// syscall with 4 args
-// -----------------------
-pub fun syscall4(id: i64, a1: i64, a2: i64, a3: i64, a4: i64) -> i64 {
-    var ret: i64;
-    asm {
-        "syscall"
-        in("rax") id
-        in("rdi") a1
-        in("rsi") a2
-        in("rdx") a3
-        in("r10") a4
-        out("rax") ret
-    }
-    return ret;
-}
-
-
-// -----------------------
-// syscall with 5 args
-// -----------------------
-pub fun syscall5(id: i64, a1: i64, a2: i64, a3: i64, a4: i64, a5: i64) -> i64 {
-    var ret: i64;
-    asm {
-        "syscall"
-        in("rax") id
-        in("rdi") a1
-        in("rsi") a2
-        in("rdx") a3
-        in("r10") a4
-        in("r8")  a5
-        out("rax") ret
-    }
-    return ret;
-}
-
-
-// -----------------------
-// syscall with 6 args
-// -----------------------
-pub fun syscall6(
-    id: i64,
-    a1: i64,
-    a2: i64,
-    a3: i64,
-    a4: i64,
-    a5: i64,
-    a6: i64
-) -> i64 {
-    var ret: i64;
-    asm {
-        "syscall"
-        in("rax") id
-        in("rdi") a1
-        in("rsi") a2
-        in("rdx") a3
-        in("r10") a4
-        in("r8")  a5
-        in("r9")  a6
-        out("rax") ret
-    }
-    return ret;
-}
+#[target(arch="riscv64")]
+pub import("std::sys::linux::riscv64::syscall")::{
+    syscall0, syscall1, syscall2, syscall3, syscall4, syscall5, syscall6,
+};

--- a/std/sys/linux/time.wave
+++ b/std/sys/linux/time.wave
@@ -1,66 +1,14 @@
 // This file is part of the Wave language project.
-// Copyright (c) 2024-2026 Wave Foundation
-// Copyright (c) 2024-2026 LunaStev and contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// Copyright (c) 2024-2026 Wave Foundation and contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// Linux x86_64 time-related syscalls
-// =======================================================
-//
-// Raw time and sleep syscalls.
-// All functions return raw syscall values.
-// Negative values indicate -errno.
-// =======================================================
+// Linux clock provider selected by target architecture.
 
-import("std::sys::linux::syscall")::{
-    syscall0,
-    syscall1,
-    syscall2,
-    syscall3,
-    syscall4,
-    syscall5,
-    syscall6,
-};
+#[target(arch="x86_64")]
+pub import("std::sys::linux::amd64::time")::{TimeSpec, nanosleep, clock_gettime};
 
+#[target(arch="aarch64")]
+pub import("std::sys::linux::arm64::time")::{TimeSpec, nanosleep, clock_gettime};
 
-// -----------------------
-// timespec
-// -----------------------
-
-pub struct TimeSpec {
-    sec: i64;
-    nsec: i64;
-}
-
-
-// -----------------------
-// nanosleep
-// -----------------------
-
-pub fun nanosleep(req: ptr<TimeSpec>, rem: ptr<TimeSpec>) -> i64 {
-    // syscall: nanosleep (35)
-    return syscall2(35, req as i64, rem as i64);
-}
-
-
-// -----------------------
-// clock_gettime
-// -----------------------
-
-pub fun clock_gettime(clock_id: i32, tp: ptr<TimeSpec>) -> i64 {
-    // syscall: clock_gettime (228)
-    return syscall2(228, clock_id as i64, tp as i64);
-}
+#[target(arch="riscv64")]
+pub import("std::sys::linux::riscv64::time")::{TimeSpec, nanosleep, clock_gettime};

--- a/std/sys/linux/tty.wave
+++ b/std/sys/linux/tty.wave
@@ -1,142 +1,35 @@
 // This file is part of the Wave language project.
-// Copyright (c) 2024-2026 Wave Foundation
-// Copyright (c) 2024-2026 LunaStev and contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// Copyright (c) 2024-2026 Wave Foundation and contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// Linux x86_64 tty helpers
-// =======================================================
-//
-// Raw terminal helpers built on top of syscall.wave.
-// No libc dependency.
-// =======================================================
+// Linux terminal provider selected by target architecture.
 
-import("std::sys::linux::syscall")::{
-    syscall0,
-    syscall1,
-    syscall2,
-    syscall3,
-    syscall4,
-    syscall5,
-    syscall6,
+#[target(arch="x86_64")]
+pub import("std::sys::linux::amd64::tty")::{
+    TTY_SYS_IOCTL, TTY_SYS_FCNTL, TTY_TCGETS, TTY_TCSETS, TTY_TCSETSW,
+    TTY_TCSETSF, TTY_TCSANOW, TTY_TCSADRAIN, TTY_TCSAFLUSH,
+    TTY_F_GETFL, TTY_F_SETFL, TTY_O_NONBLOCK, TTY_ICANON, TTY_ECHO,
+    TTY_VTIME_IDX, TTY_VMIN_IDX, Termios, TtyRawState,
+    tty_getattr, tty_setattr, tty_getfl, tty_setfl,
+    tty_enable_raw_nonblock, tty_restore,
 };
 
-pub const TTY_SYS_IOCTL: i64 = 16;
-pub const TTY_SYS_FCNTL: i64 = 72;
+#[target(arch="aarch64")]
+pub import("std::sys::linux::arm64::tty")::{
+    TTY_SYS_IOCTL, TTY_SYS_FCNTL, TTY_TCGETS, TTY_TCSETS, TTY_TCSETSW,
+    TTY_TCSETSF, TTY_TCSANOW, TTY_TCSADRAIN, TTY_TCSAFLUSH,
+    TTY_F_GETFL, TTY_F_SETFL, TTY_O_NONBLOCK, TTY_ICANON, TTY_ECHO,
+    TTY_VTIME_IDX, TTY_VMIN_IDX, Termios, TtyRawState,
+    tty_getattr, tty_setattr, tty_getfl, tty_setfl,
+    tty_enable_raw_nonblock, tty_restore,
+};
 
-pub const TTY_TCGETS: i64 = 0x5401;
-pub const TTY_TCSETS: i64 = 0x5402;
-pub const TTY_TCSETSW: i64 = 0x5403;
-pub const TTY_TCSETSF: i64 = 0x5404;
-
-pub const TTY_TCSANOW: i32 = 0;
-pub const TTY_TCSADRAIN: i32 = 1;
-pub const TTY_TCSAFLUSH: i32 = 2;
-
-pub const TTY_F_GETFL: i32 = 3;
-pub const TTY_F_SETFL: i32 = 4;
-pub const TTY_O_NONBLOCK: i32 = 2048;
-
-pub const TTY_ICANON: u32 = 2;
-pub const TTY_ECHO: u32 = 8;
-pub const TTY_VTIME_IDX: i32 = 5;
-pub const TTY_VMIN_IDX: i32 = 6;
-
-pub struct Termios {
-    c_iflag: u32;
-    c_oflag: u32;
-    c_cflag: u32;
-    c_lflag: u32;
-    c_line: u8;
-    c_cc: array<u8, 32>;
-    c_ispeed: u32;
-    c_ospeed: u32;
-}
-
-pub struct TtyRawState {
-    term: Termios;
-    flags: i32;
-    active: i32;
-}
-
-pub fun tty_getattr(fd: i32, t: ptr<Termios>) -> i64 {
-    return syscall3(TTY_SYS_IOCTL, fd as i64, TTY_TCGETS, t as i64);
-}
-
-pub fun tty_setattr(fd: i32, action: i32, t: ptr<Termios>) -> i64 {
-    var req: i64 = TTY_TCSETS;
-
-    if (action == TTY_TCSADRAIN) {
-        req = TTY_TCSETSW;
-    } else if (action == TTY_TCSAFLUSH) {
-        req = TTY_TCSETSF;
-    }
-
-    return syscall3(TTY_SYS_IOCTL, fd as i64, req, t as i64);
-}
-
-pub fun tty_getfl(fd: i32) -> i64 {
-    return syscall3(TTY_SYS_FCNTL, fd as i64, TTY_F_GETFL as i64, 0);
-}
-
-pub fun tty_setfl(fd: i32, flags: i32) -> i64 {
-    return syscall3(TTY_SYS_FCNTL, fd as i64, TTY_F_SETFL as i64, flags as i64);
-}
-
-pub fun tty_enable_raw_nonblock(fd: i32, st: ptr<TtyRawState>) -> i64 {
-    deref st.active = 0;
-
-    var orig: Termios;
-    if (tty_getattr(fd, &orig) < 0) {
-        return -1;
-    }
-
-    var raw: Termios = orig;
-    raw.c_lflag = raw.c_lflag & ~(TTY_ICANON | TTY_ECHO);
-    raw.c_cc[6] = 0;
-    raw.c_cc[5] = 0;
-
-    if (tty_setattr(fd, TTY_TCSANOW, &raw) < 0) {
-        return -1;
-    }
-
-    var flags_raw: i64 = tty_getfl(fd);
-    if (flags_raw < 0) {
-        tty_setattr(fd, TTY_TCSANOW, &orig);
-        return -1;
-    }
-
-    var old_flags: i32 = flags_raw as i32;
-    if (tty_setfl(fd, old_flags | TTY_O_NONBLOCK) < 0) {
-        tty_setattr(fd, TTY_TCSANOW, &orig);
-        return -1;
-    }
-
-    deref st.term = orig;
-    deref st.flags = old_flags;
-    deref st.active = 1;
-    return 0;
-}
-
-pub fun tty_restore(fd: i32, st: ptr<TtyRawState>) {
-    if (deref st.active == 0) {
-        return;
-    }
-
-    var orig: Termios = deref st.term;
-    tty_setattr(fd, TTY_TCSANOW, &orig);
-    tty_setfl(fd, deref st.flags);
-}
+#[target(arch="riscv64")]
+pub import("std::sys::linux::riscv64::tty")::{
+    TTY_SYS_IOCTL, TTY_SYS_FCNTL, TTY_TCGETS, TTY_TCSETS, TTY_TCSETSW,
+    TTY_TCSETSF, TTY_TCSANOW, TTY_TCSADRAIN, TTY_TCSAFLUSH,
+    TTY_F_GETFL, TTY_F_SETFL, TTY_O_NONBLOCK, TTY_ICANON, TTY_ECHO,
+    TTY_VTIME_IDX, TTY_VMIN_IDX, Termios, TtyRawState,
+    tty_getattr, tty_setattr, tty_getfl, tty_setfl,
+    tty_enable_raw_nonblock, tty_restore,
+};

--- a/std/sys/macos/amd64/env.wave
+++ b/std/sys/macos/amd64/env.wave
@@ -1,0 +1,28 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ENOSYS-style return for not implemented path.
+pub const ERR_NOT_IMPLEMENTED: i64 = -38;
+
+pub fun env_read(buf: ptr<u8>, cap: i64) -> i64 {
+    if (buf == null || cap <= 0) {
+        return -22;
+    }
+
+    return ERR_NOT_IMPLEMENTED;
+}

--- a/std/sys/macos/amd64/fs.wave
+++ b/std/sys/macos/amd64/fs.wave
@@ -55,6 +55,8 @@ pub const FS_SEEK_END: i32 = 2;
 // fcntl modes
 pub const FS_F_GETFL: i32 = 3;
 pub const FS_F_SETFL: i32 = 4;
+const FS_F_GETPATH: i32 = 50;
+const FS_MAX_PATH: i64 = 1024;
 
 // Darwin x86_64 stat64 layout used by the stat and fstat syscalls below.
 pub struct Stat {
@@ -121,7 +123,38 @@ pub fun write(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
 }
 
 pub fun getcwd(buf: ptr<u8>, size: i64) -> i64 {
-    return syscall2(326, buf as i64, size);
+    if (buf == null || size <= 0) {
+        return -22;
+    }
+
+    // Darwin has no getcwd syscall: slot 326 is nosys. Resolve the path of
+    // an open descriptor for "." with F_GETPATH and copy it to the caller.
+    var directory: i64 = open(".", FS_O_RDONLY, 0);
+    if (directory < 0) {
+        return directory;
+    }
+
+    var resolved: array<u8, 1024>;
+    var result: i64 = fcntl(directory, FS_F_GETPATH, &resolved[0] as i64);
+    close(directory);
+    if (result < 0) {
+        return result;
+    }
+
+    var length: i64 = 0;
+    while (length < FS_MAX_PATH && resolved[length] != 0) {
+        length += 1;
+    }
+    if (length >= FS_MAX_PATH || length + 1 > size) {
+        return -34;
+    }
+
+    var i: i64 = 0;
+    while (i <= length) {
+        buf[i] = resolved[i];
+        i += 1;
+    }
+    return length;
 }
 
 pub fun chdir(path: str) -> i64 {

--- a/std/sys/macos/amd64/fs.wave
+++ b/std/sys/macos/amd64/fs.wave
@@ -1,0 +1,161 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// macOS filesystem syscalls
+// =======================================================
+
+import("std::sys::macos::amd64::syscall")::{
+    MACOS_SYSCALL_BASE,
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+// open flags
+pub const FS_O_RDONLY: i32 = 0;
+pub const FS_O_WRONLY: i32 = 1;
+pub const FS_O_RDWR: i32 = 2;
+pub const FS_O_NONBLOCK: i32 = 4;
+pub const FS_O_APPEND: i32 = 8;
+pub const FS_O_CREAT: i32 = 512;
+pub const FS_O_TRUNC: i32 = 1024;
+pub const FS_O_EXCL: i32 = 2048;
+
+// access modes
+pub const FS_F_OK: i32 = 0;
+pub const FS_X_OK: i32 = 1;
+pub const FS_W_OK: i32 = 2;
+pub const FS_R_OK: i32 = 4;
+
+// seek modes
+pub const FS_SEEK_SET: i32 = 0;
+pub const FS_SEEK_CUR: i32 = 1;
+pub const FS_SEEK_END: i32 = 2;
+
+// fcntl modes
+pub const FS_F_GETFL: i32 = 3;
+pub const FS_F_SETFL: i32 = 4;
+
+// Darwin x86_64 stat64 layout used by the stat and fstat syscalls below.
+pub struct Stat {
+    dev: i32;
+    mode: i16;
+    nlink: i16;
+    ino: i64;
+    uid: i32;
+    gid: i32;
+    rdev: i32;
+    pad0: i32;
+    atime: i64;
+    atime_nsec: i64;
+    mtime: i64;
+    mtime_nsec: i64;
+    ctime: i64;
+    ctime_nsec: i64;
+    birthtime: i64;
+    birthtime_nsec: i64;
+    size: i64;
+    blocks: i64;
+    blksize: i32;
+    flags: i32;
+    generation: i32;
+    spare: i32;
+    qspare0: i64;
+    qspare1: i64;
+}
+
+pub fun open(path: str, flags: i32, mode: i32) -> i64 {
+    return syscall3(5, path as i64, flags as i64, mode as i64);
+}
+
+pub fun close(fd: i64) -> i64 {
+    return syscall1(6, fd);
+}
+
+pub fun dup(fd: i64) -> i64 {
+    return syscall1(41, fd);
+}
+
+pub fun pipe(fds: ptr<i32>) -> i64 {
+    return syscall1(42, fds as i64);
+}
+
+pub fun dup2(oldfd: i64, newfd: i64) -> i64 {
+    return syscall2(90, oldfd, newfd);
+}
+
+pub fun fsync(fd: i64) -> i64 {
+    return syscall1(95, fd);
+}
+
+pub fun fcntl(fd: i64, cmd: i32, arg: i64) -> i64 {
+    return syscall3(92, fd, cmd as i64, arg);
+}
+
+pub fun read(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
+    return syscall3(3, fd, buf as i64, len);
+}
+
+pub fun write(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
+    return syscall3(4, fd, buf as i64, len);
+}
+
+pub fun getcwd(buf: ptr<u8>, size: i64) -> i64 {
+    return syscall2(326, buf as i64, size);
+}
+
+pub fun chdir(path: str) -> i64 {
+    return syscall1(12, path as i64);
+}
+
+pub fun access(path: str, mode: i32) -> i64 {
+    return syscall2(33, path as i64, mode as i64);
+}
+
+pub fun lseek(fd: i64, offset: i64, whence: i32) -> i64 {
+    return syscall3(199, fd, offset, whence as i64);
+}
+
+pub fun unlink(path: str) -> i64 {
+    return syscall1(10, path as i64);
+}
+
+pub fun mkdir(path: str, mode: i32) -> i64 {
+    return syscall2(136, path as i64, mode as i64);
+}
+
+pub fun rmdir(path: str) -> i64 {
+    return syscall1(137, path as i64);
+}
+
+pub fun rename_path(old_path: str, new_path: str) -> i64 {
+    return syscall2(128, old_path as i64, new_path as i64);
+}
+
+pub fun stat(path: str, st: ptr<Stat>) -> i64 {
+    return syscall2(338, path as i64, st as i64);
+}
+
+pub fun fstat(fd: i64, st: ptr<Stat>) -> i64 {
+    return syscall2(339, fd, st as i64);
+}

--- a/std/sys/macos/amd64/memory.wave
+++ b/std/sys/macos/amd64/memory.wave
@@ -1,0 +1,93 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// macOS memory syscalls
+// =======================================================
+
+import("std::sys::macos::amd64::syscall")::{
+    MACOS_SYSCALL_BASE,
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub const PROT_READ: i32 = 1;
+pub const PROT_WRITE: i32 = 2;
+pub const MAP_PRIVATE: i32 = 2;
+pub const MAP_ANON: i32 = 0x1000;
+
+pub fun mmap(
+    addr: ptr<i8>,
+    length: i64,
+    prot: i32,
+    flags: i32,
+    fd: i64,
+    offset: i64
+) -> ptr<i8> {
+    return syscall6(
+        197,
+        addr as i64,
+        length,
+        prot as i64,
+        flags as i64,
+        fd,
+        offset
+    ) as ptr<i8>;
+}
+
+pub fun munmap(addr: ptr<i8>, length: i64) -> i64 {
+    return syscall2(73, addr as i64, length);
+}
+
+pub fun brk(addr: ptr<i8>) -> ptr<i8> {
+    return syscall1(17, addr as i64) as ptr<i8>;
+}
+
+pub fun sys_alloc(size: i64) -> ptr<u8> {
+    if (size <= 0) {
+        return null;
+    }
+
+    var p: ptr<i8> = mmap(
+        null,
+        size,
+        PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANON,
+        -1,
+        0
+    );
+
+    if ((p as i64) < 0) {
+        return null;
+    }
+
+    return p as ptr<u8>;
+}
+
+pub fun sys_free(p: ptr<u8>, size: i64) -> i64 {
+    if (p == null || size <= 0) {
+        return 0;
+    }
+
+    return munmap(p as ptr<i8>, size);
+}

--- a/std/sys/macos/amd64/process.wave
+++ b/std/sys/macos/amd64/process.wave
@@ -1,0 +1,65 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// macOS process syscalls
+// =======================================================
+
+import("std::sys::macos::amd64::syscall")::{
+    MACOS_SYSCALL_BASE,
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub fun exit(code: i32) -> ! {
+    syscall1(1, code as i64);
+    while (true) { }
+}
+
+pub fun getpid() -> i64 {
+    return syscall0(20);
+}
+
+pub fun getppid() -> i64 {
+    return syscall0(39);
+}
+
+pub fun fork() -> i64 {
+    return syscall0(2);
+}
+
+pub fun execve(
+    path: str,
+    argv: ptr<ptr<i8>>,
+    envp: ptr<ptr<i8>>
+) -> i64 {
+    return syscall3(59, path as i64, argv as i64, envp as i64);
+}
+
+pub fun waitpid(pid: i64, status: ptr<i32>, options: i32) -> i64 {
+    return syscall4(7, pid, status as i64, options as i64, 0);
+}
+
+pub fun kill(pid: i64, sig: i32) -> i64 {
+    return syscall2(37, pid, sig as i64);
+}

--- a/std/sys/macos/amd64/socket.wave
+++ b/std/sys/macos/amd64/socket.wave
@@ -1,0 +1,173 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// macOS socket syscalls
+// =======================================================
+//
+// Raw socket layer for macOS built on syscall.wave.
+// =======================================================
+
+import("std::sys::macos::amd64::syscall")::{
+    MACOS_SYSCALL_BASE,
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub const AF_INET: i32 = 2;
+pub const AF_INET6: i32 = 30;
+
+pub const SOCK_STREAM: i32 = 1;
+pub const SOCK_DGRAM: i32 = 2;
+
+pub const IPPROTO_IP: i32 = 0;
+pub const IPPROTO_TCP: i32 = 6;
+pub const IPPROTO_UDP: i32 = 17;
+
+pub const SHUT_RD: i32 = 0;
+pub const SHUT_WR: i32 = 1;
+pub const SHUT_RDWR: i32 = 2;
+
+pub const SOL_SOCKET: i32 = 0xFFFF;
+pub const SO_REUSEADDR: i32 = 0x0004;
+pub const SO_REUSEPORT: i32 = 0x0200;
+
+pub const POLLIN: i16 = 0x001;
+pub const POLLOUT: i16 = 0x004;
+pub const POLLERR: i16 = 0x008;
+pub const POLLHUP: i16 = 0x010;
+pub const POLLNVAL: i16 = 0x020;
+
+pub struct PollFd {
+    fd: i32;
+    events: i16;
+    revents: i16;
+}
+
+pub fun socket(domain: i32, ty: i32, protocol: i32) -> i64 {
+    return syscall3(97, domain as i64, ty as i64, protocol as i64);
+}
+
+pub fun bind(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
+    return syscall3(104, fd, addr as i64, len as i64);
+}
+
+pub fun listen(fd: i64, backlog: i32) -> i64 {
+    return syscall2(106, fd, backlog as i64);
+}
+
+pub fun accept(fd: i64, addr: ptr<i8>, len: ptr<i32>) -> i64 {
+    return syscall3(30, fd, addr as i64, len as i64);
+}
+
+pub fun connect(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
+    return syscall3(98, fd, addr as i64, len as i64);
+}
+
+pub fun shutdown(fd: i64, how: i32) -> i64 {
+    return syscall2(134, fd, how as i64);
+}
+
+pub fun setsockopt(
+    fd: i64,
+    level: i32,
+    optname: i32,
+    optval: ptr<i8>,
+    optlen: i32
+) -> i64 {
+    return syscall5(
+        105,
+        fd,
+        level as i64,
+        optname as i64,
+        optval as i64,
+        optlen as i64
+    );
+}
+
+pub fun getsockopt(
+    fd: i64,
+    level: i32,
+    optname: i32,
+    optval: ptr<i8>,
+    optlen: ptr<i32>
+) -> i64 {
+    return syscall5(
+        118,
+        fd,
+        level as i64,
+        optname as i64,
+        optval as i64,
+        optlen as i64
+    );
+}
+
+pub fun poll(fds: ptr<PollFd>, nfds: i64, timeout_ms: i32) -> i64 {
+    return syscall3(230, fds as i64, nfds, timeout_ms as i64);
+}
+
+pub fun send(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
+    return sendto(fd, buf, len, flags, null, 0);
+}
+
+pub fun recv(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
+    return recvfrom(fd, buf, len, flags, null, null);
+}
+
+pub fun sendto(
+    fd: i64,
+    buf: ptr<u8>,
+    len: i64,
+    flags: i32,
+    addr: ptr<i8>,
+    addrlen: i32
+) -> i64 {
+    return syscall6(
+        133,
+        fd,
+        buf as i64,
+        len,
+        flags as i64,
+        addr as i64,
+        addrlen as i64
+    );
+}
+
+pub fun recvfrom(
+    fd: i64,
+    buf: ptr<u8>,
+    len: i64,
+    flags: i32,
+    addr: ptr<i8>,
+    addrlen: ptr<i32>
+) -> i64 {
+    return syscall6(
+        29,
+        fd,
+        buf as i64,
+        len,
+        flags as i64,
+        addr as i64,
+        addrlen as i64
+    );
+}

--- a/std/sys/macos/amd64/syscall.wave
+++ b/std/sys/macos/amd64/syscall.wave
@@ -1,0 +1,126 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// macOS x86_64 syscall entry helpers
+// =======================================================
+//
+// Raw syscall helpers for Darwin.
+// Return values follow kernel convention:
+//   negative return value = -errno
+// =======================================================
+
+pub const MACOS_SYSCALL_BASE: i64 = 0x2000000;
+
+pub fun syscall0(id: i64) -> i64 {
+    var ret: i64;
+    var sysno: i64 = MACOS_SYSCALL_BASE + id;
+    asm {
+        "syscall\njnc 1f\nneg rax\n1:"
+        in("rax") sysno
+        out("rax") ret
+    }
+    return ret;
+}
+
+pub fun syscall1(id: i64, a1: i64) -> i64 {
+    var ret: i64;
+    var sysno: i64 = MACOS_SYSCALL_BASE + id;
+    asm {
+        "syscall\njnc 1f\nneg rax\n1:"
+        in("rax") sysno
+        in("rdi") a1
+        out("rax") ret
+    }
+    return ret;
+}
+
+pub fun syscall2(id: i64, a1: i64, a2: i64) -> i64 {
+    var ret: i64;
+    var sysno: i64 = MACOS_SYSCALL_BASE + id;
+    asm {
+        "syscall\njnc 1f\nneg rax\n1:"
+        in("rax") sysno
+        in("rdi") a1
+        in("rsi") a2
+        out("rax") ret
+    }
+    return ret;
+}
+
+pub fun syscall3(id: i64, a1: i64, a2: i64, a3: i64) -> i64 {
+    var ret: i64;
+    var sysno: i64 = MACOS_SYSCALL_BASE + id;
+    asm {
+        "syscall\njnc 1f\nneg rax\n1:"
+        in("rax") sysno
+        in("rdi") a1
+        in("rsi") a2
+        in("rdx") a3
+        out("rax") ret
+    }
+    return ret;
+}
+
+pub fun syscall4(id: i64, a1: i64, a2: i64, a3: i64, a4: i64) -> i64 {
+    var ret: i64;
+    var sysno: i64 = MACOS_SYSCALL_BASE + id;
+    asm {
+        "syscall\njnc 1f\nneg rax\n1:"
+        in("rax") sysno
+        in("rdi") a1
+        in("rsi") a2
+        in("rdx") a3
+        in("r10") a4
+        out("rax") ret
+    }
+    return ret;
+}
+
+pub fun syscall5(id: i64, a1: i64, a2: i64, a3: i64, a4: i64, a5: i64) -> i64 {
+    var ret: i64;
+    var sysno: i64 = MACOS_SYSCALL_BASE + id;
+    asm {
+        "syscall\njnc 1f\nneg rax\n1:"
+        in("rax") sysno
+        in("rdi") a1
+        in("rsi") a2
+        in("rdx") a3
+        in("r10") a4
+        in("r8") a5
+        out("rax") ret
+    }
+    return ret;
+}
+
+pub fun syscall6(id: i64, a1: i64, a2: i64, a3: i64, a4: i64, a5: i64, a6: i64) -> i64 {
+    var ret: i64;
+    var sysno: i64 = MACOS_SYSCALL_BASE + id;
+    asm {
+        "syscall\njnc 1f\nneg rax\n1:"
+        in("rax") sysno
+        in("rdi") a1
+        in("rsi") a2
+        in("rdx") a3
+        in("r10") a4
+        in("r8") a5
+        in("r9") a6
+        out("rax") ret
+    }
+    return ret;
+}

--- a/std/sys/macos/amd64/time.wave
+++ b/std/sys/macos/amd64/time.wave
@@ -1,0 +1,45 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// macOS time syscalls
+// =======================================================
+
+import("std::sys::macos::amd64::syscall")::{
+    MACOS_SYSCALL_BASE,
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub struct TimeSpec {
+    sec: i64;
+    nsec: i64;
+}
+
+pub fun nanosleep(req: ptr<TimeSpec>, rem: ptr<TimeSpec>) -> i64 {
+    return syscall2(240, req as i64, rem as i64);
+}
+
+pub fun clock_gettime(clock_id: i32, tp: ptr<TimeSpec>) -> i64 {
+    return syscall2(116, clock_id as i64, tp as i64);
+}

--- a/std/sys/macos/amd64/tty.wave
+++ b/std/sys/macos/amd64/tty.wave
@@ -1,0 +1,138 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// macOS tty helpers
+// =======================================================
+
+import("std::sys::macos::amd64::syscall")::{
+    MACOS_SYSCALL_BASE,
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub const TTY_SYS_IOCTL: i64 = 54;
+pub const TTY_SYS_FCNTL: i64 = 92;
+
+pub const TTY_TCGETS: i64 = 0x40487413;
+pub const TTY_TCSETS: i64 = 0x80487414;
+pub const TTY_TCSETSW: i64 = 0x80487415;
+pub const TTY_TCSETSF: i64 = 0x80487416;
+
+pub const TTY_TCSANOW: i32 = 0;
+pub const TTY_TCSADRAIN: i32 = 1;
+pub const TTY_TCSAFLUSH: i32 = 2;
+
+pub const TTY_F_GETFL: i32 = 3;
+pub const TTY_F_SETFL: i32 = 4;
+pub const TTY_O_NONBLOCK: i32 = 4;
+
+pub const TTY_ICANON: u64 = 0x00000100;
+pub const TTY_ECHO: u64 = 0x00000008;
+
+pub struct Termios {
+    c_iflag: u64;
+    c_oflag: u64;
+    c_cflag: u64;
+    c_lflag: u64;
+    c_cc: array<u8, 20>;
+    c_ispeed: u64;
+    c_ospeed: u64;
+}
+
+pub struct TtyRawState {
+    term: Termios;
+    flags: i32;
+    active: i32;
+}
+
+pub fun tty_getattr(fd: i32, t: ptr<Termios>) -> i64 {
+    return syscall3(TTY_SYS_IOCTL, fd as i64, TTY_TCGETS, t as i64);
+}
+
+pub fun tty_setattr(fd: i32, action: i32, t: ptr<Termios>) -> i64 {
+    var req: i64 = TTY_TCSETS;
+
+    if (action == TTY_TCSADRAIN) {
+        req = TTY_TCSETSW;
+    } else if (action == TTY_TCSAFLUSH) {
+        req = TTY_TCSETSF;
+    }
+
+    return syscall3(TTY_SYS_IOCTL, fd as i64, req, t as i64);
+}
+
+pub fun tty_getfl(fd: i32) -> i64 {
+    return syscall3(TTY_SYS_FCNTL, fd as i64, TTY_F_GETFL as i64, 0);
+}
+
+pub fun tty_setfl(fd: i32, flags: i32) -> i64 {
+    return syscall3(TTY_SYS_FCNTL, fd as i64, TTY_F_SETFL as i64, flags as i64);
+}
+
+pub fun tty_enable_raw_nonblock(fd: i32, st: ptr<TtyRawState>) -> i64 {
+    deref st.active = 0;
+    var vmin_idx: i32 = 16;
+    var vtime_idx: i32 = 17;
+
+    var orig: Termios;
+    if (tty_getattr(fd, &orig) < 0) {
+        return -1;
+    }
+
+    var raw: Termios = orig;
+    raw.c_lflag = raw.c_lflag & ~(TTY_ICANON | TTY_ECHO);
+    raw.c_cc[vmin_idx] = 0;
+    raw.c_cc[vtime_idx] = 0;
+
+    if (tty_setattr(fd, TTY_TCSANOW, &raw) < 0) {
+        return -1;
+    }
+
+    var flags_raw: i64 = tty_getfl(fd);
+    if (flags_raw < 0) {
+        tty_setattr(fd, TTY_TCSANOW, &orig);
+        return -1;
+    }
+
+    var old_flags: i32 = flags_raw as i32;
+    if (tty_setfl(fd, old_flags | TTY_O_NONBLOCK) < 0) {
+        tty_setattr(fd, TTY_TCSANOW, &orig);
+        return -1;
+    }
+
+    deref st.term = orig;
+    deref st.flags = old_flags;
+    deref st.active = 1;
+    return 0;
+}
+
+pub fun tty_restore(fd: i32, st: ptr<TtyRawState>) {
+    if (deref st.active == 0) {
+        return;
+    }
+
+    var orig: Termios = deref st.term;
+    tty_setattr(fd, TTY_TCSANOW, &orig);
+    tty_setfl(fd, deref st.flags);
+}

--- a/std/sys/macos/arm64/env.wave
+++ b/std/sys/macos/arm64/env.wave
@@ -1,0 +1,28 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ENOSYS-style return for not implemented path.
+pub const ERR_NOT_IMPLEMENTED: i64 = -38;
+
+pub fun env_read(buf: ptr<u8>, cap: i64) -> i64 {
+    if (buf == null || cap <= 0) {
+        return -22;
+    }
+
+    return ERR_NOT_IMPLEMENTED;
+}

--- a/std/sys/macos/arm64/fs.wave
+++ b/std/sys/macos/arm64/fs.wave
@@ -1,0 +1,160 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// macOS filesystem syscalls
+// =======================================================
+
+import("std::sys::macos::arm64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+// open flags
+pub const FS_O_RDONLY: i32 = 0;
+pub const FS_O_WRONLY: i32 = 1;
+pub const FS_O_RDWR: i32 = 2;
+pub const FS_O_NONBLOCK: i32 = 4;
+pub const FS_O_APPEND: i32 = 8;
+pub const FS_O_CREAT: i32 = 512;
+pub const FS_O_TRUNC: i32 = 1024;
+pub const FS_O_EXCL: i32 = 2048;
+
+// access modes
+pub const FS_F_OK: i32 = 0;
+pub const FS_X_OK: i32 = 1;
+pub const FS_W_OK: i32 = 2;
+pub const FS_R_OK: i32 = 4;
+
+// seek modes
+pub const FS_SEEK_SET: i32 = 0;
+pub const FS_SEEK_CUR: i32 = 1;
+pub const FS_SEEK_END: i32 = 2;
+
+// fcntl modes
+pub const FS_F_GETFL: i32 = 3;
+pub const FS_F_SETFL: i32 = 4;
+
+// Darwin 64-bit stat64 layout used by the stat and fstat syscalls below.
+pub struct Stat {
+    dev: i32;
+    mode: i16;
+    nlink: i16;
+    ino: i64;
+    uid: i32;
+    gid: i32;
+    rdev: i32;
+    pad0: i32;
+    atime: i64;
+    atime_nsec: i64;
+    mtime: i64;
+    mtime_nsec: i64;
+    ctime: i64;
+    ctime_nsec: i64;
+    birthtime: i64;
+    birthtime_nsec: i64;
+    size: i64;
+    blocks: i64;
+    blksize: i32;
+    flags: i32;
+    generation: i32;
+    spare: i32;
+    qspare0: i64;
+    qspare1: i64;
+}
+
+pub fun open(path: str, flags: i32, mode: i32) -> i64 {
+    return syscall3(5, path as i64, flags as i64, mode as i64);
+}
+
+pub fun close(fd: i64) -> i64 {
+    return syscall1(6, fd);
+}
+
+pub fun dup(fd: i64) -> i64 {
+    return syscall1(41, fd);
+}
+
+pub fun pipe(fds: ptr<i32>) -> i64 {
+    return syscall1(42, fds as i64);
+}
+
+pub fun dup2(oldfd: i64, newfd: i64) -> i64 {
+    return syscall2(90, oldfd, newfd);
+}
+
+pub fun fsync(fd: i64) -> i64 {
+    return syscall1(95, fd);
+}
+
+pub fun fcntl(fd: i64, cmd: i32, arg: i64) -> i64 {
+    return syscall3(92, fd, cmd as i64, arg);
+}
+
+pub fun read(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
+    return syscall3(3, fd, buf as i64, len);
+}
+
+pub fun write(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
+    return syscall3(4, fd, buf as i64, len);
+}
+
+pub fun getcwd(buf: ptr<u8>, size: i64) -> i64 {
+    return syscall2(326, buf as i64, size);
+}
+
+pub fun chdir(path: str) -> i64 {
+    return syscall1(12, path as i64);
+}
+
+pub fun access(path: str, mode: i32) -> i64 {
+    return syscall2(33, path as i64, mode as i64);
+}
+
+pub fun lseek(fd: i64, offset: i64, whence: i32) -> i64 {
+    return syscall3(199, fd, offset, whence as i64);
+}
+
+pub fun unlink(path: str) -> i64 {
+    return syscall1(10, path as i64);
+}
+
+pub fun mkdir(path: str, mode: i32) -> i64 {
+    return syscall2(136, path as i64, mode as i64);
+}
+
+pub fun rmdir(path: str) -> i64 {
+    return syscall1(137, path as i64);
+}
+
+pub fun rename_path(old_path: str, new_path: str) -> i64 {
+    return syscall2(128, old_path as i64, new_path as i64);
+}
+
+pub fun stat(path: str, st: ptr<Stat>) -> i64 {
+    return syscall2(338, path as i64, st as i64);
+}
+
+pub fun fstat(fd: i64, st: ptr<Stat>) -> i64 {
+    return syscall2(339, fd, st as i64);
+}

--- a/std/sys/macos/arm64/fs.wave
+++ b/std/sys/macos/arm64/fs.wave
@@ -54,6 +54,8 @@ pub const FS_SEEK_END: i32 = 2;
 // fcntl modes
 pub const FS_F_GETFL: i32 = 3;
 pub const FS_F_SETFL: i32 = 4;
+const FS_F_GETPATH: i32 = 50;
+const FS_MAX_PATH: i64 = 1024;
 
 // Darwin 64-bit stat64 layout used by the stat and fstat syscalls below.
 pub struct Stat {
@@ -120,7 +122,38 @@ pub fun write(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
 }
 
 pub fun getcwd(buf: ptr<u8>, size: i64) -> i64 {
-    return syscall2(326, buf as i64, size);
+    if (buf == null || size <= 0) {
+        return -22;
+    }
+
+    // Darwin has no getcwd syscall: slot 326 is nosys. Resolve the path of
+    // an open descriptor for "." with F_GETPATH and copy it to the caller.
+    var directory: i64 = open(".", FS_O_RDONLY, 0);
+    if (directory < 0) {
+        return directory;
+    }
+
+    var resolved: array<u8, 1024>;
+    var result: i64 = fcntl(directory, FS_F_GETPATH, &resolved[0] as i64);
+    close(directory);
+    if (result < 0) {
+        return result;
+    }
+
+    var length: i64 = 0;
+    while (length < FS_MAX_PATH && resolved[length] != 0) {
+        length += 1;
+    }
+    if (length >= FS_MAX_PATH || length + 1 > size) {
+        return -34;
+    }
+
+    var i: i64 = 0;
+    while (i <= length) {
+        buf[i] = resolved[i];
+        i += 1;
+    }
+    return length;
 }
 
 pub fun chdir(path: str) -> i64 {

--- a/std/sys/macos/arm64/memory.wave
+++ b/std/sys/macos/arm64/memory.wave
@@ -1,0 +1,92 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// macOS memory syscalls
+// =======================================================
+
+import("std::sys::macos::arm64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub const PROT_READ: i32 = 1;
+pub const PROT_WRITE: i32 = 2;
+pub const MAP_PRIVATE: i32 = 2;
+pub const MAP_ANON: i32 = 0x1000;
+
+pub fun mmap(
+    addr: ptr<i8>,
+    length: i64,
+    prot: i32,
+    flags: i32,
+    fd: i64,
+    offset: i64
+) -> ptr<i8> {
+    return syscall6(
+        197,
+        addr as i64,
+        length,
+        prot as i64,
+        flags as i64,
+        fd,
+        offset
+    ) as ptr<i8>;
+}
+
+pub fun munmap(addr: ptr<i8>, length: i64) -> i64 {
+    return syscall2(73, addr as i64, length);
+}
+
+pub fun brk(addr: ptr<i8>) -> ptr<i8> {
+    return syscall1(17, addr as i64) as ptr<i8>;
+}
+
+pub fun sys_alloc(size: i64) -> ptr<u8> {
+    if (size <= 0) {
+        return null;
+    }
+
+    var p: ptr<i8> = mmap(
+        null,
+        size,
+        PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANON,
+        -1,
+        0
+    );
+
+    if ((p as i64) < 0) {
+        return null;
+    }
+
+    return p as ptr<u8>;
+}
+
+pub fun sys_free(p: ptr<u8>, size: i64) -> i64 {
+    if (p == null || size <= 0) {
+        return 0;
+    }
+
+    return munmap(p as ptr<i8>, size);
+}

--- a/std/sys/macos/arm64/process.wave
+++ b/std/sys/macos/arm64/process.wave
@@ -1,0 +1,64 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// macOS process syscalls
+// =======================================================
+
+import("std::sys::macos::arm64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub fun exit(code: i32) -> ! {
+    syscall1(1, code as i64);
+    while (true) { }
+}
+
+pub fun getpid() -> i64 {
+    return syscall0(20);
+}
+
+pub fun getppid() -> i64 {
+    return syscall0(39);
+}
+
+pub fun fork() -> i64 {
+    return syscall0(2);
+}
+
+pub fun execve(
+    path: str,
+    argv: ptr<ptr<i8>>,
+    envp: ptr<ptr<i8>>
+) -> i64 {
+    return syscall3(59, path as i64, argv as i64, envp as i64);
+}
+
+pub fun waitpid(pid: i64, status: ptr<i32>, options: i32) -> i64 {
+    return syscall4(7, pid, status as i64, options as i64, 0);
+}
+
+pub fun kill(pid: i64, sig: i32) -> i64 {
+    return syscall2(37, pid, sig as i64);
+}

--- a/std/sys/macos/arm64/socket.wave
+++ b/std/sys/macos/arm64/socket.wave
@@ -1,0 +1,172 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// macOS socket syscalls
+// =======================================================
+//
+// Raw socket layer for macOS built on syscall.wave.
+// =======================================================
+
+import("std::sys::macos::arm64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub const AF_INET: i32 = 2;
+pub const AF_INET6: i32 = 30;
+
+pub const SOCK_STREAM: i32 = 1;
+pub const SOCK_DGRAM: i32 = 2;
+
+pub const IPPROTO_IP: i32 = 0;
+pub const IPPROTO_TCP: i32 = 6;
+pub const IPPROTO_UDP: i32 = 17;
+
+pub const SHUT_RD: i32 = 0;
+pub const SHUT_WR: i32 = 1;
+pub const SHUT_RDWR: i32 = 2;
+
+pub const SOL_SOCKET: i32 = 0xFFFF;
+pub const SO_REUSEADDR: i32 = 0x0004;
+pub const SO_REUSEPORT: i32 = 0x0200;
+
+pub const POLLIN: i16 = 0x001;
+pub const POLLOUT: i16 = 0x004;
+pub const POLLERR: i16 = 0x008;
+pub const POLLHUP: i16 = 0x010;
+pub const POLLNVAL: i16 = 0x020;
+
+pub struct PollFd {
+    fd: i32;
+    events: i16;
+    revents: i16;
+}
+
+pub fun socket(domain: i32, ty: i32, protocol: i32) -> i64 {
+    return syscall3(97, domain as i64, ty as i64, protocol as i64);
+}
+
+pub fun bind(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
+    return syscall3(104, fd, addr as i64, len as i64);
+}
+
+pub fun listen(fd: i64, backlog: i32) -> i64 {
+    return syscall2(106, fd, backlog as i64);
+}
+
+pub fun accept(fd: i64, addr: ptr<i8>, len: ptr<i32>) -> i64 {
+    return syscall3(30, fd, addr as i64, len as i64);
+}
+
+pub fun connect(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
+    return syscall3(98, fd, addr as i64, len as i64);
+}
+
+pub fun shutdown(fd: i64, how: i32) -> i64 {
+    return syscall2(134, fd, how as i64);
+}
+
+pub fun setsockopt(
+    fd: i64,
+    level: i32,
+    optname: i32,
+    optval: ptr<i8>,
+    optlen: i32
+) -> i64 {
+    return syscall5(
+        105,
+        fd,
+        level as i64,
+        optname as i64,
+        optval as i64,
+        optlen as i64
+    );
+}
+
+pub fun getsockopt(
+    fd: i64,
+    level: i32,
+    optname: i32,
+    optval: ptr<i8>,
+    optlen: ptr<i32>
+) -> i64 {
+    return syscall5(
+        118,
+        fd,
+        level as i64,
+        optname as i64,
+        optval as i64,
+        optlen as i64
+    );
+}
+
+pub fun poll(fds: ptr<PollFd>, nfds: i64, timeout_ms: i32) -> i64 {
+    return syscall3(230, fds as i64, nfds, timeout_ms as i64);
+}
+
+pub fun send(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
+    return sendto(fd, buf, len, flags, null, 0);
+}
+
+pub fun recv(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
+    return recvfrom(fd, buf, len, flags, null, null);
+}
+
+pub fun sendto(
+    fd: i64,
+    buf: ptr<u8>,
+    len: i64,
+    flags: i32,
+    addr: ptr<i8>,
+    addrlen: i32
+) -> i64 {
+    return syscall6(
+        133,
+        fd,
+        buf as i64,
+        len,
+        flags as i64,
+        addr as i64,
+        addrlen as i64
+    );
+}
+
+pub fun recvfrom(
+    fd: i64,
+    buf: ptr<u8>,
+    len: i64,
+    flags: i32,
+    addr: ptr<i8>,
+    addrlen: ptr<i32>
+) -> i64 {
+    return syscall6(
+        29,
+        fd,
+        buf as i64,
+        len,
+        flags as i64,
+        addr as i64,
+        addrlen as i64
+    );
+}

--- a/std/sys/macos/arm64/syscall.wave
+++ b/std/sys/macos/arm64/syscall.wave
@@ -1,0 +1,120 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Darwin AArch64 passes the BSD syscall number in x16 and arguments in
+// x0-x5. The kernel reports failures through the carry flag; `cneg` converts
+// the positive errno in x0 to the -errno convention used by std/sys.
+
+pub fun syscall0(id: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "svc #0x80\ncneg x0, x0, cs"
+        in("x16") id
+        out("x0") ret
+    }
+    return ret;
+}
+
+pub fun syscall1(id: i64, a1: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "svc #0x80\ncneg x0, x0, cs"
+        in("x16") id
+        in("x0") a1
+        out("x0") ret
+    }
+    return ret;
+}
+
+pub fun syscall2(id: i64, a1: i64, a2: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "svc #0x80\ncneg x0, x0, cs"
+        in("x16") id
+        in("x0") a1
+        in("x1") a2
+        out("x0") ret
+    }
+    return ret;
+}
+
+pub fun syscall3(id: i64, a1: i64, a2: i64, a3: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "svc #0x80\ncneg x0, x0, cs"
+        in("x16") id
+        in("x0") a1
+        in("x1") a2
+        in("x2") a3
+        out("x0") ret
+    }
+    return ret;
+}
+
+pub fun syscall4(id: i64, a1: i64, a2: i64, a3: i64, a4: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "svc #0x80\ncneg x0, x0, cs"
+        in("x16") id
+        in("x0") a1
+        in("x1") a2
+        in("x2") a3
+        in("x3") a4
+        out("x0") ret
+    }
+    return ret;
+}
+
+pub fun syscall5(id: i64, a1: i64, a2: i64, a3: i64, a4: i64, a5: i64) -> i64 {
+    var ret: i64;
+    asm {
+        "svc #0x80\ncneg x0, x0, cs"
+        in("x16") id
+        in("x0") a1
+        in("x1") a2
+        in("x2") a3
+        in("x3") a4
+        in("x4") a5
+        out("x0") ret
+    }
+    return ret;
+}
+
+pub fun syscall6(
+    id: i64,
+    a1: i64,
+    a2: i64,
+    a3: i64,
+    a4: i64,
+    a5: i64,
+    a6: i64
+) -> i64 {
+    var ret: i64;
+    asm {
+        "svc #0x80\ncneg x0, x0, cs"
+        in("x16") id
+        in("x0") a1
+        in("x1") a2
+        in("x2") a3
+        in("x3") a4
+        in("x4") a5
+        in("x5") a6
+        out("x0") ret
+    }
+    return ret;
+}

--- a/std/sys/macos/arm64/time.wave
+++ b/std/sys/macos/arm64/time.wave
@@ -1,0 +1,44 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// macOS time syscalls
+// =======================================================
+
+import("std::sys::macos::arm64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub struct TimeSpec {
+    sec: i64;
+    nsec: i64;
+}
+
+pub fun nanosleep(req: ptr<TimeSpec>, rem: ptr<TimeSpec>) -> i64 {
+    return syscall2(240, req as i64, rem as i64);
+}
+
+pub fun clock_gettime(clock_id: i32, tp: ptr<TimeSpec>) -> i64 {
+    return syscall2(116, clock_id as i64, tp as i64);
+}

--- a/std/sys/macos/arm64/tty.wave
+++ b/std/sys/macos/arm64/tty.wave
@@ -1,0 +1,137 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// =======================================================
+// macOS tty helpers
+// =======================================================
+
+import("std::sys::macos::arm64::syscall")::{
+    syscall0,
+    syscall1,
+    syscall2,
+    syscall3,
+    syscall4,
+    syscall5,
+    syscall6,
+};
+
+pub const TTY_SYS_IOCTL: i64 = 54;
+pub const TTY_SYS_FCNTL: i64 = 92;
+
+pub const TTY_TCGETS: i64 = 0x40487413;
+pub const TTY_TCSETS: i64 = 0x80487414;
+pub const TTY_TCSETSW: i64 = 0x80487415;
+pub const TTY_TCSETSF: i64 = 0x80487416;
+
+pub const TTY_TCSANOW: i32 = 0;
+pub const TTY_TCSADRAIN: i32 = 1;
+pub const TTY_TCSAFLUSH: i32 = 2;
+
+pub const TTY_F_GETFL: i32 = 3;
+pub const TTY_F_SETFL: i32 = 4;
+pub const TTY_O_NONBLOCK: i32 = 4;
+
+pub const TTY_ICANON: u64 = 0x00000100;
+pub const TTY_ECHO: u64 = 0x00000008;
+
+pub struct Termios {
+    c_iflag: u64;
+    c_oflag: u64;
+    c_cflag: u64;
+    c_lflag: u64;
+    c_cc: array<u8, 20>;
+    c_ispeed: u64;
+    c_ospeed: u64;
+}
+
+pub struct TtyRawState {
+    term: Termios;
+    flags: i32;
+    active: i32;
+}
+
+pub fun tty_getattr(fd: i32, t: ptr<Termios>) -> i64 {
+    return syscall3(TTY_SYS_IOCTL, fd as i64, TTY_TCGETS, t as i64);
+}
+
+pub fun tty_setattr(fd: i32, action: i32, t: ptr<Termios>) -> i64 {
+    var req: i64 = TTY_TCSETS;
+
+    if (action == TTY_TCSADRAIN) {
+        req = TTY_TCSETSW;
+    } else if (action == TTY_TCSAFLUSH) {
+        req = TTY_TCSETSF;
+    }
+
+    return syscall3(TTY_SYS_IOCTL, fd as i64, req, t as i64);
+}
+
+pub fun tty_getfl(fd: i32) -> i64 {
+    return syscall3(TTY_SYS_FCNTL, fd as i64, TTY_F_GETFL as i64, 0);
+}
+
+pub fun tty_setfl(fd: i32, flags: i32) -> i64 {
+    return syscall3(TTY_SYS_FCNTL, fd as i64, TTY_F_SETFL as i64, flags as i64);
+}
+
+pub fun tty_enable_raw_nonblock(fd: i32, st: ptr<TtyRawState>) -> i64 {
+    deref st.active = 0;
+    var vmin_idx: i32 = 16;
+    var vtime_idx: i32 = 17;
+
+    var orig: Termios;
+    if (tty_getattr(fd, &orig) < 0) {
+        return -1;
+    }
+
+    var raw: Termios = orig;
+    raw.c_lflag = raw.c_lflag & ~(TTY_ICANON | TTY_ECHO);
+    raw.c_cc[vmin_idx] = 0;
+    raw.c_cc[vtime_idx] = 0;
+
+    if (tty_setattr(fd, TTY_TCSANOW, &raw) < 0) {
+        return -1;
+    }
+
+    var flags_raw: i64 = tty_getfl(fd);
+    if (flags_raw < 0) {
+        tty_setattr(fd, TTY_TCSANOW, &orig);
+        return -1;
+    }
+
+    var old_flags: i32 = flags_raw as i32;
+    if (tty_setfl(fd, old_flags | TTY_O_NONBLOCK) < 0) {
+        tty_setattr(fd, TTY_TCSANOW, &orig);
+        return -1;
+    }
+
+    deref st.term = orig;
+    deref st.flags = old_flags;
+    deref st.active = 1;
+    return 0;
+}
+
+pub fun tty_restore(fd: i32, st: ptr<TtyRawState>) {
+    if (deref st.active == 0) {
+        return;
+    }
+
+    var orig: Termios = deref st.term;
+    tty_setattr(fd, TTY_TCSANOW, &orig);
+    tty_setfl(fd, deref st.flags);
+}

--- a/std/sys/macos/env.wave
+++ b/std/sys/macos/env.wave
@@ -1,28 +1,11 @@
 // This file is part of the Wave language project.
-// Copyright (c) 2024-2026 Wave Foundation
-// Copyright (c) 2024-2026 LunaStev and contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// Copyright (c) 2024-2026 Wave Foundation and contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// ENOSYS-style return for not implemented path.
-pub const ERR_NOT_IMPLEMENTED: i64 = -38;
+// macOS environment provider selected by target architecture.
 
-pub fun env_read(buf: ptr<u8>, cap: i64) -> i64 {
-    if (buf == null || cap <= 0) {
-        return -22;
-    }
+#[target(arch="x86_64")]
+pub import("std::sys::macos::amd64::env")::{ERR_NOT_IMPLEMENTED, env_read};
 
-    return ERR_NOT_IMPLEMENTED;
-}
+#[target(arch="aarch64")]
+pub import("std::sys::macos::arm64::env")::{ERR_NOT_IMPLEMENTED, env_read};

--- a/std/sys/macos/fs.wave
+++ b/std/sys/macos/fs.wave
@@ -1,146 +1,25 @@
 // This file is part of the Wave language project.
-// Copyright (c) 2024-2026 Wave Foundation
-// Copyright (c) 2024-2026 LunaStev and contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// Copyright (c) 2024-2026 Wave Foundation and contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// macOS filesystem syscalls
-// =======================================================
+// macOS filesystem provider selected by target architecture.
 
-import("std::sys::macos::syscall")::{
-    MACOS_SYSCALL_BASE,
-    syscall0,
-    syscall1,
-    syscall2,
-    syscall3,
-    syscall4,
-    syscall5,
-    syscall6,
+#[target(arch="x86_64")]
+pub import("std::sys::macos::amd64::fs")::{
+    FS_O_RDONLY, FS_O_WRONLY, FS_O_RDWR, FS_O_CREAT, FS_O_EXCL,
+    FS_O_TRUNC, FS_O_APPEND, FS_O_NONBLOCK,
+    FS_F_OK, FS_X_OK, FS_W_OK, FS_R_OK,
+    FS_SEEK_SET, FS_SEEK_CUR, FS_SEEK_END, FS_F_GETFL, FS_F_SETFL,
+    open, close, dup, dup2, pipe, fsync, fcntl, read, write, getcwd,
+    chdir, access, lseek, unlink, mkdir, rmdir, rename_path, Stat, stat, fstat,
 };
 
-// open flags
-pub const FS_O_RDONLY: i32 = 0;
-pub const FS_O_WRONLY: i32 = 1;
-pub const FS_O_RDWR: i32 = 2;
-pub const FS_O_NONBLOCK: i32 = 4;
-pub const FS_O_APPEND: i32 = 8;
-pub const FS_O_CREAT: i32 = 512;
-pub const FS_O_TRUNC: i32 = 1024;
-pub const FS_O_EXCL: i32 = 2048;
-
-// access modes
-pub const FS_F_OK: i32 = 0;
-pub const FS_X_OK: i32 = 1;
-pub const FS_W_OK: i32 = 2;
-pub const FS_R_OK: i32 = 4;
-
-// seek modes
-pub const FS_SEEK_SET: i32 = 0;
-pub const FS_SEEK_CUR: i32 = 1;
-pub const FS_SEEK_END: i32 = 2;
-
-// fcntl modes
-pub const FS_F_GETFL: i32 = 3;
-pub const FS_F_SETFL: i32 = 4;
-
-pub struct Stat {
-    dev: i64;
-    ino: i64;
-    nlink: i64;
-    mode: i32;
-    uid: i32;
-    gid: i32;
-    pad0: i32;
-    rdev: i64;
-    size: i64;
-    blksize: i64;
-    blocks: i64;
-    atime: i64;
-    mtime: i64;
-    ctime: i64;
-}
-
-pub fun open(path: str, flags: i32, mode: i32) -> i64 {
-    return syscall3(5, path as i64, flags as i64, mode as i64);
-}
-
-pub fun close(fd: i64) -> i64 {
-    return syscall1(6, fd);
-}
-
-pub fun dup(fd: i64) -> i64 {
-    return syscall1(41, fd);
-}
-
-pub fun pipe(fds: ptr<i32>) -> i64 {
-    return syscall1(42, fds as i64);
-}
-
-pub fun dup2(oldfd: i64, newfd: i64) -> i64 {
-    return syscall2(90, oldfd, newfd);
-}
-
-pub fun fsync(fd: i64) -> i64 {
-    return syscall1(95, fd);
-}
-
-pub fun fcntl(fd: i64, cmd: i32, arg: i64) -> i64 {
-    return syscall3(92, fd, cmd as i64, arg);
-}
-
-pub fun read(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
-    return syscall3(3, fd, buf as i64, len);
-}
-
-pub fun write(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
-    return syscall3(4, fd, buf as i64, len);
-}
-
-pub fun getcwd(buf: ptr<u8>, size: i64) -> i64 {
-    return syscall2(326, buf as i64, size);
-}
-
-pub fun chdir(path: str) -> i64 {
-    return syscall1(12, path as i64);
-}
-
-pub fun access(path: str, mode: i32) -> i64 {
-    return syscall2(33, path as i64, mode as i64);
-}
-
-pub fun lseek(fd: i64, offset: i64, whence: i32) -> i64 {
-    return syscall3(199, fd, offset, whence as i64);
-}
-
-pub fun unlink(path: str) -> i64 {
-    return syscall1(10, path as i64);
-}
-
-pub fun mkdir(path: str, mode: i32) -> i64 {
-    return syscall2(136, path as i64, mode as i64);
-}
-
-pub fun rmdir(path: str) -> i64 {
-    return syscall1(137, path as i64);
-}
-
-pub fun stat(path: str, st: ptr<Stat>) -> i64 {
-    return syscall2(338, path as i64, st as i64);
-}
-
-pub fun fstat(fd: i64, st: ptr<Stat>) -> i64 {
-    return syscall2(339, fd, st as i64);
-}
+#[target(arch="aarch64")]
+pub import("std::sys::macos::arm64::fs")::{
+    FS_O_RDONLY, FS_O_WRONLY, FS_O_RDWR, FS_O_CREAT, FS_O_EXCL,
+    FS_O_TRUNC, FS_O_APPEND, FS_O_NONBLOCK,
+    FS_F_OK, FS_X_OK, FS_W_OK, FS_R_OK,
+    FS_SEEK_SET, FS_SEEK_CUR, FS_SEEK_END, FS_F_GETFL, FS_F_SETFL,
+    open, close, dup, dup2, pipe, fsync, fcntl, read, write, getcwd,
+    chdir, access, lseek, unlink, mkdir, rmdir, rename_path, Stat, stat, fstat,
+};

--- a/std/sys/macos/memory.wave
+++ b/std/sys/macos/memory.wave
@@ -1,93 +1,17 @@
 // This file is part of the Wave language project.
-// Copyright (c) 2024-2026 Wave Foundation
-// Copyright (c) 2024-2026 LunaStev and contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// Copyright (c) 2024-2026 Wave Foundation and contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// macOS memory syscalls
-// =======================================================
+// macOS virtual-memory provider selected by target architecture.
 
-import("std::sys::macos::syscall")::{
-    MACOS_SYSCALL_BASE,
-    syscall0,
-    syscall1,
-    syscall2,
-    syscall3,
-    syscall4,
-    syscall5,
-    syscall6,
+#[target(arch="x86_64")]
+pub import("std::sys::macos::amd64::memory")::{
+    PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANON,
+    mmap, munmap, brk, sys_alloc, sys_free,
 };
 
-pub const PROT_READ: i32 = 1;
-pub const PROT_WRITE: i32 = 2;
-pub const MAP_PRIVATE: i32 = 2;
-pub const MAP_ANON: i32 = 0x1000;
-
-pub fun mmap(
-    addr: ptr<i8>,
-    length: i64,
-    prot: i32,
-    flags: i32,
-    fd: i64,
-    offset: i64
-) -> ptr<i8> {
-    return syscall6(
-        197,
-        addr as i64,
-        length,
-        prot as i64,
-        flags as i64,
-        fd,
-        offset
-    ) as ptr<i8>;
-}
-
-pub fun munmap(addr: ptr<i8>, length: i64) -> i64 {
-    return syscall2(73, addr as i64, length);
-}
-
-pub fun brk(addr: ptr<i8>) -> ptr<i8> {
-    return syscall1(17, addr as i64) as ptr<i8>;
-}
-
-pub fun sys_alloc(size: i64) -> ptr<u8> {
-    if (size <= 0) {
-        return null;
-    }
-
-    var p: ptr<i8> = mmap(
-        null,
-        size,
-        PROT_READ | PROT_WRITE,
-        MAP_PRIVATE | MAP_ANON,
-        -1,
-        0
-    );
-
-    if ((p as i64) < 0) {
-        return null;
-    }
-
-    return p as ptr<u8>;
-}
-
-pub fun sys_free(p: ptr<u8>, size: i64) -> i64 {
-    if (p == null || size <= 0) {
-        return 0;
-    }
-
-    return munmap(p as ptr<i8>, size);
-}
+#[target(arch="aarch64")]
+pub import("std::sys::macos::arm64::memory")::{
+    PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANON,
+    mmap, munmap, brk, sys_alloc, sys_free,
+};

--- a/std/sys/macos/process.wave
+++ b/std/sys/macos/process.wave
@@ -1,65 +1,15 @@
 // This file is part of the Wave language project.
-// Copyright (c) 2024-2026 Wave Foundation
-// Copyright (c) 2024-2026 LunaStev and contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// Copyright (c) 2024-2026 Wave Foundation and contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// macOS process syscalls
-// =======================================================
+// macOS process provider selected by target architecture.
 
-import("std::sys::macos::syscall")::{
-    MACOS_SYSCALL_BASE,
-    syscall0,
-    syscall1,
-    syscall2,
-    syscall3,
-    syscall4,
-    syscall5,
-    syscall6,
+#[target(arch="x86_64")]
+pub import("std::sys::macos::amd64::process")::{
+    exit, getpid, getppid, fork, execve, waitpid, kill,
 };
 
-pub fun exit(code: i32) -> ! {
-    syscall1(1, code as i64);
-    while (true) { }
-}
-
-pub fun getpid() -> i64 {
-    return syscall0(20);
-}
-
-pub fun getppid() -> i64 {
-    return syscall0(39);
-}
-
-pub fun fork() -> i64 {
-    return syscall0(2);
-}
-
-pub fun execve(
-    path: str,
-    argv: ptr<ptr<i8>>,
-    envp: ptr<ptr<i8>>
-) -> i64 {
-    return syscall3(59, path as i64, argv as i64, envp as i64);
-}
-
-pub fun waitpid(pid: i64, status: ptr<i32>, options: i32) -> i64 {
-    return syscall4(7, pid, status as i64, options as i64, 0);
-}
-
-pub fun kill(pid: i64, sig: i32) -> i64 {
-    return syscall2(37, pid, sig as i64);
-}
+#[target(arch="aarch64")]
+pub import("std::sys::macos::arm64::process")::{
+    exit, getpid, getppid, fork, execve, waitpid, kill,
+};

--- a/std/sys/macos/socket.wave
+++ b/std/sys/macos/socket.wave
@@ -1,173 +1,25 @@
 // This file is part of the Wave language project.
-// Copyright (c) 2024-2026 Wave Foundation
-// Copyright (c) 2024-2026 LunaStev and contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// Copyright (c) 2024-2026 Wave Foundation and contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// macOS socket syscalls
-// =======================================================
-//
-// Raw socket layer for macOS built on syscall.wave.
-// =======================================================
+// macOS socket provider selected by target architecture.
 
-import("std::sys::macos::syscall")::{
-    MACOS_SYSCALL_BASE,
-    syscall0,
-    syscall1,
-    syscall2,
-    syscall3,
-    syscall4,
-    syscall5,
-    syscall6,
+#[target(arch="x86_64")]
+pub import("std::sys::macos::amd64::socket")::{
+    AF_INET, AF_INET6, SOCK_STREAM, SOCK_DGRAM,
+    IPPROTO_IP, IPPROTO_TCP, IPPROTO_UDP,
+    SHUT_RD, SHUT_WR, SHUT_RDWR, SOL_SOCKET, SO_REUSEADDR, SO_REUSEPORT,
+    POLLIN, POLLOUT, POLLERR, POLLHUP, POLLNVAL, PollFd,
+    socket, bind, listen, accept, connect, shutdown, setsockopt, getsockopt,
+    poll, send, recv, sendto, recvfrom,
 };
 
-pub const AF_INET: i32 = 2;
-pub const AF_INET6: i32 = 30;
-
-pub const SOCK_STREAM: i32 = 1;
-pub const SOCK_DGRAM: i32 = 2;
-
-pub const IPPROTO_IP: i32 = 0;
-pub const IPPROTO_TCP: i32 = 6;
-pub const IPPROTO_UDP: i32 = 17;
-
-pub const SHUT_RD: i32 = 0;
-pub const SHUT_WR: i32 = 1;
-pub const SHUT_RDWR: i32 = 2;
-
-pub const SOL_SOCKET: i32 = 0xFFFF;
-pub const SO_REUSEADDR: i32 = 0x0004;
-pub const SO_REUSEPORT: i32 = 0x0200;
-
-pub const POLLIN: i16 = 0x001;
-pub const POLLOUT: i16 = 0x004;
-pub const POLLERR: i16 = 0x008;
-pub const POLLHUP: i16 = 0x010;
-pub const POLLNVAL: i16 = 0x020;
-
-pub struct PollFd {
-    fd: i32;
-    events: i16;
-    revents: i16;
-}
-
-pub fun socket(domain: i32, ty: i32, protocol: i32) -> i64 {
-    return syscall3(97, domain as i64, ty as i64, protocol as i64);
-}
-
-pub fun bind(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
-    return syscall3(104, fd, addr as i64, len as i64);
-}
-
-pub fun listen(fd: i64, backlog: i32) -> i64 {
-    return syscall2(106, fd, backlog as i64);
-}
-
-pub fun accept(fd: i64, addr: ptr<i8>, len: ptr<i32>) -> i64 {
-    return syscall3(30, fd, addr as i64, len as i64);
-}
-
-pub fun connect(fd: i64, addr: ptr<i8>, len: i32) -> i64 {
-    return syscall3(98, fd, addr as i64, len as i64);
-}
-
-pub fun shutdown(fd: i64, how: i32) -> i64 {
-    return syscall2(134, fd, how as i64);
-}
-
-pub fun setsockopt(
-    fd: i64,
-    level: i32,
-    optname: i32,
-    optval: ptr<i8>,
-    optlen: i32
-) -> i64 {
-    return syscall5(
-        105,
-        fd,
-        level as i64,
-        optname as i64,
-        optval as i64,
-        optlen as i64
-    );
-}
-
-pub fun getsockopt(
-    fd: i64,
-    level: i32,
-    optname: i32,
-    optval: ptr<i8>,
-    optlen: ptr<i32>
-) -> i64 {
-    return syscall5(
-        118,
-        fd,
-        level as i64,
-        optname as i64,
-        optval as i64,
-        optlen as i64
-    );
-}
-
-pub fun poll(fds: ptr<PollFd>, nfds: i64, timeout_ms: i32) -> i64 {
-    return syscall3(230, fds as i64, nfds, timeout_ms as i64);
-}
-
-pub fun send(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
-    return sendto(fd, buf, len, flags, null, 0);
-}
-
-pub fun recv(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
-    return recvfrom(fd, buf, len, flags, null, null);
-}
-
-pub fun sendto(
-    fd: i64,
-    buf: ptr<u8>,
-    len: i64,
-    flags: i32,
-    addr: ptr<i8>,
-    addrlen: i32
-) -> i64 {
-    return syscall6(
-        133,
-        fd,
-        buf as i64,
-        len,
-        flags as i64,
-        addr as i64,
-        addrlen as i64
-    );
-}
-
-pub fun recvfrom(
-    fd: i64,
-    buf: ptr<u8>,
-    len: i64,
-    flags: i32,
-    addr: ptr<i8>,
-    addrlen: ptr<i32>
-) -> i64 {
-    return syscall6(
-        29,
-        fd,
-        buf as i64,
-        len,
-        flags as i64,
-        addr as i64,
-        addrlen as i64
-    );
-}
+#[target(arch="aarch64")]
+pub import("std::sys::macos::arm64::socket")::{
+    AF_INET, AF_INET6, SOCK_STREAM, SOCK_DGRAM,
+    IPPROTO_IP, IPPROTO_TCP, IPPROTO_UDP,
+    SHUT_RD, SHUT_WR, SHUT_RDWR, SOL_SOCKET, SO_REUSEADDR, SO_REUSEPORT,
+    POLLIN, POLLOUT, POLLERR, POLLHUP, POLLNVAL, PollFd,
+    socket, bind, listen, accept, connect, shutdown, setsockopt, getsockopt,
+    poll, send, recv, sendto, recvfrom,
+};

--- a/std/sys/macos/syscall.wave
+++ b/std/sys/macos/syscall.wave
@@ -1,126 +1,15 @@
 // This file is part of the Wave language project.
-// Copyright (c) 2024-2026 Wave Foundation
-// Copyright (c) 2024-2026 LunaStev and contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// Copyright (c) 2024-2026 Wave Foundation and contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// macOS x86_64 syscall entry helpers
-// =======================================================
-//
-// Raw syscall helpers for Darwin.
-// Return values follow kernel convention:
-//   negative return value = -errno
-// =======================================================
+// macOS syscall entry selected by target architecture.
 
-pub const MACOS_SYSCALL_BASE: i64 = 0x2000000;
+#[target(arch="x86_64")]
+pub import("std::sys::macos::amd64::syscall")::{
+    syscall0, syscall1, syscall2, syscall3, syscall4, syscall5, syscall6,
+};
 
-pub fun syscall0(id: i64) -> i64 {
-    var ret: i64;
-    var sysno: i64 = MACOS_SYSCALL_BASE + id;
-    asm {
-        "syscall"
-        in("rax") sysno
-        out("rax") ret
-    }
-    return ret;
-}
-
-pub fun syscall1(id: i64, a1: i64) -> i64 {
-    var ret: i64;
-    var sysno: i64 = MACOS_SYSCALL_BASE + id;
-    asm {
-        "syscall"
-        in("rax") sysno
-        in("rdi") a1
-        out("rax") ret
-    }
-    return ret;
-}
-
-pub fun syscall2(id: i64, a1: i64, a2: i64) -> i64 {
-    var ret: i64;
-    var sysno: i64 = MACOS_SYSCALL_BASE + id;
-    asm {
-        "syscall"
-        in("rax") sysno
-        in("rdi") a1
-        in("rsi") a2
-        out("rax") ret
-    }
-    return ret;
-}
-
-pub fun syscall3(id: i64, a1: i64, a2: i64, a3: i64) -> i64 {
-    var ret: i64;
-    var sysno: i64 = MACOS_SYSCALL_BASE + id;
-    asm {
-        "syscall"
-        in("rax") sysno
-        in("rdi") a1
-        in("rsi") a2
-        in("rdx") a3
-        out("rax") ret
-    }
-    return ret;
-}
-
-pub fun syscall4(id: i64, a1: i64, a2: i64, a3: i64, a4: i64) -> i64 {
-    var ret: i64;
-    var sysno: i64 = MACOS_SYSCALL_BASE + id;
-    asm {
-        "syscall"
-        in("rax") sysno
-        in("rdi") a1
-        in("rsi") a2
-        in("rdx") a3
-        in("r10") a4
-        out("rax") ret
-    }
-    return ret;
-}
-
-pub fun syscall5(id: i64, a1: i64, a2: i64, a3: i64, a4: i64, a5: i64) -> i64 {
-    var ret: i64;
-    var sysno: i64 = MACOS_SYSCALL_BASE + id;
-    asm {
-        "syscall"
-        in("rax") sysno
-        in("rdi") a1
-        in("rsi") a2
-        in("rdx") a3
-        in("r10") a4
-        in("r8") a5
-        out("rax") ret
-    }
-    return ret;
-}
-
-pub fun syscall6(id: i64, a1: i64, a2: i64, a3: i64, a4: i64, a5: i64, a6: i64) -> i64 {
-    var ret: i64;
-    var sysno: i64 = MACOS_SYSCALL_BASE + id;
-    asm {
-        "syscall"
-        in("rax") sysno
-        in("rdi") a1
-        in("rsi") a2
-        in("rdx") a3
-        in("r10") a4
-        in("r8") a5
-        in("r9") a6
-        out("rax") ret
-    }
-    return ret;
-}
+#[target(arch="aarch64")]
+pub import("std::sys::macos::arm64::syscall")::{
+    syscall0, syscall1, syscall2, syscall3, syscall4, syscall5, syscall6,
+};

--- a/std/sys/macos/time.wave
+++ b/std/sys/macos/time.wave
@@ -1,45 +1,11 @@
 // This file is part of the Wave language project.
-// Copyright (c) 2024-2026 Wave Foundation
-// Copyright (c) 2024-2026 LunaStev and contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// Copyright (c) 2024-2026 Wave Foundation and contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// macOS time syscalls
-// =======================================================
+// macOS clock provider selected by target architecture.
 
-import("std::sys::macos::syscall")::{
-    MACOS_SYSCALL_BASE,
-    syscall0,
-    syscall1,
-    syscall2,
-    syscall3,
-    syscall4,
-    syscall5,
-    syscall6,
-};
+#[target(arch="x86_64")]
+pub import("std::sys::macos::amd64::time")::{TimeSpec, nanosleep, clock_gettime};
 
-pub struct TimeSpec {
-    sec: i64;
-    nsec: i64;
-}
-
-pub fun nanosleep(req: ptr<TimeSpec>, rem: ptr<TimeSpec>) -> i64 {
-    return syscall2(240, req as i64, rem as i64);
-}
-
-pub fun clock_gettime(clock_id: i32, tp: ptr<TimeSpec>) -> i64 {
-    return syscall2(116, clock_id as i64, tp as i64);
-}
+#[target(arch="aarch64")]
+pub import("std::sys::macos::arm64::time")::{TimeSpec, nanosleep, clock_gettime};

--- a/std/sys/macos/tty.wave
+++ b/std/sys/macos/tty.wave
@@ -1,139 +1,25 @@
 // This file is part of the Wave language project.
-// Copyright (c) 2024-2026 Wave Foundation
-// Copyright (c) 2024-2026 LunaStev and contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// Copyright (c) 2024-2026 Wave Foundation and contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// macOS tty helpers
-// =======================================================
+// macOS terminal provider selected by target architecture.
 
-import("std::sys::macos::syscall")::{
-    MACOS_SYSCALL_BASE,
-    syscall0,
-    syscall1,
-    syscall2,
-    syscall3,
-    syscall4,
-    syscall5,
-    syscall6,
+#[target(arch="x86_64")]
+pub import("std::sys::macos::amd64::tty")::{
+    TTY_SYS_IOCTL, TTY_SYS_FCNTL, TTY_TCGETS, TTY_TCSETS, TTY_TCSETSW,
+    TTY_TCSETSF, TTY_TCSANOW, TTY_TCSADRAIN, TTY_TCSAFLUSH,
+    TTY_F_GETFL, TTY_F_SETFL, TTY_O_NONBLOCK, TTY_ICANON, TTY_ECHO,
+    Termios, TtyRawState,
+    tty_getattr, tty_setattr, tty_getfl, tty_setfl,
+    tty_enable_raw_nonblock, tty_restore,
 };
 
-pub const TTY_SYS_IOCTL: i64 = 54;
-pub const TTY_SYS_FCNTL: i64 = 92;
-
-pub const TTY_TCGETS: i64 = 0x40487413;
-pub const TTY_TCSETS: i64 = 0x80487414;
-pub const TTY_TCSETSW: i64 = 0x80487415;
-pub const TTY_TCSETSF: i64 = 0x80487416;
-
-pub const TTY_TCSANOW: i32 = 0;
-pub const TTY_TCSADRAIN: i32 = 1;
-pub const TTY_TCSAFLUSH: i32 = 2;
-
-pub const TTY_F_GETFL: i32 = 3;
-pub const TTY_F_SETFL: i32 = 4;
-pub const TTY_O_NONBLOCK: i32 = 4;
-
-pub const TTY_ICANON: u32 = 0x00000100;
-pub const TTY_ECHO: u32 = 0x00000008;
-
-pub struct Termios {
-    c_iflag: u32;
-    c_oflag: u32;
-    c_cflag: u32;
-    c_lflag: u32;
-    c_line: u8;
-    c_cc: array<u8, 32>;
-    c_ispeed: u32;
-    c_ospeed: u32;
-}
-
-pub struct TtyRawState {
-    term: Termios;
-    flags: i32;
-    active: i32;
-}
-
-pub fun tty_getattr(fd: i32, t: ptr<Termios>) -> i64 {
-    return syscall3(TTY_SYS_IOCTL, fd as i64, TTY_TCGETS, t as i64);
-}
-
-pub fun tty_setattr(fd: i32, action: i32, t: ptr<Termios>) -> i64 {
-    var req: i64 = TTY_TCSETS;
-
-    if (action == TTY_TCSADRAIN) {
-        req = TTY_TCSETSW;
-    } else if (action == TTY_TCSAFLUSH) {
-        req = TTY_TCSETSF;
-    }
-
-    return syscall3(TTY_SYS_IOCTL, fd as i64, req, t as i64);
-}
-
-pub fun tty_getfl(fd: i32) -> i64 {
-    return syscall3(TTY_SYS_FCNTL, fd as i64, TTY_F_GETFL as i64, 0);
-}
-
-pub fun tty_setfl(fd: i32, flags: i32) -> i64 {
-    return syscall3(TTY_SYS_FCNTL, fd as i64, TTY_F_SETFL as i64, flags as i64);
-}
-
-pub fun tty_enable_raw_nonblock(fd: i32, st: ptr<TtyRawState>) -> i64 {
-    deref st.active = 0;
-    var vmin_idx: i32 = 16;
-    var vtime_idx: i32 = 17;
-
-    var orig: Termios;
-    if (tty_getattr(fd, &orig) < 0) {
-        return -1;
-    }
-
-    var raw: Termios = orig;
-    raw.c_lflag = raw.c_lflag & ~(TTY_ICANON | TTY_ECHO);
-    raw.c_cc[vmin_idx] = 0;
-    raw.c_cc[vtime_idx] = 0;
-
-    if (tty_setattr(fd, TTY_TCSANOW, &raw) < 0) {
-        return -1;
-    }
-
-    var flags_raw: i64 = tty_getfl(fd);
-    if (flags_raw < 0) {
-        tty_setattr(fd, TTY_TCSANOW, &orig);
-        return -1;
-    }
-
-    var old_flags: i32 = flags_raw as i32;
-    if (tty_setfl(fd, old_flags | TTY_O_NONBLOCK) < 0) {
-        tty_setattr(fd, TTY_TCSANOW, &orig);
-        return -1;
-    }
-
-    deref st.term = orig;
-    deref st.flags = old_flags;
-    deref st.active = 1;
-    return 0;
-}
-
-pub fun tty_restore(fd: i32, st: ptr<TtyRawState>) {
-    if (deref st.active == 0) {
-        return;
-    }
-
-    var orig: Termios = deref st.term;
-    tty_setattr(fd, TTY_TCSANOW, &orig);
-    tty_setfl(fd, deref st.flags);
-}
+#[target(arch="aarch64")]
+pub import("std::sys::macos::arm64::tty")::{
+    TTY_SYS_IOCTL, TTY_SYS_FCNTL, TTY_TCGETS, TTY_TCSETS, TTY_TCSETSW,
+    TTY_TCSETSF, TTY_TCSANOW, TTY_TCSADRAIN, TTY_TCSAFLUSH,
+    TTY_F_GETFL, TTY_F_SETFL, TTY_O_NONBLOCK, TTY_ICANON, TTY_ECHO,
+    Termios, TtyRawState,
+    tty_getattr, tty_setattr, tty_getfl, tty_setfl,
+    tty_enable_raw_nonblock, tty_restore,
+};

--- a/std/sys/memory.wave
+++ b/std/sys/memory.wave
@@ -16,9 +16,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// Memory sys dispatcher
-// =======================================================
+// Selects the target virtual-memory ABI. std::mem builds its allocation
+// helpers on this raw, target-specific layer.
 
 #[target(os="linux")]
 pub import("std::sys::linux::memory")::{
@@ -33,7 +32,7 @@ pub import("std::sys::linux::memory")::{
     sys_free,
 };
 
-#[target(os="macos", arch="x86_64")]
+#[target(os="macos")]
 pub import("std::sys::macos::memory")::{
     PROT_READ,
     PROT_WRITE,
@@ -44,4 +43,16 @@ pub import("std::sys::macos::memory")::{
     brk,
     sys_alloc,
     sys_free,
+};
+
+#[target(os="windows")]
+pub import("std::sys::windows::memory")::{
+    PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS,
+    mmap, munmap, brk, sys_alloc, sys_free,
+};
+
+#[target(os="freebsd")]
+pub import("std::sys::freebsd::memory")::{
+    PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS,
+    mmap, munmap, brk, sys_alloc, sys_free,
 };

--- a/std/sys/process.wave
+++ b/std/sys/process.wave
@@ -16,9 +16,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// Process sys dispatcher
-// =======================================================
+// Selects the target process ABI. Callers that want portable process helpers
+// should use std::process instead of these raw operations.
 
 #[target(os="linux")]
 pub import("std::sys::linux::process")::{
@@ -31,7 +30,7 @@ pub import("std::sys::linux::process")::{
     kill,
 };
 
-#[target(os="macos", arch="x86_64")]
+#[target(os="macos")]
 pub import("std::sys::macos::process")::{
     exit,
     getpid,
@@ -40,4 +39,14 @@ pub import("std::sys::macos::process")::{
     execve,
     waitpid,
     kill,
+};
+
+#[target(os="windows")]
+pub import("std::sys::windows::process")::{
+    exit, getpid, getppid, fork, execve, waitpid, kill,
+};
+
+#[target(os="freebsd")]
+pub import("std::sys::freebsd::process")::{
+    exit, getpid, getppid, fork, execve, waitpid, kill,
 };

--- a/std/sys/socket.wave
+++ b/std/sys/socket.wave
@@ -16,13 +16,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// Socket sys dispatcher
-// =======================================================
-//
-// This layer selects the OS-specific socket implementation.
-// Keep target attributes only in this dispatch module.
-// =======================================================
+// Selects the target socket ABI. These symbols expose OS-level descriptors,
+// constants, and negative error results; std::net provides portable helpers.
 
 #[target(os="linux")]
 pub import("std::sys::linux::socket")::{
@@ -60,7 +55,7 @@ pub import("std::sys::linux::socket")::{
     recvfrom,
 };
 
-#[target(os="macos", arch="x86_64")]
+#[target(os="macos")]
 pub import("std::sys::macos::socket")::{
     AF_INET,
     AF_INET6,
@@ -94,4 +89,24 @@ pub import("std::sys::macos::socket")::{
     recv,
     sendto,
     recvfrom,
+};
+
+#[target(os="windows")]
+pub import("std::sys::windows::socket")::{
+    AF_INET, AF_INET6, SOCK_STREAM, SOCK_DGRAM,
+    IPPROTO_IP, IPPROTO_TCP, IPPROTO_UDP,
+    SHUT_RD, SHUT_WR, SHUT_RDWR, SOL_SOCKET, SO_REUSEADDR, SO_REUSEPORT,
+    POLLIN, POLLOUT, POLLERR, POLLHUP, POLLNVAL, PollFd,
+    socket, bind, listen, accept, connect, shutdown, setsockopt, getsockopt,
+    poll, send, recv, sendto, recvfrom,
+};
+
+#[target(os="freebsd")]
+pub import("std::sys::freebsd::socket")::{
+    AF_INET, AF_INET6, SOCK_STREAM, SOCK_DGRAM,
+    IPPROTO_IP, IPPROTO_TCP, IPPROTO_UDP,
+    SHUT_RD, SHUT_WR, SHUT_RDWR, SOL_SOCKET, SO_REUSEADDR, SO_REUSEPORT,
+    POLLIN, POLLOUT, POLLERR, POLLHUP, POLLNVAL, PollFd,
+    socket, bind, listen, accept, connect, shutdown, setsockopt, getsockopt,
+    poll, send, recv, sendto, recvfrom,
 };

--- a/std/sys/time.wave
+++ b/std/sys/time.wave
@@ -16,9 +16,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// Time sys dispatcher
-// =======================================================
+// Selects the target clock and sleep ABI. Portable clock helpers live in
+// std::time; this module keeps the raw TimeSpec operations available.
 
 #[target(os="linux")]
 pub import("std::sys::linux::time")::{
@@ -27,9 +26,15 @@ pub import("std::sys::linux::time")::{
     clock_gettime,
 };
 
-#[target(os="macos", arch="x86_64")]
+#[target(os="macos")]
 pub import("std::sys::macos::time")::{
     TimeSpec,
     nanosleep,
     clock_gettime,
 };
+
+#[target(os="windows")]
+pub import("std::sys::windows::time")::{TimeSpec, nanosleep, clock_gettime};
+
+#[target(os="freebsd")]
+pub import("std::sys::freebsd::time")::{TimeSpec, nanosleep, clock_gettime};

--- a/std/sys/tty.wave
+++ b/std/sys/tty.wave
@@ -16,9 +16,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// =======================================================
-// TTY sys dispatcher
-// =======================================================
+// Selects the target terminal ABI. These operations expose native terminal
+// state; higher-level terminal code is responsible for restoring that state.
 
 #[target(os="linux")]
 pub import("std::sys::linux::tty")::{
@@ -48,7 +47,7 @@ pub import("std::sys::linux::tty")::{
     tty_restore,
 };
 
-#[target(os="macos", arch="x86_64")]
+#[target(os="macos")]
 pub import("std::sys::macos::tty")::{
     TTY_SYS_IOCTL,
     TTY_SYS_FCNTL,
@@ -72,4 +71,24 @@ pub import("std::sys::macos::tty")::{
     tty_setfl,
     tty_enable_raw_nonblock,
     tty_restore,
+};
+
+#[target(os="windows")]
+pub import("std::sys::windows::tty")::{
+    TTY_SYS_IOCTL, TTY_SYS_FCNTL, TTY_TCGETS, TTY_TCSETS, TTY_TCSETSW,
+    TTY_TCSETSF, TTY_TCSANOW, TTY_TCSADRAIN, TTY_TCSAFLUSH,
+    TTY_F_GETFL, TTY_F_SETFL, TTY_O_NONBLOCK, TTY_ICANON, TTY_ECHO,
+    TTY_VTIME_IDX, TTY_VMIN_IDX, Termios, TtyRawState,
+    tty_getattr, tty_setattr, tty_getfl, tty_setfl,
+    tty_enable_raw_nonblock, tty_restore,
+};
+
+#[target(os="freebsd")]
+pub import("std::sys::freebsd::tty")::{
+    TTY_SYS_IOCTL, TTY_SYS_FCNTL, TTY_TCGETS, TTY_TCSETS, TTY_TCSETSW,
+    TTY_TCSETSF, TTY_TCSANOW, TTY_TCSADRAIN, TTY_TCSAFLUSH,
+    TTY_F_GETFL, TTY_F_SETFL, TTY_O_NONBLOCK, TTY_ICANON, TTY_ECHO,
+    TTY_VTIME_IDX, TTY_VMIN_IDX, Termios, TtyRawState,
+    tty_getattr, tty_setattr, tty_getfl, tty_setfl,
+    tty_enable_raw_nonblock, tty_restore,
 };

--- a/std/sys/windows/env.wave
+++ b/std/sys/windows/env.wave
@@ -1,0 +1,36 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Copies the native double-NUL-terminated environment block into caller-owned
+// storage, preserving the format consumed by std::env.
+
+extern(system, "GetEnvironmentStringsA") fun win_get_environment_strings() -> ptr<u8>;
+extern(system, "FreeEnvironmentStringsA") fun win_free_environment_strings(block: ptr<u8>) -> i32;
+
+pub fun env_read(buf: ptr<u8>, cap: i64) -> i64 {
+    if (buf == null || cap <= 0) {
+        return -22;
+    }
+
+    var block: ptr<u8> = win_get_environment_strings();
+    if (block == null) {
+        return -1;
+    }
+
+    var i: i64 = 0;
+    while (i + 1 < cap) {
+        var next: i64 = i + 1;
+        buf[i] = block[i];
+        if (block[i] == 0 && block[next] == 0) {
+            buf[next] = 0;
+            win_free_environment_strings(block);
+            return i + 2;
+        }
+        i += 1;
+    }
+
+    win_free_environment_strings(block);
+    return -28;
+}

--- a/std/sys/windows/fs.wave
+++ b/std/sys/windows/fs.wave
@@ -1,0 +1,243 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Windows filesystem provider. Native HANDLE values are carried as i64 so
+// the portable descriptor layer does not truncate them.
+
+extern(system, "CreateFileA") fun win_create_file(
+    name: ptr<i8>, access: u32, share: u32, security: ptr<i8>, creation: u32,
+    attributes: u32, template: ptr<i8>
+) -> ptr<i8>;
+extern(system, "CloseHandle") fun win_close_handle(handle: ptr<i8>) -> i32;
+extern(system, "closesocket") fun win_close_socket(socket: i64) -> i32;
+extern(system, "ReadFile") fun win_read_file(
+    handle: ptr<i8>, buffer: ptr<u8>, length: u32, read_count: ptr<u32>, overlapped: ptr<i8>
+) -> i32;
+extern(system, "WriteFile") fun win_write_file(
+    handle: ptr<i8>, buffer: ptr<u8>, length: u32, write_count: ptr<u32>, overlapped: ptr<i8>
+) -> i32;
+extern(system, "FlushFileBuffers") fun win_flush_file_buffers(handle: ptr<i8>) -> i32;
+extern(system, "SetFilePointerEx") fun win_set_file_pointer(
+    handle: ptr<i8>, distance: i64, new_position: ptr<i64>, method: u32
+) -> i32;
+extern(system, "GetFileSizeEx") fun win_get_file_size(handle: ptr<i8>, size: ptr<i64>) -> i32;
+extern(system, "GetFileAttributesA") fun win_get_file_attributes(path: ptr<i8>) -> u32;
+extern(system, "GetFileAttributesExA") fun win_get_file_attributes_ex(
+    path: ptr<i8>, info_level: i32, data: ptr<WinFileAttributeData>
+) -> i32;
+extern(system, "GetCurrentDirectoryA") fun win_get_current_directory(cap: u32, buffer: ptr<u8>) -> u32;
+extern(system, "SetCurrentDirectoryA") fun win_set_current_directory(path: ptr<i8>) -> i32;
+extern(system, "DeleteFileA") fun win_delete_file(path: ptr<i8>) -> i32;
+extern(system, "CreateDirectoryA") fun win_create_directory(path: ptr<i8>, security: ptr<i8>) -> i32;
+extern(system, "RemoveDirectoryA") fun win_remove_directory(path: ptr<i8>) -> i32;
+extern(system, "MoveFileExA") fun win_move_file(old_path: ptr<i8>, new_path: ptr<i8>, flags: u32) -> i32;
+extern(system, "GetCurrentProcess") fun win_get_current_process() -> ptr<i8>;
+extern(system, "GetStdHandle") fun win_get_std_handle(kind: u32) -> ptr<i8>;
+extern(system, "DuplicateHandle") fun win_duplicate_handle(
+    source_process: ptr<i8>, source: ptr<i8>, target_process: ptr<i8>, target: ptr<ptr<i8>>,
+    access: u32, inherit: i32, options: u32
+) -> i32;
+
+pub const FS_O_RDONLY: i32 = 0;
+pub const FS_O_WRONLY: i32 = 1;
+pub const FS_O_RDWR: i32 = 2;
+pub const FS_O_CREAT: i32 = 64;
+pub const FS_O_EXCL: i32 = 128;
+pub const FS_O_TRUNC: i32 = 512;
+pub const FS_O_APPEND: i32 = 1024;
+pub const FS_O_NONBLOCK: i32 = 2048;
+pub const FS_F_OK: i32 = 0;
+pub const FS_X_OK: i32 = 1;
+pub const FS_W_OK: i32 = 2;
+pub const FS_R_OK: i32 = 4;
+pub const FS_SEEK_SET: i32 = 0;
+pub const FS_SEEK_CUR: i32 = 1;
+pub const FS_SEEK_END: i32 = 2;
+pub const FS_F_GETFL: i32 = 3;
+pub const FS_F_SETFL: i32 = 4;
+
+const GENERIC_READ: u32 = 2147483648;
+const GENERIC_WRITE: u32 = 1073741824;
+const FILE_APPEND_DATA: u32 = 4;
+const FILE_SHARE_ALL: u32 = 7;
+const CREATE_NEW: u32 = 1;
+const CREATE_ALWAYS: u32 = 2;
+const OPEN_EXISTING: u32 = 3;
+const OPEN_ALWAYS: u32 = 4;
+const FILE_ATTRIBUTE_NORMAL: u32 = 128;
+const FILE_ATTRIBUTE_DIRECTORY: u32 = 16;
+const INVALID_FILE_ATTRIBUTES: u32 = 4294967295;
+const DUPLICATE_SAME_ACCESS: u32 = 2;
+const MOVEFILE_REPLACE_EXISTING: u32 = 1;
+const SYS_ERR_NOT_IMPLEMENTED: i64 = -38;
+const STD_INPUT_HANDLE: u32 = 4294967286;
+const STD_OUTPUT_HANDLE: u32 = 4294967285;
+const STD_ERROR_HANDLE: u32 = 4294967284;
+
+pub struct Stat {
+    mode: i16;
+    size: i64;
+    mtime: i64;
+}
+
+struct WinFileAttributeData {
+    attributes: u32;
+    creation_low: u32;
+    creation_high: u32;
+    access_low: u32;
+    access_high: u32;
+    write_low: u32;
+    write_high: u32;
+    size_high: u32;
+    size_low: u32;
+}
+
+fun win_handle_from_fd(fd: i64) -> ptr<i8> {
+    if (fd == 0) { return win_get_std_handle(STD_INPUT_HANDLE); }
+    if (fd == 1) { return win_get_std_handle(STD_OUTPUT_HANDLE); }
+    if (fd == 2) { return win_get_std_handle(STD_ERROR_HANDLE); }
+    return fd as ptr<i8>;
+}
+
+pub fun open(path: str, flags: i32, mode: i32) -> i64 {
+    var desired: u32 = GENERIC_READ;
+    if ((flags & FS_O_RDWR) != 0) {
+        desired = GENERIC_READ | GENERIC_WRITE;
+    } else if ((flags & FS_O_WRONLY) != 0) {
+        desired = GENERIC_WRITE;
+    }
+    if ((flags & FS_O_APPEND) != 0) {
+        desired = desired | FILE_APPEND_DATA;
+    }
+
+    var creation: u32 = OPEN_EXISTING;
+    if ((flags & FS_O_CREAT) != 0 && (flags & FS_O_EXCL) != 0) {
+        creation = CREATE_NEW;
+    } else if ((flags & FS_O_CREAT) != 0 && (flags & FS_O_TRUNC) != 0) {
+        creation = CREATE_ALWAYS;
+    } else if ((flags & FS_O_CREAT) != 0) {
+        creation = OPEN_ALWAYS;
+    }
+
+    var handle: ptr<i8> = win_create_file(
+        path as ptr<i8>, desired, FILE_SHARE_ALL, null, creation, FILE_ATTRIBUTE_NORMAL, null
+    );
+    if ((handle as i64) == -1) {
+        return -1;
+    }
+    if ((flags & FS_O_APPEND) != 0) {
+        var ignored: i64 = 0;
+        win_set_file_pointer(handle, 0, &ignored, FS_SEEK_END as u32);
+    }
+    return handle as i64;
+}
+
+pub fun close(fd: i64) -> i64 {
+    if (win_close_handle(win_handle_from_fd(fd)) != 0) { return 0; }
+    if (win_close_socket(fd) == 0) { return 0; }
+    return -1;
+}
+
+pub fun dup(fd: i64) -> i64 {
+    var current: ptr<i8> = win_get_current_process();
+    var duplicate: ptr<i8> = null;
+    if (win_duplicate_handle(current, win_handle_from_fd(fd), current, &duplicate, 0, 0, DUPLICATE_SAME_ACCESS) == 0) {
+        return -1;
+    }
+    return duplicate as i64;
+}
+
+pub fun dup2(oldfd: i64, newfd: i64) -> i64 { return SYS_ERR_NOT_IMPLEMENTED; }
+pub fun pipe(fds: ptr<i32>) -> i64 { return SYS_ERR_NOT_IMPLEMENTED; }
+
+pub fun fsync(fd: i64) -> i64 {
+    if (win_flush_file_buffers(win_handle_from_fd(fd)) == 0) { return -1; }
+    return 0;
+}
+
+pub fun fcntl(fd: i64, cmd: i32, arg: i64) -> i64 { return SYS_ERR_NOT_IMPLEMENTED; }
+
+pub fun read(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
+    if (buf == null || len < 0 || len > 4294967295) { return -22; }
+    var count: u32 = 0;
+    if (win_read_file(win_handle_from_fd(fd), buf, len as u32, &count, null) == 0) { return -1; }
+    return count as i64;
+}
+
+pub fun write(fd: i64, buf: ptr<u8>, len: i64) -> i64 {
+    if (buf == null || len < 0 || len > 4294967295) { return -22; }
+    var count: u32 = 0;
+    if (win_write_file(win_handle_from_fd(fd), buf, len as u32, &count, null) == 0) { return -1; }
+    return count as i64;
+}
+
+pub fun getcwd(buf: ptr<u8>, size: i64) -> i64 {
+    if (buf == null || size <= 0 || size > 4294967295) { return -22; }
+    var count: u32 = win_get_current_directory(size as u32, buf);
+    if (count == 0 || count >= size as u32) { return -1; }
+    return count as i64;
+}
+
+pub fun chdir(path: str) -> i64 {
+    if (win_set_current_directory(path as ptr<i8>) == 0) { return -1; }
+    return 0;
+}
+
+pub fun access(path: str, mode: i32) -> i64 {
+    if (win_get_file_attributes(path as ptr<i8>) == INVALID_FILE_ATTRIBUTES) { return -1; }
+    return 0;
+}
+
+pub fun lseek(fd: i64, offset: i64, whence: i32) -> i64 {
+    var position: i64 = 0;
+    if (win_set_file_pointer(win_handle_from_fd(fd), offset, &position, whence as u32) == 0) { return -1; }
+    return position;
+}
+
+pub fun unlink(path: str) -> i64 {
+    if (win_delete_file(path as ptr<i8>) == 0) { return -1; }
+    return 0;
+}
+
+pub fun mkdir(path: str, mode: i32) -> i64 {
+    if (win_create_directory(path as ptr<i8>, null) == 0) { return -1; }
+    return 0;
+}
+
+pub fun rmdir(path: str) -> i64 {
+    if (win_remove_directory(path as ptr<i8>) == 0) { return -1; }
+    return 0;
+}
+
+pub fun rename_path(old_path: str, new_path: str) -> i64 {
+    if (win_move_file(old_path as ptr<i8>, new_path as ptr<i8>, MOVEFILE_REPLACE_EXISTING) == 0) { return -1; }
+    return 0;
+}
+
+pub fun fstat(fd: i64, st: ptr<Stat>) -> i64 {
+    if (st == null) { return -22; }
+    var native_size: i64 = 0;
+    if (win_get_file_size(win_handle_from_fd(fd), &native_size) == 0) { return -1; }
+    deref st.mode = 32768 as i16;
+    deref st.size = native_size;
+    deref st.mtime = 0;
+    return 0;
+}
+
+pub fun stat(path: str, st: ptr<Stat>) -> i64 {
+    if (st == null) { return -22; }
+    var native: WinFileAttributeData;
+    if (win_get_file_attributes_ex(path as ptr<i8>, 0, &native) == 0) { return -1; }
+    deref st.size = ((native.size_high as u64 << 32) | native.size_low as u64) as i64;
+    var write_ticks: u64 = (native.write_high as u64 << 32) | native.write_low as u64;
+    deref st.mtime = (write_ticks / 10000000) as i64 - 11644473600;
+    if ((native.attributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+        deref st.mode = 16384 as i16;
+        deref st.size = 0;
+    } else {
+        deref st.mode = 32768 as i16;
+    }
+    return 0;
+}

--- a/std/sys/windows/memory.wave
+++ b/std/sys/windows/memory.wave
@@ -1,0 +1,66 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Windows system ABI provider for virtual memory.
+
+extern(system, "VirtualAlloc") fun win_virtual_alloc(
+    address: ptr<i8>, size: i64, allocation_type: u32, protect: u32
+) -> ptr<i8>;
+extern(system, "VirtualFree") fun win_virtual_free(
+    address: ptr<i8>, size: i64, free_type: u32
+) -> i32;
+
+pub const PROT_READ: i32 = 1;
+pub const PROT_WRITE: i32 = 2;
+pub const MAP_PRIVATE: i32 = 2;
+pub const MAP_ANONYMOUS: i32 = 32;
+
+const MEM_COMMIT_RESERVE: u32 = 12288;
+const MEM_RELEASE: u32 = 32768;
+const PAGE_READWRITE: u32 = 4;
+const SYS_ERR_INVALID: i64 = -22;
+
+pub fun mmap(
+    addr: ptr<i8>,
+    length: i64,
+    prot: i32,
+    flags: i32,
+    fd: i64,
+    offset: i64
+) -> ptr<i8> {
+    if (length <= 0 || fd != -1 || offset != 0) {
+        return null;
+    }
+    return win_virtual_alloc(addr, length, MEM_COMMIT_RESERVE, PAGE_READWRITE);
+}
+
+pub fun munmap(addr: ptr<i8>, length: i64) -> i64 {
+    if (addr == null || length <= 0) {
+        return SYS_ERR_INVALID;
+    }
+    if (win_virtual_free(addr, 0, MEM_RELEASE) == 0) {
+        return -1;
+    }
+    return 0;
+}
+
+// Windows has no process break; allocation callers use VirtualAlloc instead.
+pub fun brk(addr: ptr<i8>) -> ptr<i8> {
+    return null;
+}
+
+pub fun sys_alloc(size: i64) -> ptr<u8> {
+    if (size <= 0) {
+        return null;
+    }
+    return win_virtual_alloc(null, size, MEM_COMMIT_RESERVE, PAGE_READWRITE) as ptr<u8>;
+}
+
+pub fun sys_free(p: ptr<u8>, size: i64) -> i64 {
+    if (p == null || size <= 0) {
+        return 0;
+    }
+    return munmap(p as ptr<i8>, size);
+}

--- a/std/sys/windows/process.wave
+++ b/std/sys/windows/process.wave
@@ -1,0 +1,41 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Windows system ABI provider. POSIX-only process operations return
+// -ENOSYS until std::process gains a native CreateProcess API.
+
+extern(system, "ExitProcess") fun win_exit_process(code: u32);
+extern(system, "GetCurrentProcessId") fun win_get_current_process_id() -> u32;
+
+const SYS_ERR_NOT_IMPLEMENTED: i64 = -38;
+
+pub fun exit(code: i32) -> ! {
+    win_exit_process(code as u32);
+    while (true) { }
+}
+
+pub fun getpid() -> i64 {
+    return win_get_current_process_id() as i64;
+}
+
+pub fun getppid() -> i64 {
+    return SYS_ERR_NOT_IMPLEMENTED;
+}
+
+pub fun fork() -> i64 {
+    return SYS_ERR_NOT_IMPLEMENTED;
+}
+
+pub fun execve(path: str, argv: ptr<ptr<i8>>, envp: ptr<ptr<i8>>) -> i64 {
+    return SYS_ERR_NOT_IMPLEMENTED;
+}
+
+pub fun waitpid(pid: i64, status: ptr<i32>, options: i32) -> i64 {
+    return SYS_ERR_NOT_IMPLEMENTED;
+}
+
+pub fun kill(pid: i64, sig: i32) -> i64 {
+    return SYS_ERR_NOT_IMPLEMENTED;
+}

--- a/std/sys/windows/socket.wave
+++ b/std/sys/windows/socket.wave
@@ -1,0 +1,95 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Windows Winsock provider. Calls retain SOCKET values in i64.
+
+extern(system, "WSAStartup") fun win_wsa_startup(version: u16, data: ptr<u8>) -> i32;
+extern(system, "socket") fun win_socket(domain: i32, ty: i32, protocol: i32) -> i64;
+extern(system, "bind") fun win_bind(fd: i64, address: ptr<i8>, length: i32) -> i32;
+extern(system, "listen") fun win_listen(fd: i64, backlog: i32) -> i32;
+extern(system, "accept") fun win_accept(fd: i64, address: ptr<i8>, length: ptr<i32>) -> i64;
+extern(system, "connect") fun win_connect(fd: i64, address: ptr<i8>, length: i32) -> i32;
+extern(system, "shutdown") fun win_shutdown(fd: i64, how: i32) -> i32;
+extern(system, "setsockopt") fun win_setsockopt(
+    fd: i64, level: i32, name: i32, value: ptr<i8>, length: i32
+) -> i32;
+extern(system, "getsockopt") fun win_getsockopt(
+    fd: i64, level: i32, name: i32, value: ptr<i8>, length: ptr<i32>
+) -> i32;
+extern(system, "WSAPoll") fun win_poll(fds: ptr<PollFd>, count: u32, timeout: i32) -> i32;
+extern(system, "send") fun win_send(fd: i64, buffer: ptr<u8>, length: i32, flags: i32) -> i32;
+extern(system, "recv") fun win_recv(fd: i64, buffer: ptr<u8>, length: i32, flags: i32) -> i32;
+extern(system, "sendto") fun win_sendto(
+    fd: i64, buffer: ptr<u8>, length: i32, flags: i32, address: ptr<i8>, address_len: i32
+) -> i32;
+extern(system, "recvfrom") fun win_recvfrom(
+    fd: i64, buffer: ptr<u8>, length: i32, flags: i32, address: ptr<i8>, address_len: ptr<i32>
+) -> i32;
+
+pub const AF_INET: i32 = 2;
+pub const AF_INET6: i32 = 23;
+pub const SOCK_STREAM: i32 = 1;
+pub const SOCK_DGRAM: i32 = 2;
+pub const IPPROTO_IP: i32 = 0;
+pub const IPPROTO_TCP: i32 = 6;
+pub const IPPROTO_UDP: i32 = 17;
+pub const SHUT_RD: i32 = 0;
+pub const SHUT_WR: i32 = 1;
+pub const SHUT_RDWR: i32 = 2;
+pub const SOL_SOCKET: i32 = 65535;
+pub const SO_REUSEADDR: i32 = 4;
+pub const SO_REUSEPORT: i32 = 512;
+pub const POLLIN: i16 = 256;
+pub const POLLOUT: i16 = 16;
+pub const POLLERR: i16 = 1;
+pub const POLLHUP: i16 = 2;
+pub const POLLNVAL: i16 = 4;
+
+pub struct PollFd {
+    fd: i64;
+    events: i16;
+    revents: i16;
+}
+
+fun winsock_ready() -> bool {
+    var data: array<u8, 512>;
+    return win_wsa_startup(514, &data[0]) == 0;
+}
+
+pub fun socket(domain: i32, ty: i32, protocol: i32) -> i64 {
+    if (!winsock_ready()) { return -1; }
+    return win_socket(domain, ty, protocol);
+}
+pub fun bind(fd: i64, addr: ptr<i8>, len: i32) -> i64 { return win_bind(fd, addr, len) as i64; }
+pub fun listen(fd: i64, backlog: i32) -> i64 { return win_listen(fd, backlog) as i64; }
+pub fun accept(fd: i64, addr: ptr<i8>, len: ptr<i32>) -> i64 { return win_accept(fd, addr, len); }
+pub fun connect(fd: i64, addr: ptr<i8>, len: i32) -> i64 { return win_connect(fd, addr, len) as i64; }
+pub fun shutdown(fd: i64, how: i32) -> i64 { return win_shutdown(fd, how) as i64; }
+pub fun setsockopt(fd: i64, level: i32, optname: i32, optval: ptr<i8>, optlen: i32) -> i64 {
+    return win_setsockopt(fd, level, optname, optval, optlen) as i64;
+}
+pub fun getsockopt(fd: i64, level: i32, optname: i32, optval: ptr<i8>, optlen: ptr<i32>) -> i64 {
+    return win_getsockopt(fd, level, optname, optval, optlen) as i64;
+}
+pub fun poll(fds: ptr<PollFd>, nfds: i64, timeout_ms: i32) -> i64 {
+    if (nfds < 0 || nfds > 4294967295) { return -22; }
+    return win_poll(fds, nfds as u32, timeout_ms) as i64;
+}
+pub fun send(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
+    if (len < 0 || len > 2147483647) { return -22; }
+    return win_send(fd, buf, len as i32, flags) as i64;
+}
+pub fun recv(fd: i64, buf: ptr<u8>, len: i64, flags: i32) -> i64 {
+    if (len < 0 || len > 2147483647) { return -22; }
+    return win_recv(fd, buf, len as i32, flags) as i64;
+}
+pub fun sendto(fd: i64, buf: ptr<u8>, len: i64, flags: i32, addr: ptr<i8>, addrlen: i32) -> i64 {
+    if (len < 0 || len > 2147483647) { return -22; }
+    return win_sendto(fd, buf, len as i32, flags, addr, addrlen) as i64;
+}
+pub fun recvfrom(fd: i64, buf: ptr<u8>, len: i64, flags: i32, addr: ptr<i8>, addrlen: ptr<i32>) -> i64 {
+    if (len < 0 || len > 2147483647) { return -22; }
+    return win_recvfrom(fd, buf, len as i32, flags, addr, addrlen) as i64;
+}

--- a/std/sys/windows/time.wave
+++ b/std/sys/windows/time.wave
@@ -1,0 +1,63 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Windows clock and sleep provider.
+
+extern(system, "Sleep") fun win_sleep(milliseconds: u32);
+extern(system, "GetSystemTimeAsFileTime") fun win_get_system_time_as_file_time(value: ptr<FileTime>);
+extern(system, "QueryPerformanceCounter") fun win_query_performance_counter(value: ptr<i64>) -> i32;
+extern(system, "QueryPerformanceFrequency") fun win_query_performance_frequency(value: ptr<i64>) -> i32;
+
+struct FileTime {
+    low: u32;
+    high: u32;
+}
+
+pub struct TimeSpec {
+    sec: i64;
+    nsec: i64;
+}
+
+pub fun nanosleep(req: ptr<TimeSpec>, rem: ptr<TimeSpec>) -> i64 {
+    if (req == null || deref req.sec < 0 || deref req.nsec < 0) {
+        return -22;
+    }
+    var millis: i64 = deref req.sec * 1000 + deref req.nsec / 1000000;
+    if (millis > 4294967295) {
+        return -22;
+    }
+    win_sleep(millis as u32);
+    return 0;
+}
+
+pub fun clock_gettime(clock_id: i32, tp: ptr<TimeSpec>) -> i64 {
+    if (tp == null) {
+        return -22;
+    }
+    if (clock_id == 1) {
+        var counter: i64 = 0;
+        var frequency: i64 = 0;
+        if (
+            win_query_performance_counter(&counter) == 0 ||
+            win_query_performance_frequency(&frequency) == 0 ||
+            frequency <= 0
+        ) {
+            return -1;
+        }
+        deref tp.sec = counter / frequency;
+        deref tp.nsec = ((counter % frequency) * 1000000000) / frequency;
+        return 0;
+    }
+    if (clock_id != 0) {
+        return -22;
+    }
+    var raw: FileTime;
+    win_get_system_time_as_file_time(&raw);
+    var ticks: u64 = (raw.high as u64 << 32) | raw.low as u64;
+    var unix_ticks: u64 = ticks - 116444736000000000;
+    deref tp.sec = (unix_ticks / 10000000) as i64;
+    deref tp.nsec = ((unix_ticks % 10000000) * 100) as i64;
+    return 0;
+}

--- a/std/sys/windows/tty.wave
+++ b/std/sys/windows/tty.wave
@@ -1,0 +1,51 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// The portable terminal surface is present on Windows, but termios-specific
+// mutation remains unavailable until a console-mode API is added.
+
+pub const TTY_SYS_IOCTL: i64 = 0;
+pub const TTY_SYS_FCNTL: i64 = 0;
+pub const TTY_TCGETS: i64 = 0;
+pub const TTY_TCSETS: i64 = 0;
+pub const TTY_TCSETSW: i64 = 0;
+pub const TTY_TCSETSF: i64 = 0;
+pub const TTY_TCSANOW: i32 = 0;
+pub const TTY_TCSADRAIN: i32 = 1;
+pub const TTY_TCSAFLUSH: i32 = 2;
+pub const TTY_F_GETFL: i32 = 3;
+pub const TTY_F_SETFL: i32 = 4;
+pub const TTY_O_NONBLOCK: i32 = 0;
+pub const TTY_ICANON: u32 = 2;
+pub const TTY_ECHO: u32 = 4;
+pub const TTY_VTIME_IDX: i32 = 5;
+pub const TTY_VMIN_IDX: i32 = 6;
+
+pub struct Termios {
+    c_iflag: u32;
+    c_oflag: u32;
+    c_cflag: u32;
+    c_lflag: u32;
+    c_line: u8;
+    c_cc: array<u8, 32>;
+    c_ispeed: u32;
+    c_ospeed: u32;
+}
+
+pub struct TtyRawState {
+    term: Termios;
+    flags: i32;
+    active: i32;
+}
+
+pub fun tty_getattr(fd: i32, t: ptr<Termios>) -> i64 { return -38; }
+pub fun tty_setattr(fd: i32, action: i32, t: ptr<Termios>) -> i64 { return -38; }
+pub fun tty_getfl(fd: i32) -> i64 { return -38; }
+pub fun tty_setfl(fd: i32, flags: i32) -> i64 { return -38; }
+pub fun tty_enable_raw_nonblock(fd: i32, st: ptr<TtyRawState>) -> i64 {
+    if (st != null) { deref st.active = 0; }
+    return -38;
+}
+pub fun tty_restore(fd: i32, st: ptr<TtyRawState>) { }

--- a/tests/cases/test110.wave
+++ b/tests/cases/test110.wave
@@ -1,0 +1,199 @@
+// wave-test: host-os=linux, host-arch=x86_64
+
+import("std::fs::file")::{
+    Metadata,
+    exists,
+    open_read,
+    open_append,
+    open_read_write,
+    create,
+    metadata,
+    size,
+    read_into,
+    read_to_end,
+    write,
+    append,
+    copy,
+    rename,
+    remove,
+    create_dir,
+    remove_dir,
+};
+import("std::io::fd")::{
+    io_close,
+};
+import("std::io::consts")::{
+    IO_ERR_NO_SPACE,
+};
+import("std::buffer::alloc")::{
+    Buffer,
+    buffer_new,
+    buffer_free,
+};
+
+fun check_i64(label: str, got: i64, expected: i64) -> i64 {
+    if (got == expected) {
+        println("[OK] {} => {}", label, got);
+        return 1;
+    }
+
+    println("[FAIL] {} => got {}, expected {}", label, got, expected);
+    return 0;
+}
+
+fun main() {
+    var path: str = "/tmp/wave-std-test110.txt";
+    var copy_path: str = "/tmp/wave-std-test110-copy.txt";
+    var renamed_path: str = "/tmp/wave-std-test110-renamed.txt";
+    var created_path: str = "/tmp/wave-std-test110-created.txt";
+    var dir_path: str = "/tmp/wave-std-test110-dir";
+    var payload: str = "wave-fs-path";
+
+    remove(path);
+    remove(copy_path);
+    remove(renamed_path);
+    remove(created_path);
+    remove_dir(dir_path);
+
+    var passed: i64 = 0;
+
+    var write_n: i64 = write(path, payload as ptr<u8>, 12);
+    passed += check_i64("write byte count", write_n, 12);
+
+    var path_exists: i64 = 0;
+    if (exists(path)) {
+        path_exists = 1;
+    }
+    passed += check_i64("exists", path_exists, 1);
+    passed += check_i64("size", size(path), 12);
+
+    var info: Metadata;
+    passed += check_i64("metadata", metadata(path, &info), 0);
+    passed += check_i64("metadata size", info.size, 12);
+
+    var is_file: i64 = 0;
+    if (info.is_file) {
+        is_file = 1;
+    }
+    passed += check_i64("metadata file kind", is_file, 1);
+
+    var fixed: array<u8, 32>;
+    var fixed_n: i64 = read_into(path, &fixed[0], 32);
+    passed += check_i64("read_into byte count", fixed_n, 12);
+
+    var too_small: array<u8, 4>;
+    passed += check_i64(
+        "read_into capacity error",
+        read_into(path, &too_small[0], 4),
+        IO_ERR_NO_SPACE
+    );
+
+    var fixed_ok: i64 = 0;
+    if (fixed[0] == 119 && fixed[1] == 97 && fixed[2] == 118) {
+        fixed_ok = 1;
+    }
+    passed += check_i64("read_into contents", fixed_ok, 1);
+
+    var dynamic: Buffer = buffer_new(2);
+    var initial_dynamic_data: ptr<u8> = dynamic.data;
+    deref initial_dynamic_data[0] = 88;
+    dynamic.len = 1;
+    var dynamic_n: i64 = read_to_end(path, &dynamic);
+    passed += check_i64("read_to_end byte count", dynamic_n, 12);
+    passed += check_i64("read_to_end buffer len", dynamic.len, 13);
+
+    var dynamic_data: ptr<u8> = dynamic.data;
+    var dynamic_ok: i64 = 0;
+    if (
+        dynamic_data[0] == 88 &&
+        dynamic_data[1] == 119 &&
+        dynamic_data[2] == 97 &&
+        dynamic_data[3] == 118
+    ) {
+        dynamic_ok = 1;
+    }
+    passed += check_i64("read_to_end contents", dynamic_ok, 1);
+    buffer_free(&dynamic);
+
+    var append_n: i64 = append(path, "!" as ptr<u8>, 1);
+    passed += check_i64("append byte count", append_n, 1);
+    passed += check_i64("size after append", size(path), 13);
+
+    var append_fd: i64 = open_append(path);
+    var append_fd_ok: i64 = 0;
+    if (append_fd >= 0) {
+        append_fd_ok = 1;
+    }
+    passed += check_i64("open_append descriptor", append_fd_ok, 1);
+    if (append_fd >= 0) {
+        passed += check_i64("close append descriptor", io_close(append_fd), 0);
+    }
+
+    var rw_fd: i64 = open_read_write(path);
+    var rw_fd_ok: i64 = 0;
+    if (rw_fd >= 0) {
+        rw_fd_ok = 1;
+    }
+    passed += check_i64("open_read_write descriptor", rw_fd_ok, 1);
+    if (rw_fd >= 0) {
+        passed += check_i64("close read-write descriptor", io_close(rw_fd), 0);
+    }
+
+    var copied: i64 = copy(path, copy_path);
+    passed += check_i64("copy byte count", copied, 13);
+    passed += check_i64("rename", rename(copy_path, renamed_path), 0);
+
+    var renamed_exists: i64 = 0;
+    if (exists(renamed_path)) {
+        renamed_exists = 1;
+    }
+    passed += check_i64("renamed path exists", renamed_exists, 1);
+
+    var old_copy_missing: i64 = 0;
+    if (!exists(copy_path)) {
+        old_copy_missing = 1;
+    }
+    passed += check_i64("old copy path missing", old_copy_missing, 1);
+
+    passed += check_i64("create_dir", create_dir(dir_path), 0);
+
+    var dir_info: Metadata;
+    passed += check_i64("directory metadata", metadata(dir_path, &dir_info), 0);
+
+    var is_directory: i64 = 0;
+    if (dir_info.is_directory) {
+        is_directory = 1;
+    }
+    passed += check_i64("metadata directory kind", is_directory, 1);
+    passed += check_i64("remove_dir", remove_dir(dir_path), 0);
+
+    var created_fd: i64 = create(created_path);
+    var created_ok: i64 = 0;
+    if (created_fd >= 0) {
+        created_ok = 1;
+    }
+    passed += check_i64("create descriptor", created_ok, 1);
+
+    if (created_fd >= 0) {
+        passed += check_i64("close created descriptor", io_close(created_fd), 0);
+    }
+
+    var read_fd: i64 = open_read(path);
+    var read_fd_ok: i64 = 0;
+    if (read_fd >= 0) {
+        read_fd_ok = 1;
+    }
+    passed += check_i64("open_read descriptor", read_fd_ok, 1);
+
+    if (read_fd >= 0) {
+        passed += check_i64("close read descriptor", io_close(read_fd), 0);
+    }
+
+    remove(path);
+    remove(renamed_path);
+    remove(created_path);
+    remove_dir(dir_path);
+
+    println("passed checks = {}", passed);
+    println("expected checks = 30");
+}

--- a/tests/cases/test111.wave
+++ b/tests/cases/test111.wave
@@ -1,0 +1,38 @@
+import("std::string::ascii")::{
+    is_alpha,
+    is_digit,
+    is_space,
+    to_lower,
+    to_upper,
+};
+import("std::string::cmp")::{
+    cmp,
+    ends_with,
+    eq,
+    starts_with,
+};
+import("std::string::find")::{
+    contains_char,
+    count_char,
+    find_char,
+    rfind_char,
+};
+import("std::string::hash")::{djb2_32, fnv1a_64};
+import("std::string::len")::{is_empty, len};
+import("std::string::trim")::{trim_left_index, trim_right_index};
+
+fun main() -> i32 {
+    var failed: i32 = 0;
+
+    if (len("wave") != 4 || !is_empty("") || is_empty("wave")) { failed += 1; }
+    if (!eq("wave", "wave") || eq("wave", "whale") || cmp("a", "b") >= 0) { failed += 1; }
+    if (!starts_with("wave-lang", "wave") || !ends_with("main.wave", ".wave")) { failed += 1; }
+    if (find_char("banana", 97) != 1 || rfind_char("banana", 97) != 5) { failed += 1; }
+    if (!contains_char("wave", 118) || count_char("banana", 97) != 3) { failed += 1; }
+    if (!is_alpha(87) || !is_digit(55) || !is_space(10)) { failed += 1; }
+    if (to_lower(87) != 119 || to_upper(119) != 87) { failed += 1; }
+    if (trim_left_index("  wave \n") != 2 || trim_right_index("  wave \n") != 6) { failed += 1; }
+    if (djb2_32("wave") == 0 || fnv1a_64("wave") == 0) { failed += 1; }
+
+    return failed;
+}

--- a/tests/cases/test112.wave
+++ b/tests/cases/test112.wave
@@ -1,0 +1,39 @@
+import("std::path::analyze")::{
+    path_basename_len,
+    path_basename_start,
+    path_dirname_len,
+    path_ext_start,
+    path_has_ext,
+};
+import("std::path::copy")::{
+    path_basename_copy,
+    path_dirname_copy,
+    path_join2,
+};
+import("std::path::core")::{path_is_abs, path_is_sep, path_len};
+import("std::string::cmp")::{eq};
+
+fun main() -> i32 {
+    var failed: i32 = 0;
+    var path: str = "/tmp/wave/main.wave";
+
+    if (!path_is_sep(47) || !path_is_sep(92) || path_is_sep(45)) { failed += 1; }
+    if (!path_is_abs(path) || path_is_abs("relative/file")) { failed += 1; }
+    if (path_len(path) != 19 || path_basename_start(path) != 10) { failed += 1; }
+    if (path_basename_len(path) != 9 || path_dirname_len(path) != 9) { failed += 1; }
+    if (!path_has_ext(path) || path_ext_start(path) != 14) { failed += 1; }
+
+    var joined: array<u8, 32>;
+    if (path_join2(&joined[0], 32, "examples", "std") != 12) { failed += 1; }
+    if (!eq(&joined[0] as str, "examples/std")) { failed += 1; }
+
+    var base: array<u8, 16>;
+    if (path_basename_copy(&base[0], 16, path) != 9) { failed += 1; }
+    if (!eq(&base[0] as str, "main.wave")) { failed += 1; }
+
+    var dir: array<u8, 16>;
+    if (path_dirname_copy(&dir[0], 16, path) != 9) { failed += 1; }
+    if (!eq(&dir[0] as str, "/tmp/wave")) { failed += 1; }
+
+    return failed;
+}

--- a/tests/cases/test113.wave
+++ b/tests/cases/test113.wave
@@ -1,0 +1,51 @@
+// wave-test: host-os=linux, host-arch=x86_64
+
+import("std::buffer::alloc")::{
+    Buffer,
+    TypedBuffer,
+    buffer_clear,
+    buffer_free,
+    buffer_new,
+    tbuffer_free,
+    tbuffer_new,
+};
+import("std::buffer::read")::{buffer_at, tbuffer_at, tbuffer_len};
+import("std::buffer::write")::{
+    buffer_append_str,
+    buffer_push,
+    buffer_set,
+    tbuffer_push,
+    tbuffer_set,
+};
+
+fun main() -> i32 {
+    var bytes: Buffer = buffer_new(2);
+    if (bytes.data == null) { return 12; }
+    var append_result: i64 = buffer_append_str(&bytes, "wave");
+    if (append_result < 0) { return 1; }
+    if (buffer_push(&bytes, 33) < 0) { return 11; }
+    if (bytes.len != 5 || buffer_at(bytes, 0) != 119 || buffer_at(bytes, 4) != 33) {
+        return 2;
+    }
+    if (!buffer_set(&bytes, 4, 63) || buffer_at(bytes, 4) != 63) {
+        return 3;
+    }
+    buffer_clear(&bytes);
+    if (bytes.len != 0) { return 4; }
+    if (buffer_free(&bytes) != 0) { return 5; }
+
+    var numbers: TypedBuffer<i32> = tbuffer_new<i32>(4, 1);
+    if (numbers.data == null) { return 16; }
+    if (tbuffer_push<i32>(&numbers, 10) < 0 || tbuffer_push<i32>(&numbers, 20) < 0) {
+        return 6;
+    }
+    if (tbuffer_len<i32>(numbers) != 2) { return 7; }
+    if (!tbuffer_set<i32>(&numbers, 1, 30)) { return 8; }
+    var value: i32 = 0;
+    if (!tbuffer_at<i32>(numbers, 1, &value) || value != 30) {
+        return 9;
+    }
+    if (tbuffer_free<i32>(&numbers) != 0) { return 10; }
+
+    return 0;
+}

--- a/tests/cases/test114.wave
+++ b/tests/cases/test114.wave
@@ -1,0 +1,33 @@
+// wave-test: host-os=linux, host-arch=x86_64
+
+import("std::env::consts")::{ENV_ERR_INVALID_KEY, ENV_ERR_NO_SPACE};
+import("std::env::cwd")::{env_getcwd};
+import("std::env::environ")::{env_get_i64_default, env_unwrap_or, env_result_ok};
+import("std::env::parse")::{_env_copy_value, _env_key_len, _env_parse_i64};
+
+fun main() -> i32 {
+    var failed: i32 = 0;
+
+    if (_env_key_len("WAVE_HOME") != 9 || _env_key_len("BAD=KEY") != ENV_ERR_INVALID_KEY) { failed += 1; }
+
+    var positive: array<u8, 4> = [52, 50, 0, 0];
+    var parsed: i64 = 0;
+    if (!_env_parse_i64(&positive[0], &parsed) || parsed != 42) { failed += 1; }
+
+    var negative: array<u8, 5> = [45, 49, 55, 0, 0];
+    if (!_env_parse_i64(&negative[0], &parsed) || parsed != -17) { failed += 1; }
+
+    var invalid: array<u8, 4> = [49, 120, 0, 0];
+    if (_env_parse_i64(&invalid[0], &parsed)) { failed += 1; }
+
+    var blob: array<u8, 4> = [97, 98, 99, 0];
+    var small: array<u8, 3>;
+    if (_env_copy_value(&blob[0], 0, 3, &small[0], 3) != ENV_ERR_NO_SPACE) { failed += 1; }
+
+    var cwd: array<u8, 1024>;
+    if (env_getcwd(&cwd[0], 1024) <= 0) { failed += 1; }
+    if (env_get_i64_default("WAVE_TEST_VARIABLE_THAT_DOES_NOT_EXIST", 73) != 73) { failed += 1; }
+    if (env_unwrap_or<i32>(env_result_ok<i32>(9), 0) != 9) { failed += 1; }
+
+    return failed;
+}

--- a/tests/cases/test115.wave
+++ b/tests/cases/test115.wave
@@ -1,0 +1,23 @@
+// wave-test: host-os=linux, host-arch=x86_64
+
+import("std::time::clock")::{TimeSpec, time_now_monotonic, time_now_monotonic_ns};
+import("std::time::consts")::{TIME_NS_PER_MS, TIME_NS_PER_SEC, TIME_NS_PER_US};
+import("std::time::diff")::{time_diff_ms, time_diff_ns};
+import("std::time::sleep")::{time_sleep_ms, time_sleep_ns, time_sleep_us};
+
+fun main() -> i32 {
+    var failed: i32 = 0;
+
+    if (TIME_NS_PER_US != 1000 || TIME_NS_PER_MS != 1000000 || TIME_NS_PER_SEC != 1000000000) { failed += 1; }
+
+    var start: TimeSpec;
+    var end: TimeSpec;
+    if (time_now_monotonic(&start) < 0) { failed += 1; }
+    if (time_sleep_ms(1) < 0) { failed += 1; }
+    if (time_now_monotonic(&end) < 0) { failed += 1; }
+    if (time_diff_ns(start, end) < 0 || time_diff_ms(start, end) < 0) { failed += 1; }
+    if (time_now_monotonic_ns() <= 0) { failed += 1; }
+    if (time_sleep_ns(0) != 0 || time_sleep_us(0) != 0) { failed += 1; }
+
+    return failed;
+}

--- a/tests/cases/test116.wave
+++ b/tests/cases/test116.wave
@@ -1,0 +1,25 @@
+import("std::math::bits")::{align_down, align_up, ctz32, is_pow2, popcount};
+import("std::math::float")::{abs_f32, clamp_f32};
+import("std::math::int")::{abs, clamp, is_even, is_odd, max, min, swap_i32};
+import("std::math::num")::{gcd, lcm, pow_i32};
+import("std::math::trig")::{cos_f64, sin_f64, sqrt_f64};
+
+fun main() -> i32 {
+    var failed: i32 = 0;
+
+    if (abs(-7) != 7 || min(3, 8) != 3 || max(3, 8) != 8 || clamp(20, 0, 10) != 10) { failed += 1; }
+    if (!is_even(8) || !is_odd(9)) { failed += 1; }
+    if (gcd(54, 24) != 6 || lcm(6, 8) != 24 || pow_i32(3, 4) != 81) { failed += 1; }
+    if (!is_pow2(1024) || align_down(19, 8) != 16 || align_up(19, 8) != 24) { failed += 1; }
+    if (popcount(15) != 4 || ctz32(16) != 4) { failed += 1; }
+    if (abs_f32(-2.5) != 2.5 || clamp_f32(4.0, 0.0, 3.0) != 3.0) { failed += 1; }
+    if (sqrt_f64(81.0) < 8.999 || sqrt_f64(81.0) > 9.001) { failed += 1; }
+    if (sin_f64(0.0) != 0.0 || cos_f64(0.0) != 1.0) { failed += 1; }
+
+    var a: i32 = 1;
+    var b: i32 = 2;
+    swap_i32(&a, &b);
+    if (a != 2 || b != 1) { failed += 1; }
+
+    return failed;
+}

--- a/tests/cases/test117.wave
+++ b/tests/cases/test117.wave
@@ -1,0 +1,12 @@
+// wave-test: mode=build, runner=compile, target=aarch64-unknown-linux-gnu, emit=obj, object-arch=aarch64, object-bits=64
+
+import("std::fs::file")::{exists, size};
+import("std::mem::alloc")::{mem_alloc, mem_free};
+import("std::time::clock")::{time_now_monotonic_ns};
+
+fun std_target_smoke(path: str) -> i64 {
+    var p: ptr<u8> = mem_alloc(16);
+    if (p != null) { mem_free(p, 16); }
+    if (exists(path)) { return size(path); }
+    return time_now_monotonic_ns();
+}

--- a/tests/cases/test118.wave
+++ b/tests/cases/test118.wave
@@ -1,0 +1,12 @@
+// wave-test: mode=build, runner=compile, target=riscv64-unknown-linux-gnu, emit=obj, object-arch=riscv64, object-bits=64, riscv-float-abi=lp64d
+
+import("std::fs::file")::{exists, size};
+import("std::mem::alloc")::{mem_alloc, mem_free};
+import("std::time::clock")::{time_now_monotonic_ns};
+
+fun std_target_smoke(path: str) -> i64 {
+    var p: ptr<u8> = mem_alloc(16);
+    if (p != null) { mem_free(p, 16); }
+    if (exists(path)) { return size(path); }
+    return time_now_monotonic_ns();
+}

--- a/tests/cases/test119.wave
+++ b/tests/cases/test119.wave
@@ -1,0 +1,12 @@
+// wave-test: mode=build, runner=compile, target=aarch64-apple-darwin, emit=obj
+
+import("std::fs::file")::{exists, size};
+import("std::mem::alloc")::{mem_alloc, mem_free};
+import("std::time::clock")::{time_now_monotonic_ns};
+
+fun std_target_smoke(path: str) -> i64 {
+    var p: ptr<u8> = mem_alloc(16);
+    if (p != null) { mem_free(p, 16); }
+    if (exists(path)) { return size(path); }
+    return time_now_monotonic_ns();
+}

--- a/tests/cases/test120.wave
+++ b/tests/cases/test120.wave
@@ -1,0 +1,12 @@
+// wave-test: mode=build, runner=compile, target=aarch64-w64-windows-gnu, emit=obj
+
+import("std::fs::file")::{exists, size};
+import("std::mem::alloc")::{mem_alloc, mem_free};
+import("std::time::clock")::{time_now_monotonic_ns};
+
+fun std_target_smoke(path: str) -> i64 {
+    var p: ptr<u8> = mem_alloc(16);
+    if (p != null) { mem_free(p, 16); }
+    if (exists(path)) { return size(path); }
+    return time_now_monotonic_ns();
+}

--- a/tests/cases/test121.wave
+++ b/tests/cases/test121.wave
@@ -1,0 +1,12 @@
+// wave-test: mode=build, runner=compile, target=x86_64-unknown-freebsd, emit=obj, object-arch=x86_64, object-bits=64
+
+import("std::fs::file")::{exists, size};
+import("std::mem::alloc")::{mem_alloc, mem_free};
+import("std::time::clock")::{time_now_monotonic_ns};
+
+fun std_target_smoke(path: str) -> i64 {
+    var p: ptr<u8> = mem_alloc(16);
+    if (p != null) { mem_free(p, 16); }
+    if (exists(path)) { return size(path); }
+    return time_now_monotonic_ns();
+}

--- a/tests/codegen_regressions.rs
+++ b/tests/codegen_regressions.rs
@@ -116,6 +116,96 @@ where
 }
 
 #[test]
+fn windows_system_abi_is_target_scoped() {
+    let dir = temp_case_dir("windows-system-abi");
+    let source = write_wave(
+        &dir,
+        "system.wave",
+        r#"
+extern(system, "GetCurrentProcessId") fun get_current_process_id() -> u32;
+fun main() -> i32 { return get_current_process_id() as i32; }
+"#,
+    );
+    for target in ["x86_64-w64-windows-gnu", "aarch64-w64-windows-gnu"] {
+        let windows_out = dir.join(target);
+        run_wavec([
+            OsStr::new("build"),
+            source.as_os_str(),
+            OsStr::new("--target"),
+            OsStr::new(target),
+            OsStr::new("--emit=ir"),
+            OsStr::new("--out-dir"),
+            windows_out.as_os_str(),
+        ]);
+        let ir = fs::read_to_string(windows_out.join("system.ll")).unwrap();
+        assert!(ir.contains("@GetCurrentProcessId"), "{target}: {ir}");
+    }
+
+    let arm64_bin = dir.join("system-arm64.exe");
+    let link_error = run_wavec_expect_failure([
+        OsStr::new("build"),
+        source.as_os_str(),
+        OsStr::new("--target=aarch64-w64-windows-gnu"),
+        OsStr::new("--emit=bin"),
+        OsStr::new("-o"),
+        arm64_bin.as_os_str(),
+    ]);
+    assert!(
+        link_error.contains("Windows arm64 object generation is supported"),
+        "{link_error}"
+    );
+
+    let linux_out = dir.join("linux");
+    let error = run_wavec_expect_failure([
+        OsStr::new("build"),
+        source.as_os_str(),
+        OsStr::new("--target=x86_64-unknown-linux-gnu"),
+        OsStr::new("--emit=ir"),
+        OsStr::new("--out-dir"),
+        linux_out.as_os_str(),
+    ]);
+    assert!(error.contains("Windows 'system'"), "{error}");
+}
+
+#[test]
+fn incompatible_std_is_rejected_from_an_isolated_home() {
+    let dir = temp_case_dir("std-compatibility-home");
+    let home = dir.join("home");
+    let std_root = home.join(".wave/lib/wave/std");
+    fs::create_dir_all(std_root.join("string")).unwrap();
+    fs::write(
+        std_root.join("manifest.json"),
+        r#"{"name":"std","compatibility_revision":0}"#,
+    )
+    .unwrap();
+    fs::write(
+        std_root.join("string/len.wave"),
+        "pub fun len(value: str) -> i64 { return 0; }\n",
+    )
+    .unwrap();
+    let source = write_wave(
+        &dir,
+        "main.wave",
+        "import(\"std::string::len\")::{len};\nfun main() { len(\"x\"); }\n",
+    );
+
+    let output = wavec_command()
+        .env("HOME", &home)
+        .arg("check")
+        .arg(&source)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let error = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        error.contains("installed std compatibility revision 0"),
+        "{error}"
+    );
+    assert!(error.contains("requires 1"), "{error}");
+    assert!(error.contains("wavec update std"), "{error}");
+}
+
+#[test]
 fn variant_frontend_resolves_imported_types_constructors_and_patterns() {
     let dir = temp_case_dir("variant-imports");
     write_wave(
@@ -2365,7 +2455,12 @@ fn advertised_target_options_reach_object_codegen_without_backend_diagnostics() 
                 "{target}: {target_spec}"
             );
         } else if target_spec.contains("\"object_format\":\"coff\"") {
-            assert!(object.starts_with(&[0x64, 0x86]), "{target}: {target_spec}");
+            let machine = if target_spec.contains("\"arch\":\"aarch64\"") {
+                [0x64, 0xaa]
+            } else {
+                [0x64, 0x86]
+            };
+            assert!(object.starts_with(&machine), "{target}: {target_spec}");
         } else {
             panic!("target spec has an unknown object format: {target_spec}");
         }

--- a/tools/check_wave_corpus.py
+++ b/tools/check_wave_corpus.py
@@ -39,6 +39,11 @@ def parse_args() -> argparse.Namespace:
         default=15.0,
         help="per-file timeout in seconds (default: 15)",
     )
+    parser.add_argument(
+        "--run-std-examples",
+        action="store_true",
+        help="run every examples/std/*.wave program after checking the corpus",
+    )
     return parser.parse_args()
 
 
@@ -73,6 +78,50 @@ def corpus_files() -> list[Path]:
     return sorted(files)
 
 
+def run_std_examples(
+    wavec: Path,
+    compiler_env: dict[str, str],
+    timeout: float,
+) -> list[tuple[Path, str]]:
+    examples = sorted((ROOT / "examples" / "std").glob("*.wave"))
+    failures: list[tuple[Path, str]] = []
+
+    print(f"Running {len(examples)} standard-library examples")
+    for path in examples:
+        relative = path.relative_to(ROOT)
+        try:
+            result = subprocess.run(
+                [str(wavec), "run", str(relative)],
+                cwd=ROOT,
+                env=compiler_env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            failures.append((relative, f"timed out after {timeout:g}s"))
+            print(f"[RUN TIMEOUT] {relative}")
+            continue
+
+        if result.returncode == 0:
+            print(f"[RUN PASS] {relative}")
+            continue
+
+        detail = "\n".join(
+            part.rstrip() for part in (result.stdout, result.stderr) if part.strip()
+        )
+        failures.append((relative, detail or f"exit status {result.returncode}"))
+        print(f"[RUN FAIL] {relative}")
+
+    print(
+        f"Example result: {len(examples) - len(failures)} passed, "
+        f"{len(failures)} failed"
+    )
+    return failures
+
+
 def main() -> int:
     args = parse_args()
     try:
@@ -83,6 +132,7 @@ def main() -> int:
 
     files = corpus_files()
     failures: list[tuple[Path, str]] = []
+    example_failures: list[tuple[Path, str]] = []
 
     print(f"Checking {len(files)} Wave corpus files with {wavec}")
     with tempfile.TemporaryDirectory(prefix="wave-corpus-home-") as temp_home:
@@ -120,11 +170,17 @@ def main() -> int:
             failures.append((relative, detail or f"exit status {result.returncode}"))
             print(f"[FAIL] {relative}")
 
+        if args.run_std_examples:
+            example_failures = run_std_examples(wavec, compiler_env, args.timeout)
+
     print(f"Corpus result: {len(files) - len(failures)} passed, {len(failures)} failed")
     for relative, detail in failures:
         print(f"\n--- {relative} ---\n{detail}", file=sys.stderr)
 
-    return 1 if failures else 0
+    for relative, detail in example_failures:
+        print(f"\n--- run {relative} ---\n{detail}", file=sys.stderr)
+
+    return 1 if failures or example_failures else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR completes the current standard-library foundation work and extends it into a portable OS and architecture provider model.

- defines documented public std::fs and std::io APIs with runnable file examples
- makes std updates compatibility-versioned, staged, validated, transactional, and rollback-safe
- separates portable APIs from OS providers and architecture-specific syscall ABIs
- adds Linux amd64, arm64, and riscv64 providers
- adds macOS amd64 and arm64 providers
- adds an initial FreeBSD amd64 provider and compiler target
- adds architecture-neutral Windows Win32 and Winsock providers shared by x86-64 and ARM64
- adds the aarch64-w64-windows-gnu compiler target and extern(system) ARM64 handling
- expands native, cross-target, corpus, example, and CI coverage

## Issue coverage

### Standard-library layering and contracts

- keeps user-facing modules independent from raw syscall providers
- documents public std and libc surfaces with short usage-oriented comments
- centralizes OS and architecture selection through target attributes
- rejects duplicate target keys and canonicalizes OS and architecture aliases

### Version-aware transactional std updates

- adds a standard-library compatibility revision manifest
- rejects incompatible installed std revisions with an actionable diagnostic
- stages and validates the complete Wave source tree before activation
- records installation source metadata
- atomically replaces an installation and restores the previous tree on activation failure
- adds replacement and rollback regression tests with isolated HOME directories

### User-facing filesystem API

- adds portable open, create, read, write, append, copy, rename, metadata, directory, and removal helpers
- provides fixed-buffer and growable-buffer read paths
- updates the file I/O example to the public API
- adds end-to-end filesystem coverage

## Additional work

- adds FreeBSD target selection, object generation, linker planning, sysroot, and CRT handling
- corrects Linux, Darwin, and FreeBSD termios layouts and syscall contracts
- adds Windows file, environment, memory, process, socket, time, and tty provider surfaces
- maps Windows standard descriptors through GetStdHandle
- keeps Windows std implementations architecture-neutral while retaining architecture-specific LLVM and C ABI target handling
- fixes TypedBuffer pointer arithmetic exposed by the new runtime tests
- verifies ARM64 and x86-64 COFF machine headers independently
- adds 11 Wave E2E cases for string, path, buffer, environment, time, math, and cross-target std object generation
- adds 12 focused examples under examples/std
- runs the std example suite natively on Linux amd64 and arm64, macOS amd64 and arm64, and Windows CI
- limits Cargo CI parallelism to two jobs and applies the same example gate to release validation

## Validation

- cargo fmt --all --check
- cargo test --locked --workspace --jobs 2
- RUSTDOCFLAGS=-D warnings cargo doc --locked --no-deps --jobs 2
- standard-library policy validation
- 43 codegen regression tests
- 167 of 167 Wave corpus files
- 12 of 12 standard-library examples
- 113 Wave E2E passes, 8 platform or sandbox skips, 0 failures
- Windows x86-64 and ARM64 COFF object generation
- git diff --check

Closes #375
Closes #379
Closes #380