### PR TITLE
feat: complete WebAssembly and payload variant support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,10 @@ jobs:
             echo "Invalid release version: $RELEASE_VERSION" >&2
             exit 1
           fi
+          if [[ "$RELEASE_VERSION" == *-dev ]]; then
+            echo "Development version cannot be released: $RELEASE_VERSION" >&2
+            exit 1
+          fi
 
           cargo_version="$(python3 -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["package"]["version"])')"
           if [[ "$cargo_version" != "$RELEASE_VERSION" ]]; then

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,6 +45,7 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 21
+          sudo apt-get install -y lld-21
           echo "LLVM_SYS_211_PREFIX=/usr/lib/llvm-21" >> "$GITHUB_ENV"
           echo "LLVM_CONFIG_PATH=/usr/lib/llvm-21/bin/llvm-config" >> "$GITHUB_ENV"
           echo "/usr/lib/llvm-21/bin" >> "$GITHUB_PATH"
@@ -76,6 +77,32 @@ jobs:
 
       - name: Build release compiler
         run: cargo build --locked --release --verbose
+
+      - name: Build and run WebAssembly module
+        run: |
+          set -euo pipefail
+
+          command -v wasm-ld
+          command -v node
+          output_dir="$RUNNER_TEMP/wave-wasm32"
+          target/release/wavec build examples/wasm_module.wave \
+            --target wasm32-unknown-unknown \
+            --out-dir "$output_dir"
+          llvm-readobj --file-headers "$output_dir/wasm_module.wasm" \
+            | grep -F 'Format: WASM'
+          node tools/run_wasm_smoke.mjs "$output_dir/wasm_module.wasm"
+          target/release/wavec run examples/wasm_run.wave \
+            --target wasm32-unknown-unknown
+
+          target/release/wavec build examples/wasm_wasi.wave \
+            --target wasm32-wasip1 \
+            --out-dir "$output_dir"
+          llvm-readobj --file-headers "$output_dir/wasm_wasi.wasm" \
+            | grep -F 'Format: WASM'
+          node --no-warnings tools/run_wasi_smoke.mjs \
+            "$output_dir/wasm_wasi.wasm" "$GITHUB_WORKSPACE"
+          target/release/wavec run examples/wasm_wasi.wave \
+            --target wasm32-wasip1
 
       - name: Run Rust tests
         run: cargo test --locked --all-targets --verbose
@@ -264,6 +291,11 @@ jobs:
         run: >-
           cargo build --locked --no-default-features
           --features llvm-target-aarch64 --jobs 2
+
+      - name: Build with the WebAssembly-only LLVM feature
+        run: >-
+          cargo build --locked --no-default-features
+          --features llvm-target-wasm --jobs 2
 
       - name: Build with the core 64-bit LLVM feature set
         run: >-

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,32 +78,6 @@ jobs:
       - name: Build release compiler
         run: cargo build --locked --release --verbose
 
-      - name: Build and run WebAssembly module
-        run: |
-          set -euo pipefail
-
-          command -v wasm-ld
-          command -v node
-          output_dir="$RUNNER_TEMP/wave-wasm32"
-          target/release/wavec build examples/wasm_module.wave \
-            --target wasm32-unknown-unknown \
-            --out-dir "$output_dir"
-          llvm-readobj --file-headers "$output_dir/wasm_module.wasm" \
-            | grep -F 'Format: WASM'
-          node tools/run_wasm_smoke.mjs "$output_dir/wasm_module.wasm"
-          target/release/wavec run examples/wasm_run.wave \
-            --target wasm32-unknown-unknown
-
-          target/release/wavec build examples/wasm_wasi.wave \
-            --target wasm32-wasip1 \
-            --out-dir "$output_dir"
-          llvm-readobj --file-headers "$output_dir/wasm_wasi.wasm" \
-            | grep -F 'Format: WASM'
-          node --no-warnings tools/run_wasi_smoke.mjs \
-            "$output_dir/wasm_wasi.wasm" "$GITHUB_WORKSPACE"
-          target/release/wavec run examples/wasm_wasi.wave \
-            --target wasm32-wasip1
-
       - name: Run Rust tests
         run: cargo test --locked --all-targets --verbose
 
@@ -130,6 +104,88 @@ jobs:
           name: wave-e2e-${{ github.job }}
           path: wave-e2e-report.json
           if-no-files-found: warn
+
+  build-wasm:
+    name: Build WebAssembly
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@1.89.0
+
+      - name: Install LLVM 21 and WebAssembly linker
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget software-properties-common
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 21
+          sudo apt-get install -y lld-21
+          echo "LLVM_SYS_211_PREFIX=/usr/lib/llvm-21" >> "$GITHUB_ENV"
+          echo "LLVM_CONFIG_PATH=/usr/lib/llvm-21/bin/llvm-config" >> "$GITHUB_ENV"
+          echo "/usr/lib/llvm-21/bin" >> "$GITHUB_PATH"
+
+      - name: Install Wave stdlib
+        run: |
+          mkdir -p "$HOME/.wave/lib/wave"
+          rm -rf "$HOME/.wave/lib/wave/std"
+          cp -R std "$HOME/.wave/lib/wave/std"
+
+      - name: Verify WebAssembly tools
+        run: |
+          set -euo pipefail
+
+          llvm-config --version
+          wasm-ld --version
+          llvm-readobj --version
+          node --version
+
+      - name: Build compiler with the WebAssembly backend only
+        run: >-
+          cargo build --locked --release --no-default-features
+          --features llvm-target-wasm --jobs 2
+
+      - name: Run WebAssembly compiler regressions
+        run: >-
+          cargo test --locked --no-default-features
+          --features llvm-target-wasm --test codegen_regressions
+          wasm32_ --jobs 2 --verbose
+
+      - name: Build and run browser and WASI modules
+        run: |
+          set -euo pipefail
+
+          output_dir="$RUNNER_TEMP/wave-wasm32"
+          target/release/wavec build examples/wasm_module.wave \
+            --target wasm32-unknown-unknown \
+            --out-dir "$output_dir"
+          llvm-readobj --file-headers "$output_dir/wasm_module.wasm" \
+            | grep -F 'Format: WASM'
+          node tools/run_wasm_smoke.mjs "$output_dir/wasm_module.wasm"
+          target/release/wavec run examples/wasm_run.wave \
+            --target wasm32-unknown-unknown
+
+          target/release/wavec build examples/wasm_wasi.wave \
+            --target wasm32-wasip1 \
+            --out-dir "$output_dir"
+          llvm-readobj --file-headers "$output_dir/wasm_wasi.wasm" \
+            | grep -F 'Format: WASM'
+          node --no-warnings tools/run_wasi_smoke.mjs \
+            "$output_dir/wasm_wasi.wasm" "$GITHUB_WORKSPACE"
+          target/release/wavec run examples/wasm_wasi.wave \
+            --target wasm32-wasip1
+
+      - name: Run payload variants on WebAssembly targets
+        run: |
+          set -euo pipefail
+
+          target/release/wavec run tests/cases/test129.wave \
+            --target wasm32-unknown-unknown
+          target/release/wavec run tests/cases/test129.wave \
+            --target wasm32-wasip1
 
   build-linux-arm64:
     name: Build Linux arm64
@@ -291,11 +347,6 @@ jobs:
         run: >-
           cargo build --locked --no-default-features
           --features llvm-target-aarch64 --jobs 2
-
-      - name: Build with the WebAssembly-only LLVM feature
-        run: >-
-          cargo build --locked --no-default-features
-          --features llvm-target-wasm --jobs 2
 
       - name: Build with the core 64-bit LLVM feature set
         run: >-
@@ -566,6 +617,9 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 60
 
+    # The pinned MINGW64 LLVM 21 package omits WebAssembly target libraries.
+    # The dedicated build-wasm job validates that backend with a complete LLVM.
+
     steps:
       - uses: actions/checkout@v4
 
@@ -664,7 +718,9 @@ jobs:
 
       - name: Run Clippy
         shell: msys2 {0}
-        run: cargo clippy --locked --all-targets -- -D warnings
+        run: >-
+          cargo clippy --locked --all-targets --no-default-features
+          --features llvm-target-core64 -- -D warnings
 
       - name: Validate Python tooling
         shell: msys2 {0}
@@ -677,7 +733,9 @@ jobs:
 
       - name: Build release compiler
         shell: msys2 {0}
-        run: cargo build --locked --release --verbose
+        run: >-
+          cargo build --locked --release --no-default-features
+          --features llvm-target-core64 --verbose
 
       - name: Check and run standard library examples
         shell: msys2 {0}
@@ -687,7 +745,9 @@ jobs:
 
       - name: Run Rust tests
         shell: msys2 {0}
-        run: cargo test --locked --all-targets --verbose
+        run: >-
+          cargo test --locked --all-targets --no-default-features
+          --features llvm-target-core64 --verbose
 
       - name: Run Wave end-to-end tests
         shell: msys2 {0}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ version = "0.1.0"
 
 [[package]]
 name = "wavec"
-version = "0.2.0-pre-beta"
+version = "0.2.1-pre-beta-dev"
 dependencies = [
  "error",
  "lexer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavec"
-version = "0.2.0-pre-beta"
+version = "0.2.1-pre-beta-dev"
 edition = "2021"
 
 [lib]
@@ -15,11 +15,12 @@ error = { path = "front/error" }
 llvm = { path = "./llvm", default-features = false }
 
 [features]
-default = ["llvm-target-core64"]
+default = ["llvm-target-core64", "llvm-target-wasm"]
 llvm-target-core64 = ["llvm-target-x86", "llvm-target-aarch64", "llvm-target-riscv"]
 llvm-target-all = ["llvm/llvm-target-all"]
 llvm-target-aarch64 = ["llvm/llvm-target-aarch64"]
 llvm-target-riscv = ["llvm/llvm-target-riscv"]
+llvm-target-wasm = ["llvm/llvm-target-wasm"]
 llvm-target-x86 = ["llvm/llvm-target-x86"]
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ C made native software portable, direct, and durable. Wave starts from those fun
 Wave is not a C dialect and does not aim for C source compatibility. It is a new general-purpose language with its own syntax, semantics, module system, and toolchain.
 
 - **General-purpose by design.** Use the same language for applications, command-line tools, libraries, and freestanding software.
-- **Native and direct.** Compile to executables, objects, assembly, LLVM IR, or bitcode without hiding target details.
+- **Native and direct.** Compile to executables, WebAssembly modules, objects, assembly, LLVM IR, or bitcode without hiding target details.
 - **Machine access when needed.** Use pointers, C ABI boundaries, inline assembly, and freestanding targets when system contracts must stay visible.
 - **Modern language structure.** Organize code with modules, `pub` visibility, generics, structs, enums, variants, `proto`, and explicit `var` declarations.
-- **Cross-target compilation.** Generate code for x86-64, AArch64, and RISC-V 64 from supported compiler hosts.
+- **Cross-target compilation.** Generate code for x86-64, AArch64, RISC-V 64, and WebAssembly from supported compiler hosts.
 - **Tool-friendly interfaces.** Query targets and compiler capabilities in human-readable or JSON form for build tools and editors.
 
 Wave is under active pre-beta development. Syntax and toolchain contracts are being stabilized and may still change between releases.
@@ -123,6 +123,11 @@ wavec -O2 build main.wave -o app
 
 # Emit a freestanding RISC-V object.
 wavec --target=riscv64-unknown-none-elf build kernel.wave --freestanding --emit=obj
+
+# Build a browser-hosted module or a WASI Preview 1 command.
+wavec --target=wasm32-unknown-unknown build module.wave
+wavec --target=wasm32-wasip1 build command.wave
+wavec --target=wasm32-wasip1 run command.wave
 ```
 
 The compiler exposes its current capabilities instead of requiring tools to maintain hard-coded lists:
@@ -143,8 +148,17 @@ Run `wavec --help` for the complete CLI contract.
 | x86-64 | Linux GNU, macOS, Windows GNU | `x86_64-unknown-none-elf` |
 | AArch64 | Linux GNU, macOS | `aarch64-unknown-none-elf` |
 | RISC-V 64 | Linux GNU | `riscv64-unknown-none-elf` |
+| WebAssembly 32 | WASI Preview 1 | `wasm32-unknown-unknown` |
 
-Hosted cross-linking requires a compatible linker, system libraries, and sysroot for the selected target. For Linux RISC-V 64, `wavec` discovers complete cross-toolchain sysroots automatically; an explicit `--sysroot` always takes precedence. Freestanding builds omit the default hosted runtime assumptions and are intended for kernels, firmware, boot code, and other no-OS environments.
+Hosted cross-linking requires a compatible linker, system libraries, and sysroot for the selected target. For Linux RISC-V 64, `wavec` discovers complete cross-toolchain sysroots automatically; an explicit `--sysroot` always takes precedence. WebAssembly builds use `wasm-ld`; `wasm32-unknown-unknown` imports host functions from `env`, while `wasm32-wasip1` emits a `_start` command entry and WASI Preview 1 imports. `wavec run` executes both WebAssembly targets through Node.js; WASI commands receive the current directory as their `.` preopen. Freestanding builds omit the default hosted runtime assumptions and are intended for kernels, firmware, boot code, and other no-OS environments.
+
+The initial WebAssembly backend supports Wave control flow, pointers and linear
+memory, structs, arrays, enums, payload variants, generics, stable `extern(c)`/`export(c)` host
+boundaries, and the portable standard-library layers backed by WASI descriptor
+I/O, preopened paths, clocks, sleep, environment access, process exit, and a
+single-threaded allocator. WASI Preview 1 does not provide POSIX process trees,
+native sockets, or terminal control; process-tree calls report unsupported, and
+socket and terminal providers are not exposed on WASI.
 
 ## Build from source
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,7 +13,7 @@ February, April, June, August, October, and December.
 ## Release prerequisites
 
 1. Merge the release candidate into `master`.
-2. Set the release version in `Cargo.toml` and update `Cargo.lock`.
+2. Remove the development `-dev` suffix in `Cargo.toml` and update `Cargo.lock`.
 3. Confirm that the normal `Wave CI` workflow passes on `master`.
 4. Prepare and review the release post separately in the Wave blog repository.
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -43,13 +43,16 @@ example, after the final `pre-beta` release, the first `alpha` release starts at
 
 ## Current Sequence
 
-`v0.1.9-pre-beta` is the 19th `pre-beta` release.
+`v0.2.0-pre-beta` is the latest public `pre-beta` release.
 
-The next `pre-beta` release is `v0.2.0-pre-beta`.
+The repository uses `v0.2.1-pre-beta-dev` while the next release is under
+development. The `-dev` suffix is removed when the release candidate is ready
+to publish as `v0.2.1-pre-beta`.
 
 ## Rules
 
 - The version in `Cargo.toml` must match the release workflow input.
+- Development revisions use the next release version with a `-dev` suffix.
 - Git tags use the `v` prefix, for example `v0.2.0-pre-beta`.
 - Release workflow input omits the `v` prefix, for example `0.2.0-pre-beta`.
 - Do not describe Wave releases as SemVer-compatible unless the policy changes.

--- a/examples/wasm_module.wave
+++ b/examples/wasm_module.wave
@@ -1,0 +1,82 @@
+// Web hosts provide extern(c) functions through the conventional `env` module.
+extern(c, "host_add") fun host_add(a: i32, b: i32) -> i32;
+
+// export(c) gives the host a stable ABI and symbol name.
+export(c, "wave_add") fun add(a: i32, b: i32) -> i32 {
+    return host_add(a, b);
+}
+
+enum Operation -> i32 {
+    Sum = 0,
+    Multiply = 1
+}
+
+struct Box<T> {
+    value: T;
+}
+
+struct Pair {
+    left: i32;
+    right: i32;
+}
+
+variant FeatureValue<T> {
+    Present(T),
+    Absent
+}
+
+fun identity<T>(value: T) -> T {
+    return value;
+}
+
+fun increment(value: ptr<i32>) {
+    deref value = deref value + 1;
+}
+
+fun apply_operation(operation: Operation, pair: Pair) -> i32 {
+    var result: i32 = -1;
+    match (operation) {
+        Sum => { result = pair.left + pair.right; }
+        Multiply => { result = pair.left * pair.right; }
+        _ => { result = -1; }
+    }
+    return result;
+}
+
+fun feature_value(value: FeatureValue<i32>) -> i32 {
+    var result: i32 = -1;
+    match value {
+        FeatureValue::Present(item) => { result = item; }
+        FeatureValue::Absent => { result = 0; }
+    }
+    return result;
+}
+
+// This keeps the browser smoke test honest: arrays, loops, pointers, structs,
+// enums, match, and generic monomorphization must all execute in wasm.
+fun exercise_features(seed: i32) -> i32 {
+    var values: array<i32, 4> = [seed, 2, 3, 4];
+    var total: i32 = 0;
+    var index: i32 = 0;
+    while (index < 4) {
+        total += values[index];
+        index += 1;
+    }
+
+    var boxed: Box<i32> = Box<i32> { value: identity<i32>(seed) };
+    var pair: Pair = Pair { left: boxed.value, right: total };
+    var incremented: i32 = pair.right;
+    increment(&incremented);
+    pair.right = incremented;
+
+    var result: FeatureValue<i32> = FeatureValue::Present(apply_operation(Sum, pair));
+    return feature_value(result);
+}
+
+export(c, "wave_features") fun exported_features(seed: i32) -> i32 {
+    return exercise_features(seed);
+}
+
+fun main() -> i32 {
+    return add(20, 22);
+}

--- a/examples/wasm_run.wave
+++ b/examples/wasm_run.wave
@@ -1,0 +1,11 @@
+// A browser-hosted module that can be executed directly with `wavec run`.
+import("std::mem::alloc")::{mem_alloc, mem_free};
+
+fun main() -> i32 {
+    var data: ptr<u8> = mem_alloc(32);
+    if (data == null) { return 1; }
+    deref data[0] = 42;
+    if (deref data[0] != 42) { return 2; }
+    if (mem_free(data, 32) != 0) { return 3; }
+    return 0;
+}

--- a/examples/wasm_wasi.wave
+++ b/examples/wasm_wasi.wave
@@ -1,0 +1,34 @@
+// Run this WASI Preview 1 command with the current directory preopened as fd 3.
+import("std::io::fd")::{io_write_all};
+import("std::time::clock")::{time_now_monotonic_ns};
+import("std::time::sleep")::{time_sleep_ms};
+import("std::mem::alloc")::{mem_alloc, mem_free};
+import("std::env::environ")::{env_exists};
+import("std::sys::fs")::{FS_O_RDONLY, Stat, open, close, read, fstat};
+
+fun main() -> i32 {
+    var message: str = "Wave WASI Preview 1\n";
+    var written: i64 = io_write_all(1, message as ptr<u8>, 20);
+    if (written != 20) { return 1; }
+
+    var now: i64 = time_now_monotonic_ns();
+    if (now < 0) { return 2; }
+    if (time_sleep_ms(1) < 0) { return 3; }
+    if (!env_exists("HOME")) { return 4; }
+
+    var allocation: ptr<u8> = mem_alloc(32);
+    if (allocation == null) { return 5; }
+    deref allocation[0] = 87;
+    if (allocation[0] != 87 || mem_free(allocation, 32) < 0) { return 6; }
+
+    // Relative paths stay inside the directory capability supplied by the host.
+    var fd: i64 = open("README.md", FS_O_RDONLY, 0);
+    if (fd < 0) { return 7; }
+    var info: Stat;
+    if (fstat(fd, &info) < 0 || info.size <= 0) { return 8; }
+    var prefix: array<u8, 2> = [0, 0];
+    if (read(fd, &prefix[0], 2) != 2) { return 9; }
+    if (prefix[0] != 35 || prefix[1] != 32) { return 10; }
+    if (close(fd) < 0) { return 11; }
+    return 0;
+}

--- a/front/parser/src/generics.rs
+++ b/front/parser/src/generics.rs
@@ -12,9 +12,11 @@
 
 //! Ahead-of-time generic monomorphization for the Wave AST.
 //!
-//! Generic templates are removed from the emitted AST and replaced by concrete
-//! instances discovered while rewriting non-generic roots. Instance names are
-//! deterministic so repeated references resolve to one generated definition.
+//! Callable templates are removed from the emitted AST and replaced by concrete
+//! instances discovered while rewriting non-generic roots. Type templates stay
+//! available to final semantic analysis alongside their concrete instances;
+//! backends ignore the unresolved templates. Instance names are deterministic
+//! so repeated references resolve to one generated definition.
 
 use crate::ast::{
     ASTNode, EnumNode, Expression, ExternFunctionNode, FunctionNode, Literal, MatchArm,
@@ -31,21 +33,24 @@ struct GenericEnv {
     function_templates: HashMap<String, FunctionNode>,
     function_parameters: HashMap<String, Vec<ParameterNode>>,
     struct_templates: HashMap<String, StructNode>,
+    variant_templates: HashMap<String, VariantNode>,
     variant_generic_params: HashMap<String, Vec<String>>,
 
     function_instances: BTreeMap<String, FunctionNode>,
     struct_instances: BTreeMap<String, StructNode>,
+    variant_instances: BTreeMap<String, VariantNode>,
 
     function_in_progress: HashSet<String>,
     struct_in_progress: HashSet<String>,
+    variant_in_progress: HashSet<String>,
 }
 
-/// Rewrites a parsed program into an AST containing only concrete generic instances.
+/// Rewrites a parsed program and materializes every referenced generic instance.
 ///
 /// Callers must run this after import expansion and before concrete-AST
 /// validation or code generation. A template-aware semantic pass may run first,
 /// but later phases do not accept unresolved generic parameters in emitted
-/// function and struct definitions.
+/// function definitions or backend-lowered aggregate definitions.
 pub fn monomorphize_generics(ast: Vec<ASTNode>) -> Result<Vec<ASTNode>, String> {
     let mut env = GenericEnv::default();
 
@@ -87,6 +92,10 @@ pub fn monomorphize_generics(ast: Vec<ASTNode>) -> Result<Vec<ASTNode>, String> 
             ASTNode::Variant(variant) => {
                 env.variant_generic_params
                     .insert(variant.name.clone(), variant.generic_params.clone());
+                if !variant.generic_params.is_empty() {
+                    env.variant_templates
+                        .insert(variant.name.clone(), variant.clone());
+                }
             }
             _ => {}
         }
@@ -112,13 +121,17 @@ pub fn monomorphize_generics(ast: Vec<ASTNode>) -> Result<Vec<ASTNode>, String> 
                 out.push(ASTNode::Struct(rewrite_struct(s, &empty_subst, &mut env)?));
             }
 
-            ASTNode::Struct(_) => {}
+            ASTNode::Struct(s) => out.push(ASTNode::Struct(s)),
             ASTNode::Variant(variant) => {
-                out.push(ASTNode::Variant(rewrite_variant(
-                    variant,
-                    &empty_subst,
-                    &mut env,
-                )?));
+                if variant.generic_params.is_empty() {
+                    out.push(ASTNode::Variant(rewrite_variant(
+                        variant,
+                        &empty_subst,
+                        &mut env,
+                    )?));
+                } else {
+                    out.push(ASTNode::Variant(variant));
+                }
             }
             ASTNode::Variable(v) => {
                 out.push(ASTNode::Variable(rewrite_variable(
@@ -183,6 +196,9 @@ pub fn monomorphize_generics(ast: Vec<ASTNode>) -> Result<Vec<ASTNode>, String> 
         }
     }
 
+    for (_, variant) in env.variant_instances {
+        out.push(ASTNode::Variant(variant));
+    }
     for (_, s) in env.struct_instances {
         out.push(ASTNode::Struct(s));
     }
@@ -725,15 +741,11 @@ fn rewrite_struct_type(
                 .into_iter()
                 .map(|argument| {
                     let parsed = parse_wave_type_from_str(&argument)?;
-                    let rewritten = rewrite_wave_type(&parsed, subst, env)?;
-                    Ok(display_type_for_application(&rewritten))
+                    rewrite_wave_type(&parsed, subst, env)
                 })
                 .collect::<Result<Vec<_>, String>>()?;
-            return Ok(WaveType::Struct(format!(
-                "{}<{}>",
-                base,
-                arguments.join(",")
-            )));
+            let instantiated = ensure_variant_instance(&base, &arguments, env)?;
+            return Ok(WaveType::Struct(instantiated));
         }
         if !env.struct_templates.contains_key(&base) {
             return Err(format!(
@@ -762,6 +774,55 @@ fn rewrite_struct_type(
     }
 
     Ok(WaveType::Struct(name.to_string()))
+}
+
+fn ensure_variant_instance(
+    base: &str,
+    args: &[WaveType],
+    env: &mut GenericEnv,
+) -> Result<String, String> {
+    let template = env
+        .variant_templates
+        .get(base)
+        .cloned()
+        .ok_or_else(|| format!("unknown generic variant template '{}'", base))?;
+    if template.generic_params.len() != args.len() {
+        return Err(format!(
+            "generic variant '{}' expects {} type arguments, got {}",
+            base,
+            template.generic_params.len(),
+            args.len()
+        ));
+    }
+    let instance_name = format!(
+        "{}<{}>",
+        base,
+        args.iter()
+            .map(display_type_for_application)
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    if env.variant_instances.contains_key(&instance_name)
+        || env.variant_in_progress.contains(&instance_name)
+    {
+        return Ok(instance_name);
+    }
+
+    let substitutions = template
+        .generic_params
+        .iter()
+        .cloned()
+        .zip(args.iter().cloned())
+        .collect::<HashMap<_, _>>();
+    env.variant_in_progress.insert(instance_name.clone());
+    let mut instance = template;
+    instance.name = instance_name.clone();
+    instance.generic_params.clear();
+    instance = rewrite_variant(instance, &substitutions, env)?;
+    env.variant_in_progress.remove(&instance_name);
+    env.variant_instances
+        .insert(instance_name.clone(), instance);
+    Ok(instance_name)
 }
 
 fn rewrite_struct_name_usage(

--- a/front/parser/src/hir.rs
+++ b/front/parser/src/hir.rs
@@ -19,6 +19,7 @@
 //! backend-owned state or expression addresses as public identities.
 
 use crate::ast::{ASTNode, Expression, MatchPattern, StatementNode, WaveType};
+use crate::types::{parse_type, split_top_level_generic_args, token_type_to_wave_type};
 use crate::verification::{analyze_hir_expression_types, SemanticDiagnostic};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -193,6 +194,10 @@ impl TypedProgram {
         self.expression_types.get(id.index())
     }
 
+    pub fn expression_types(&self) -> impl Iterator<Item = &HirExpressionType> {
+        self.expression_types.iter()
+    }
+
     pub fn type_of(&self, expression: &Expression) -> Option<&HirExpressionType> {
         self.expression_id(expression)
             .and_then(|id| self.expression_type(id))
@@ -200,6 +205,10 @@ impl TypedProgram {
 
     pub fn variant_construction(&self, id: ExpressionId) -> Option<&HirVariantConstruction> {
         self.variant_constructions.get(id.index())?.as_ref()
+    }
+
+    pub fn variant_constructions(&self) -> impl Iterator<Item = &HirVariantConstruction> {
+        self.variant_constructions.iter().flatten()
     }
 
     /// Returns resolved constructor metadata for a syntax expression in this program.
@@ -219,6 +228,10 @@ impl TypedProgram {
 
     pub fn variant_pattern(&self, id: PatternId) -> Option<&HirVariantPattern> {
         self.variant_patterns.get(id.index())?.as_ref()
+    }
+
+    pub fn variant_patterns(&self) -> impl Iterator<Item = &HirVariantPattern> {
+        self.variant_patterns.iter().flatten()
     }
 
     /// Returns resolved variant metadata for a syntax pattern in this program.
@@ -245,6 +258,12 @@ fn collect_named_types(nodes: &[ASTNode]) -> HashMap<String, WaveType> {
             ASTNode::Enum(enumeration) => {
                 named.insert(enumeration.name.clone(), enumeration.repr_type.clone());
             }
+            ASTNode::Variant(variant) => {
+                named.insert(
+                    variant.name.clone(),
+                    WaveType::Variant(variant.name.clone()),
+                );
+            }
             _ => {}
         }
     }
@@ -263,16 +282,74 @@ fn canonical_type(
         WaveType::Array(inner, length) => {
             WaveType::Array(Box::new(canonical_type(inner, named, visiting)), *length)
         }
-        WaveType::Struct(name) if named.contains_key(name) => {
-            assert!(
-                visiting.insert(name.clone()),
-                "semantic validation allowed a named type cycle at `{name}`"
-            );
-            let resolved = canonical_type(&named[name], named, visiting);
-            visiting.remove(name);
-            resolved
-        }
+        WaveType::Struct(name) => canonical_named_type(name, named, visiting)
+            .unwrap_or_else(|| WaveType::Struct(name.clone())),
+        WaveType::Variant(name) => canonical_variant_application(name, named, visiting)
+            .unwrap_or_else(|| WaveType::Variant(name.clone())),
         _ => ty.clone(),
+    }
+}
+
+fn canonical_named_type(
+    name: &str,
+    named: &HashMap<String, WaveType>,
+    visiting: &mut HashSet<String>,
+) -> Option<WaveType> {
+    if let Some(target) = named.get(name) {
+        assert!(
+            visiting.insert(name.to_string()),
+            "semantic validation allowed a named type cycle at `{name}`"
+        );
+        let resolved = canonical_type(target, named, visiting);
+        visiting.remove(name);
+        return Some(resolved);
+    }
+    canonical_variant_application(name, named, visiting)
+}
+
+fn canonical_variant_application(
+    name: &str,
+    named: &HashMap<String, WaveType>,
+    visiting: &mut HashSet<String>,
+) -> Option<WaveType> {
+    let (base, arguments) = split_named_application(name)?;
+    if !matches!(named.get(base), Some(WaveType::Variant(_))) {
+        return None;
+    }
+    let arguments = arguments
+        .into_iter()
+        .map(|argument| canonical_type(&argument, named, visiting))
+        .map(|argument| display_wave_type(&argument))
+        .collect::<Vec<_>>()
+        .join(",");
+    Some(WaveType::Variant(format!("{base}<{arguments}>")))
+}
+
+fn split_named_application(name: &str) -> Option<(&str, Vec<WaveType>)> {
+    let (base, tail) = name.split_once('<')?;
+    let inner = tail.strip_suffix('>')?;
+    let arguments = split_top_level_generic_args(inner)?
+        .into_iter()
+        .map(|argument| token_type_to_wave_type(&parse_type(&argument)?))
+        .collect::<Option<Vec<_>>>()?;
+    Some((base.trim(), arguments))
+}
+
+fn display_wave_type(ty: &WaveType) -> String {
+    match ty {
+        WaveType::Int(bits) => format!("i{bits}"),
+        WaveType::Uint(bits) => format!("u{bits}"),
+        WaveType::Float(bits) => format!("f{bits}"),
+        WaveType::Bool => "bool".to_string(),
+        WaveType::Char => "char".to_string(),
+        WaveType::Byte => "byte".to_string(),
+        WaveType::String => "str".to_string(),
+        WaveType::Pointer(inner) => format!("ptr<{}>", display_wave_type(inner)),
+        WaveType::Array(inner, length) => {
+            format!("array<{},{}>", display_wave_type(inner), length)
+        }
+        WaveType::Void => "void".to_string(),
+        WaveType::Struct(name) | WaveType::Variant(name) => name.clone(),
     }
 }
 

--- a/front/parser/src/verification.rs
+++ b/front/parser/src/verification.rs
@@ -426,7 +426,9 @@ impl ProgramTypes {
     }
 
     fn variant_type(&self, name: &str) -> Option<&VariantType> {
-        self.variants.get(self.named_type_base(name))
+        self.variants
+            .get(name)
+            .or_else(|| self.variants.get(self.named_type_base(name)))
     }
 
     fn variant_constructor<'b>(&self, name: &'b str) -> Option<(&'b str, &'b str)> {
@@ -1904,9 +1906,17 @@ impl<'a> Validator<'a> {
             }
             Expression::ArrayLiteral(values) => {
                 self.mark_span(SemanticSpanKind::Keyword, "[");
+                let expected_element =
+                    expected
+                        .map(|ty| self.program.canonical_type(ty))
+                        .and_then(|ty| match ty {
+                            WaveType::Array(element, _) => Some(*element),
+                            _ => None,
+                        });
                 let mut element_types = Vec::with_capacity(values.len());
                 for value in values {
-                    element_types.push(self.validate_expr(value)?);
+                    element_types
+                        .push(self.validate_expr_expected(value, expected_element.as_ref())?);
                 }
                 Ok(ExpressionType::ArrayLiteral(element_types))
             }
@@ -2147,14 +2157,10 @@ impl<'a> Validator<'a> {
             format!("{}<{}>", owner, arguments)
         };
 
-        let substitution = self.program.generic_substitution(&concrete_name);
-        let payload_types = template_payloads
-            .iter()
-            .map(|ty| {
-                self.program
-                    .canonical_type(&substitute_wave_type(ty, &substitution))
-            })
-            .collect::<Vec<_>>();
+        let (discriminant, payload_types) = self
+            .program
+            .variant_case(&concrete_name, case_name)
+            .expect("validated variant case remains available");
         for (index, (argument, payload_type)) in args.iter().zip(&payload_types).enumerate() {
             let actual = self.validate_expr_expected(argument, Some(payload_type))?;
             self.require_assignable(
@@ -2164,10 +2170,6 @@ impl<'a> Validator<'a> {
             )?;
         }
 
-        let (discriminant, _) = self
-            .program
-            .variant_case(&concrete_name, case_name)
-            .expect("validated variant case remains available");
         let variant_type = WaveType::Variant(concrete_name);
         self.hir_variant_constructions.insert(
             expression as *const Expression as usize,

--- a/front/parser/tests/variant_frontend.rs
+++ b/front/parser/tests/variant_frontend.rs
@@ -305,7 +305,14 @@ fun concrete() -> Option<i64> {
             ASTNode::Function(function)
                 if function.name.contains("wrap$g$i64")
                     && function.return_type
-                        == Some(WaveType::Struct("Option<i64>".into()))
+                        == Some(WaveType::Variant("Option<i64>".into()))
+        )
+    }));
+    assert!(program.syntax().iter().any(|node| {
+        matches!(
+            node,
+            ASTNode::Variant(variant)
+                if variant.name == "Option<i64>" && variant.generic_params.is_empty()
         )
     }));
 }

--- a/llvm/Cargo.toml
+++ b/llvm/Cargo.toml
@@ -19,4 +19,5 @@ llvm-target-core64 = ["llvm-target-x86", "llvm-target-aarch64", "llvm-target-ris
 llvm-target-all = ["inkwell/target-all"]
 llvm-target-aarch64 = ["inkwell/target-aarch64"]
 llvm-target-riscv = ["inkwell/target-riscv"]
+llvm-target-wasm = ["inkwell/target-webassembly"]
 llvm-target-x86 = ["inkwell/target-x86"]

--- a/llvm/src/backend.rs
+++ b/llvm/src/backend.rs
@@ -43,6 +43,12 @@ fn is_windows_gnu_target(target: Option<&str>) -> bool {
         .is_some_and(|spec| spec.os == "windows" && spec.env == "gnu")
 }
 
+fn is_wasm_target(target: Option<&str>) -> bool {
+    target
+        .and_then(target_spec_for_triple)
+        .is_some_and(|spec| spec.object_format == "wasm")
+}
+
 fn normalize_llvm_opt_flag(opt_flag: &str) -> &str {
     match opt_flag {
         // LLVM pass pipeline currently has no dedicated Ofast preset, so keep
@@ -129,7 +135,14 @@ pub fn link_objects(
     let mut cmd = Command::new(&linker_bin);
     configure_bundled_llvm_tool_env(&mut cmd, &linker_bin);
 
-    if backend.linker.is_none() && !(is_windows_gnu_target(Some(target)) && linker_bin == "gcc") {
+    if is_wasm_target(Some(target)) {
+        cmd.arg("--no-entry")
+            .arg("--allow-undefined")
+            .arg("--export-if-defined=main")
+            .arg("--export-memory");
+    } else if backend.linker.is_none()
+        && !(is_windows_gnu_target(Some(target)) && linker_bin == "gcc")
+    {
         append_lld_target_args(&mut cmd, target, backend);
     }
 
@@ -151,7 +164,7 @@ pub fn link_objects(
 
     cmd.arg("-o").arg(output);
 
-    if !backend.no_default_libs {
+    if !backend.no_default_libs && !is_wasm_target(Some(target)) {
         if is_darwin_target(target) {
             cmd.arg("-lSystem");
         } else if !is_windows_gnu_target(backend.target.as_deref()) {
@@ -166,7 +179,9 @@ pub fn link_objects(
 }
 
 fn default_lld_for_target(target: &str) -> String {
-    if is_darwin_target(target) {
+    if is_wasm_target(Some(target)) {
+        resolve_bundled_tool("wasm-ld")
+    } else if is_darwin_target(target) {
         resolve_bundled_tool("ld64.lld")
     } else if is_windows_gnu_target(Some(target)) {
         resolve_bundled_tool_path("ld.lld")
@@ -247,6 +262,7 @@ fn elf_lld_emulation(target: &str) -> Option<&'static str> {
         | CodegenTarget::FreestandingX86_64 => Some("elf_x86_64"),
         CodegenTarget::LinuxArm64 | CodegenTarget::FreestandingArm64 => Some("aarch64elf"),
         CodegenTarget::LinuxRISCV64 | CodegenTarget::FreestandingRISCV64 => Some("elf64lriscv"),
+        CodegenTarget::Wasm32Unknown | CodegenTarget::Wasm32WasiP1 => None,
         _ => None,
     }
 }

--- a/llvm/src/codegen/abi_c.rs
+++ b/llvm/src/codegen/abi_c.rs
@@ -108,6 +108,7 @@ fn integer_extension_for_target(target: CodegenTarget, ty: &WaveType) -> Option<
         | CodegenTarget::FreestandingArm64
         | CodegenTarget::WindowsX86_64Gnu
         | CodegenTarget::WindowsArm64Gnu => None,
+        CodegenTarget::Wasm32Unknown | CodegenTarget::Wasm32WasiP1 => narrow_extension(),
     }
 }
 
@@ -685,6 +686,58 @@ fn classify_ret_riscv64<'ctx>(
     RetLowering::Direct(t)
 }
 
+// Clang's wasm32 C ABI unwraps aggregates that contain exactly one scalar
+// leaf. Other non-empty aggregates are passed by value through linear memory
+// and returned through an sret pointer.
+fn wasm32_single_leaf<'ctx>(t: BasicTypeEnum<'ctx>) -> Option<BasicTypeEnum<'ctx>> {
+    let mut leaves = Vec::new();
+    flatten_leaf_types(t, &mut leaves);
+    (leaves.len() == 1).then_some(leaves[0])
+}
+
+fn classify_param_wasm32<'ctx>(td: &TargetData, t: BasicTypeEnum<'ctx>) -> ParamLowering<'ctx> {
+    let is_aggregate = matches!(
+        t,
+        BasicTypeEnum::StructType(_) | BasicTypeEnum::ArrayType(_)
+    );
+    if !is_aggregate {
+        return ParamLowering::Direct(t);
+    }
+    if td.get_store_size(&t) == 0 {
+        return ParamLowering::Ignore;
+    }
+    if let Some(leaf) = wasm32_single_leaf(t) {
+        return ParamLowering::Direct(leaf);
+    }
+    ParamLowering::ByVal {
+        ty: t.as_any_type_enum(),
+        align: td.get_abi_alignment(&t),
+    }
+}
+
+fn classify_ret_wasm32<'ctx>(td: &TargetData, t: Option<BasicTypeEnum<'ctx>>) -> RetLowering<'ctx> {
+    let Some(t) = t else {
+        return RetLowering::Void;
+    };
+    let is_aggregate = matches!(
+        t,
+        BasicTypeEnum::StructType(_) | BasicTypeEnum::ArrayType(_)
+    );
+    if !is_aggregate {
+        return RetLowering::Direct(t);
+    }
+    if td.get_store_size(&t) == 0 {
+        return RetLowering::Void;
+    }
+    if let Some(leaf) = wasm32_single_leaf(t) {
+        return RetLowering::Direct(leaf);
+    }
+    RetLowering::SRet {
+        ty: t.as_any_type_enum(),
+        align: td.get_abi_alignment(&t),
+    }
+}
+
 fn classify_param<'ctx>(
     context: &'ctx Context,
     td: &TargetData,
@@ -704,6 +757,7 @@ fn classify_param<'ctx>(
         CodegenTarget::LinuxRISCV64 | CodegenTarget::FreestandingRISCV64 => {
             classify_param_riscv64(context, td, t)
         }
+        CodegenTarget::Wasm32Unknown | CodegenTarget::Wasm32WasiP1 => classify_param_wasm32(td, t),
     }
 }
 
@@ -726,6 +780,7 @@ fn classify_ret<'ctx>(
         CodegenTarget::LinuxRISCV64 | CodegenTarget::FreestandingRISCV64 => {
             classify_ret_riscv64(context, td, t)
         }
+        CodegenTarget::Wasm32Unknown | CodegenTarget::Wasm32WasiP1 => classify_ret_wasm32(td, t),
     }
 }
 

--- a/llvm/src/codegen/arch/mod.rs
+++ b/llvm/src/codegen/arch/mod.rs
@@ -19,6 +19,7 @@
 
 pub(crate) mod aarch64;
 pub(crate) mod riscv64;
+pub(crate) mod wasm32;
 pub(crate) mod x86_64;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -26,6 +27,7 @@ pub enum Architecture {
     X86_64,
     Aarch64,
     Riscv64,
+    Wasm32,
 }
 
 impl Architecture {
@@ -34,6 +36,7 @@ impl Architecture {
             Self::X86_64 => "x86_64",
             Self::Aarch64 => "aarch64",
             Self::Riscv64 => "riscv64",
+            Self::Wasm32 => "wasm32",
         }
     }
 }
@@ -43,6 +46,7 @@ pub(crate) fn register_group(architecture: Architecture, token: &str) -> Option<
         Architecture::X86_64 => x86_64::register_group(token),
         Architecture::Aarch64 => aarch64::register_group(token),
         Architecture::Riscv64 => riscv64::register_group(token),
+        Architecture::Wasm32 => wasm32::register_group(token),
     }
 }
 
@@ -51,6 +55,7 @@ pub(crate) fn operand_register_group(architecture: Architecture, token: &str) ->
         Architecture::X86_64 => x86_64::operand_register_group(token),
         Architecture::Aarch64 => aarch64::operand_register_group(token),
         Architecture::Riscv64 => riscv64::operand_register_group(token),
+        Architecture::Wasm32 => wasm32::operand_register_group(token),
     }
 }
 
@@ -59,13 +64,16 @@ pub(crate) fn register_width_bits(architecture: Architecture, token: &str) -> Op
         Architecture::X86_64 => x86_64::register_width_bits(token),
         Architecture::Aarch64 => aarch64::register_width_bits(token),
         Architecture::Riscv64 => riscv64::register_width_bits(token),
+        Architecture::Wasm32 => wasm32::register_width_bits(token),
     }
 }
 
 pub(crate) const fn inline_asm_dialect(architecture: Architecture) -> inkwell::InlineAsmDialect {
     match architecture {
         Architecture::X86_64 => inkwell::InlineAsmDialect::Intel,
-        Architecture::Aarch64 | Architecture::Riscv64 => inkwell::InlineAsmDialect::ATT,
+        Architecture::Aarch64 | Architecture::Riscv64 | Architecture::Wasm32 => {
+            inkwell::InlineAsmDialect::ATT
+        }
     }
 }
 
@@ -74,6 +82,7 @@ pub(crate) fn default_clobbers(architecture: Architecture) -> Vec<String> {
         Architecture::X86_64 => x86_64::default_clobbers(),
         Architecture::Aarch64 => aarch64::default_clobbers(),
         Architecture::Riscv64 => riscv64::default_clobbers(),
+        Architecture::Wasm32 => wasm32::default_clobbers(),
     }
 }
 
@@ -82,6 +91,7 @@ pub(crate) fn allocatable_registers(architecture: Architecture) -> Vec<String> {
         Architecture::X86_64 => x86_64::allocatable_registers(),
         Architecture::Aarch64 => aarch64::allocatable_registers(),
         Architecture::Riscv64 => riscv64::allocatable_registers(),
+        Architecture::Wasm32 => wasm32::allocatable_registers(),
     }
 }
 
@@ -90,6 +100,7 @@ pub(crate) fn normalize_special_clobber(architecture: Architecture, token: &str)
         Architecture::X86_64 => x86_64::normalize_special_clobber(token),
         Architecture::Aarch64 => aarch64::normalize_special_clobber(token),
         Architecture::Riscv64 => riscv64::normalize_special_clobber(token),
+        Architecture::Wasm32 => wasm32::normalize_special_clobber(token),
     }
 }
 
@@ -142,6 +153,7 @@ pub(crate) fn stack_analysis(architecture: Architecture, line: &str) -> StackAna
         Architecture::X86_64 => x86_64::stack_analysis(line),
         Architecture::Aarch64 => aarch64::stack_analysis(line),
         Architecture::Riscv64 => riscv64::stack_analysis(line),
+        Architecture::Wasm32 => wasm32::stack_analysis(line),
     }
 }
 

--- a/llvm/src/codegen/arch/wasm32.rs
+++ b/llvm/src/codegen/arch/wasm32.rs
@@ -1,0 +1,65 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024–2026 Wave Foundation
+// Copyright (c) 2024–2026 LunaStev and contributors
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+
+//! WebAssembly target options and the deliberately empty native-register set.
+//!
+//! Wave inline assembly names physical registers, while WebAssembly exposes a
+//! stack machine rather than a native register file. Returning no registers
+//! makes existing inline-assembly validation reject such blocks for wasm32.
+
+#[cfg(any(feature = "llvm-target-all", feature = "llvm-target-wasm"))]
+pub(crate) const CPUS: &[&str] = &["generic"];
+#[cfg(any(feature = "llvm-target-all", feature = "llvm-target-wasm"))]
+pub(crate) const FEATURES: &[&str] = &[
+    "bulk-memory",
+    "mutable-globals",
+    "nontrapping-fptoint",
+    "reference-types",
+    "sign-ext",
+    "simd128",
+];
+#[cfg(any(feature = "llvm-target-all", feature = "llvm-target-wasm"))]
+pub(crate) const DEFAULT_CPU: &str = "generic";
+#[cfg(any(feature = "llvm-target-all", feature = "llvm-target-wasm"))]
+pub(crate) const DEFAULT_FEATURES: &[&str] = &[];
+
+pub(crate) fn register_group(_token: &str) -> Option<String> {
+    None
+}
+
+pub(crate) fn operand_register_group(_token: &str) -> Option<String> {
+    None
+}
+
+pub(crate) fn register_width_bits(_token: &str) -> Option<u32> {
+    None
+}
+
+pub(crate) fn default_clobbers() -> Vec<String> {
+    Vec::new()
+}
+
+pub(crate) fn allocatable_registers() -> Vec<String> {
+    Vec::new()
+}
+
+pub(crate) fn normalize_special_clobber(_token: &str) -> Option<String> {
+    None
+}
+
+pub(crate) fn stack_analysis(line: &str) -> super::StackAnalysis {
+    let mut out = super::StackAnalysis::default();
+    if !line.trim().is_empty() {
+        out.unknown_stack_write = true;
+    }
+    out
+}

--- a/llvm/src/codegen/consts.rs
+++ b/llvm/src/codegen/consts.rs
@@ -22,6 +22,7 @@ use inkwell::types::{BasicTypeEnum, StringRadix, StructType};
 use inkwell::values::{BasicValue, BasicValueEnum};
 
 use parser::ast::{Expression, Literal, WaveType};
+use parser::hir::TypedProgram;
 use std::collections::HashMap;
 use std::fmt;
 
@@ -153,7 +154,107 @@ fn const_from_expected<'ctx>(
     struct_types: &HashMap<String, StructType<'ctx>>,
     struct_field_indices: &HashMap<String, HashMap<String, u32>>,
     const_env: &HashMap<String, BasicValueEnum<'ctx>>,
+    program: Option<&TypedProgram>,
 ) -> Result<BasicValueEnum<'ctx>, ConstEvalError> {
+    if let Some(construction) = program.and_then(|program| program.variant_construction_of(expr)) {
+        let variant_ty = match expected {
+            BasicTypeEnum::StructType(variant_ty) => variant_ty,
+            _ => {
+                return Err(ConstEvalError::TypeMismatch {
+                    expected: type_name(expected),
+                    got: format!(
+                        "variant constructor '{}::{}'",
+                        match &construction.variant_type {
+                            WaveType::Variant(name) => name,
+                            _ => "<invalid>",
+                        },
+                        construction.case_name
+                    ),
+                    note: "variant constructor used where a non-variant constant is expected"
+                        .to_string(),
+                });
+            }
+        };
+        let args: &[Expression] = match expr {
+            Expression::FunctionCall { args, .. } => args,
+            Expression::Variable(_) if construction.payload_types.is_empty() => &[],
+            _ => {
+                return Err(ConstEvalError::Unsupported(format!(
+                    "variant constructor '{}::{}' has an unsupported syntax form",
+                    match &construction.variant_type {
+                        WaveType::Variant(name) => name,
+                        _ => "<invalid>",
+                    },
+                    construction.case_name
+                )));
+            }
+        };
+        if args.len() != construction.payload_types.len() {
+            return Err(ConstEvalError::Unsupported(format!(
+                "variant constructor payload count changed after semantic validation: expected {}, got {}",
+                construction.payload_types.len(),
+                args.len()
+            )));
+        }
+
+        let case_index = construction.discriminant + 1;
+        let payload_ty = variant_ty
+            .get_field_type_at_index(case_index)
+            .ok_or_else(|| {
+                ConstEvalError::Unsupported(format!(
+                    "variant case '{}' has no LLVM payload slot",
+                    construction.case_name
+                ))
+            })?
+            .into_struct_type();
+        if payload_ty.count_fields() as usize != args.len() {
+            return Err(ConstEvalError::Unsupported(format!(
+                "variant case '{}' LLVM payload layout expects {} fields, got {}",
+                construction.case_name,
+                payload_ty.count_fields(),
+                args.len()
+            )));
+        }
+
+        let mut payload_values = Vec::with_capacity(args.len());
+        for (index, argument) in args.iter().enumerate() {
+            let field_type = payload_ty
+                .get_field_type_at_index(index as u32)
+                .ok_or_else(|| {
+                    ConstEvalError::Unsupported(format!(
+                        "variant case '{}' has no payload field {}",
+                        construction.case_name, index
+                    ))
+                })?;
+            payload_values.push(const_from_expected(
+                context,
+                field_type,
+                argument,
+                struct_types,
+                struct_field_indices,
+                const_env,
+                program,
+            )?);
+        }
+
+        let mut fields = (0..variant_ty.count_fields())
+            .map(|index| {
+                variant_ty
+                    .get_field_type_at_index(index)
+                    .expect("variant field count changed")
+                    .const_zero()
+            })
+            .collect::<Vec<_>>();
+        fields[0] = context
+            .i32_type()
+            .const_int(construction.discriminant as u64, false)
+            .as_basic_value_enum();
+        fields[case_index as usize] = payload_ty
+            .const_named_struct(&payload_values)
+            .as_basic_value_enum();
+        return Ok(variant_ty.const_named_struct(&fields).as_basic_value_enum());
+    }
+
     match expr {
         Expression::Grouped(inner) => {
             return const_from_expected(
@@ -163,6 +264,7 @@ fn const_from_expected<'ctx>(
                 struct_types,
                 struct_field_indices,
                 const_env,
+                program,
             );
         }
 
@@ -268,6 +370,7 @@ fn const_from_expected<'ctx>(
                     struct_types,
                     struct_field_indices,
                     const_env,
+                    program,
                 ),
             }
         }
@@ -367,6 +470,7 @@ fn const_from_expected<'ctx>(
                         struct_types,
                         struct_field_indices,
                         const_env,
+                        program,
                     )?;
                     slots[i] = Some(cv);
                 }
@@ -400,6 +504,7 @@ fn const_from_expected<'ctx>(
                         struct_types,
                         struct_field_indices,
                         const_env,
+                        program,
                     )?;
                     slots[idx] = Some(cv);
                 }
@@ -438,6 +543,7 @@ fn const_from_expected<'ctx>(
                             struct_types,
                             struct_field_indices,
                             const_env,
+                            program,
                         )
                     })
                     .collect::<Result<_, _>>()?;
@@ -555,6 +661,7 @@ pub(super) fn create_llvm_const_value<'ctx>(
     struct_types: &HashMap<String, StructType<'ctx>>,
     struct_field_indices: &HashMap<String, HashMap<String, u32>>,
     const_env: &HashMap<String, BasicValueEnum<'ctx>>,
+    program: Option<&TypedProgram>,
 ) -> Result<BasicValueEnum<'ctx>, ConstEvalError> {
     if matches!(expr, Expression::Null) && !matches!(ty, WaveType::Pointer(_)) {
         return Err(ConstEvalError::TypeMismatch {
@@ -572,5 +679,6 @@ pub(super) fn create_llvm_const_value<'ctx>(
         struct_types,
         struct_field_indices,
         const_env,
+        program,
     )
 }

--- a/llvm/src/codegen/ir.rs
+++ b/llvm/src/codegen/ir.rs
@@ -44,6 +44,7 @@ use crate::statement::generate_statement_ir;
 
 use super::consts::{create_llvm_const_value, ConstEvalError};
 use super::types::{wave_type_to_llvm_type, TypeFlavor, VariableInfo};
+use super::variants::{declare_variant_types, define_variant_types};
 
 use crate::codegen::abi_c::{
     apply_extern_c_attrs, lower_extern_c, ExternCInfo, ParamLowering, RetLowering,
@@ -324,12 +325,19 @@ fn is_implicit_i32_main(name: &str, return_type: &Option<WaveType>) -> bool {
 }
 
 fn is_supported_extern_abi(abi: &str, target: CodegenTarget) -> bool {
-    abi.eq_ignore_ascii_case("c")
-        || (abi.eq_ignore_ascii_case("system")
-            && matches!(
-                target,
-                CodegenTarget::WindowsX86_64Gnu | CodegenTarget::WindowsArm64Gnu
-            ))
+    match target {
+        CodegenTarget::WindowsX86_64Gnu | CodegenTarget::WindowsArm64Gnu => {
+            abi.eq_ignore_ascii_case("c") || abi.eq_ignore_ascii_case("system")
+        }
+        _ => abi.eq_ignore_ascii_case("c"),
+    }
+}
+
+fn supported_extern_abi_description(target: CodegenTarget) -> &'static str {
+    match target {
+        CodegenTarget::WindowsX86_64Gnu | CodegenTarget::WindowsArm64Gnu => "'c' and 'system'",
+        _ => "'c'; Windows 'system' is accepted only on Windows GNU targets",
+    }
 }
 
 fn normalize_opt_flag_for_passes(opt_flag: &str) -> &str {
@@ -425,6 +433,11 @@ fn initialize_llvm_targets() {
         {
             Target::initialize_riscv(&config);
         }
+
+        #[cfg(all(not(feature = "llvm-target-all"), feature = "llvm-target-wasm"))]
+        {
+            Target::initialize_webassembly(&config);
+        }
     });
 }
 
@@ -474,6 +487,88 @@ fn apply_function_codegen_attrs<'ctx>(
         let attr = context.create_enum_attribute(no_unwind, 0);
         function.add_attribute(AttributeLoc::Function, attr);
     }
+}
+
+fn apply_wasm_import_attrs<'ctx>(
+    context: &'ctx Context,
+    function: FunctionValue<'ctx>,
+    target: CodegenTarget,
+    import_name: &str,
+) {
+    if import_name.starts_with("llvm.wasm.") {
+        return;
+    }
+    let module = match target {
+        CodegenTarget::Wasm32Unknown => "env",
+        CodegenTarget::Wasm32WasiP1 => "wasi_snapshot_preview1",
+        _ => return,
+    };
+    function.add_attribute(
+        AttributeLoc::Function,
+        context.create_string_attribute("wasm-import-module", module),
+    );
+    function.add_attribute(
+        AttributeLoc::Function,
+        context.create_string_attribute("wasm-import-name", import_name),
+    );
+}
+
+fn apply_wasm_export_attr<'ctx>(
+    context: &'ctx Context,
+    function: FunctionValue<'ctx>,
+    target: CodegenTarget,
+    export_name: &str,
+) {
+    if !matches!(
+        target,
+        CodegenTarget::Wasm32Unknown | CodegenTarget::Wasm32WasiP1
+    ) {
+        return;
+    }
+    function.add_attribute(
+        AttributeLoc::Function,
+        context.create_string_attribute("wasm-export-name", export_name),
+    );
+}
+
+fn build_wasi_start_wrapper<'ctx>(
+    context: &'ctx Context,
+    builder: &inkwell::builder::Builder<'ctx>,
+    module: &Module<'ctx>,
+    target: CodegenTarget,
+) {
+    if target != CodegenTarget::Wasm32WasiP1 {
+        return;
+    }
+    let Some(main) = module.get_function("main") else {
+        return;
+    };
+    if main.count_params() != 0
+        || main.get_type().get_return_type() != Some(context.i32_type().into())
+    {
+        panic!("wasm32-wasip1 requires 'main' to take no parameters and return i32 or omit its return type");
+    }
+    if module.get_function("_start").is_some() {
+        panic!("wasm32-wasip1 reserves '_start' for its command entry point");
+    }
+
+    let exit_type = context
+        .void_type()
+        .fn_type(&[context.i32_type().into()], false);
+    let proc_exit = module.add_function("__wasi_proc_exit", exit_type, None);
+    apply_wasm_import_attrs(context, proc_exit, target, "proc_exit");
+
+    let start = module.add_function("_start", context.void_type().fn_type(&[], false), None);
+    apply_wasm_export_attr(context, start, target, "_start");
+    let block = context.append_basic_block(start, "entry");
+    builder.position_at_end(block);
+    let call = builder.build_call(main, &[], "main_status").unwrap();
+    let status = match call.try_as_basic_value() {
+        ValueKind::Basic(value) => value.into_int_value(),
+        ValueKind::Instruction(_) => unreachable!("validated WASI main returned void"),
+    };
+    builder.build_call(proc_exit, &[status.into()], "").unwrap();
+    builder.build_unreachable().unwrap();
 }
 
 /// Builds an LLVM module and returns its textual representation.
@@ -618,6 +713,9 @@ fn build_module(
     // (1) struct opaque + field index map
     for ast in ast_nodes {
         if let ASTNode::Struct(struct_node) = ast {
+            if !struct_node.generic_params.is_empty() {
+                continue;
+            }
             let st = context.opaque_struct_type(&struct_node.name);
             struct_types.insert(struct_node.name.clone(), st);
 
@@ -632,8 +730,13 @@ fn build_module(
         }
     }
 
+    let variant_definitions = declare_variant_types(context, program, &mut struct_types);
+
     for ast in ast_nodes {
         if let ASTNode::Struct(struct_node) = ast {
+            if !struct_node.generic_params.is_empty() {
+                continue;
+            }
             let st = *struct_types
                 .get(&struct_node.name)
                 .unwrap_or_else(|| panic!("Opaque struct missing: {}", struct_node.name));
@@ -647,6 +750,8 @@ fn build_module(
             st.set_body(&field_types, false);
         }
     }
+
+    define_variant_types(context, &variant_definitions, &struct_types);
 
     for ast in ast_nodes {
         if let ASTNode::Enum(e) = ast {
@@ -682,6 +787,7 @@ fn build_module(
                 &struct_types,
                 &struct_field_indices,
                 &global_consts,
+                Some(program),
             ) {
                 Ok(val) => {
                     global_consts.insert(v.name.clone(), val);
@@ -730,6 +836,7 @@ fn build_module(
                 &struct_types,
                 &struct_field_indices,
                 &global_consts,
+                Some(program),
             )
             .unwrap_or_else(|e| panic!("static '{}' initialization failed: {}", v.name, e))
         } else {
@@ -794,8 +901,11 @@ fn build_module(
         if let Some(export) = export {
             if !is_supported_extern_abi(&export.abi, abi_target) {
                 panic!(
-                    "unsupported export ABI '{}' for function '{}' on {}: supported ABIs are 'c' and Windows 'system'",
-                    export.abi, name, abi_target.desc()
+                    "unsupported export ABI '{}' for function '{}' on {}: supported ABIs are {}",
+                    export.abi,
+                    name,
+                    abi_target.desc(),
+                    supported_extern_abi_description(abi_target)
                 );
             }
         }
@@ -864,6 +974,7 @@ fn build_module(
             let wrapper = module.add_function(&lowered.llvm_name, lowered.fn_type, None);
             apply_extern_c_attrs(context, wrapper, &lowered.info);
             apply_function_codegen_attrs(context, wrapper, disable_red_zone, cpu, features);
+            apply_wasm_export_attr(context, wrapper, abi_target, &lowered.llvm_name);
 
             let implementation_name = format!("__wave_export_impl_{}", symbol);
             let implementation =
@@ -889,8 +1000,11 @@ fn build_module(
     for ext in &extern_functions {
         if !is_supported_extern_abi(&ext.abi, abi_target) {
             panic!(
-                "unsupported extern ABI '{}' for function '{}' on {}: supported ABIs are 'c' and Windows 'system'",
-                ext.abi, ext.name, abi_target.desc()
+                "unsupported extern ABI '{}' for function '{}' on {}: supported ABIs are {}",
+                ext.abi,
+                ext.name,
+                abi_target.desc(),
+                supported_extern_abi_description(abi_target)
             );
         }
 
@@ -899,6 +1013,7 @@ fn build_module(
         let f = module.add_function(&lowered.llvm_name, lowered.fn_type, None);
         apply_extern_c_attrs(context, f, &lowered.info);
         apply_function_codegen_attrs(context, f, disable_red_zone, cpu, features);
+        apply_wasm_import_attrs(context, f, abi_target, &lowered.llvm_name);
 
         functions.insert(ext.name.clone(), f);
 
@@ -990,6 +1105,8 @@ fn build_module(
     for export in &export_wrappers {
         build_export_c_wrapper(context, builder, td, export);
     }
+
+    build_wasi_start_wrapper(context, builder, module, abi_target);
 
     if should_run_llvm_pass_pipeline() {
         let pbo = PassBuilderOptions::create();

--- a/llvm/src/codegen/mod.rs
+++ b/llvm/src/codegen/mod.rs
@@ -25,6 +25,7 @@ pub mod legacy;
 pub mod plan;
 pub mod target;
 pub mod types;
+pub mod variants;
 
 pub use address::{generate_address_and_type_ir, generate_address_ir};
 pub use format::{wave_format_to_c, wave_format_to_scanf};

--- a/llvm/src/codegen/plan.rs
+++ b/llvm/src/codegen/plan.rs
@@ -390,6 +390,16 @@ impl<'a> AsmPlan<'a> {
         user_clobbers_raw: &'a [String],
         mode: AsmSafetyMode,
     ) -> Self {
+        if matches!(
+            target,
+            CodegenTarget::Wasm32Unknown | CodegenTarget::Wasm32WasiP1
+        ) {
+            panic!(
+                "inline assembly is not supported for {}; use a WebAssembly host import instead",
+                target.desc()
+            );
+        }
+
         let asm_code = instructions.join("\n");
         let asm_code = gcc_percent_to_llvm_dollar(&asm_code);
         let stack_contract = stack_contract_from_user_clobbers(user_clobbers_raw);

--- a/llvm/src/codegen/target.rs
+++ b/llvm/src/codegen/target.rs
@@ -36,6 +36,8 @@ pub enum CodegenTarget {
     FreestandingX86_64,
     FreestandingArm64,
     FreestandingRISCV64,
+    Wasm32Unknown,
+    Wasm32WasiP1,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -469,6 +471,42 @@ const FREESTANDING_RISCV64: TargetSpec = TargetSpec {
     default_abi: Some(arch::riscv64::FREESTANDING_DEFAULT_ABI),
 };
 
+#[cfg(any(feature = "llvm-target-all", feature = "llvm-target-wasm"))]
+const WASM32_UNKNOWN_UNKNOWN: TargetSpec = TargetSpec {
+    triple: "wasm32-unknown-unknown",
+    codegen: CodegenTarget::Wasm32Unknown,
+    architecture: Architecture::Wasm32,
+    vendor: "unknown",
+    os: "unknown",
+    env: "",
+    object_format: "wasm",
+    hosted: false,
+    cpus: arch::wasm32::CPUS,
+    features: arch::wasm32::FEATURES,
+    abis: &[],
+    default_cpu: arch::wasm32::DEFAULT_CPU,
+    default_features: arch::wasm32::DEFAULT_FEATURES,
+    default_abi: None,
+};
+
+#[cfg(any(feature = "llvm-target-all", feature = "llvm-target-wasm"))]
+const WASM32_WASIP1: TargetSpec = TargetSpec {
+    triple: "wasm32-wasip1",
+    codegen: CodegenTarget::Wasm32WasiP1,
+    architecture: Architecture::Wasm32,
+    vendor: "unknown",
+    os: "wasi",
+    env: "p1",
+    object_format: "wasm",
+    hosted: true,
+    cpus: arch::wasm32::CPUS,
+    features: arch::wasm32::FEATURES,
+    abis: &[],
+    default_cpu: arch::wasm32::DEFAULT_CPU,
+    default_features: arch::wasm32::DEFAULT_FEATURES,
+    default_abi: None,
+};
+
 /// Returns the targets compiled into this backend, in deterministic order.
 pub fn supported_target_specs() -> Vec<&'static TargetSpec> {
     let mut specs: Vec<&'static TargetSpec> = Vec::new();
@@ -494,6 +532,9 @@ pub fn supported_target_specs() -> Vec<&'static TargetSpec> {
     #[cfg(any(feature = "llvm-target-all", feature = "llvm-target-riscv"))]
     specs.extend([&LINUX_RISCV64, &FREESTANDING_RISCV64]);
 
+    #[cfg(any(feature = "llvm-target-all", feature = "llvm-target-wasm"))]
+    specs.extend([&WASM32_UNKNOWN_UNKNOWN, &WASM32_WASIP1]);
+
     specs.sort_unstable_by_key(|spec| spec.triple);
     specs
 }
@@ -518,6 +559,7 @@ impl CodegenTarget {
             | Self::WindowsArm64Gnu
             | Self::FreestandingArm64 => Architecture::Aarch64,
             Self::LinuxRISCV64 | Self::FreestandingRISCV64 => Architecture::Riscv64,
+            Self::Wasm32Unknown | Self::Wasm32WasiP1 => Architecture::Wasm32,
         }
     }
 
@@ -548,6 +590,8 @@ impl CodegenTarget {
             Self::FreestandingArm64 => "freestanding arm64",
             Self::LinuxRISCV64 => "linux riscv64",
             Self::FreestandingRISCV64 => "freestanding riscv64",
+            Self::Wasm32Unknown => "webassembly wasm32 unknown",
+            Self::Wasm32WasiP1 => "webassembly wasm32 WASI Preview 1",
         }
     }
 }

--- a/llvm/src/codegen/types.rs
+++ b/llvm/src/codegen/types.rs
@@ -95,12 +95,10 @@ pub fn wave_type_to_llvm_type<'ctx>(
             .get(name)
             .unwrap_or_else(|| panic!("Struct type '{}' not found", name))
             .as_basic_type_enum(),
-        WaveType::Variant(name) => {
-            panic!(
-                "variant type '{}' reached LLVM before variant lowering",
-                name
-            )
-        }
+        WaveType::Variant(name) => struct_types
+            .get(name)
+            .unwrap_or_else(|| panic!("Variant type '{}' not found", name))
+            .as_basic_type_enum(),
     }
 }
 

--- a/llvm/src/codegen/variants.rs
+++ b/llvm/src/codegen/variants.rs
@@ -1,0 +1,352 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024–2026 Wave Foundation
+// Copyright (c) 2024–2026 LunaStev and contributors
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+
+//! Internal tagged-variant layout construction.
+//!
+//! Variants cannot cross the C ABI directly, so their representation is an
+//! internal compiler contract. Each value stores an `i32` discriminant followed
+//! by one naturally aligned payload tuple per case. Only the selected case is
+//! initialized by a constructor; the complete value is zeroed first so copying
+//! and inspecting nested patterns never reads uninitialized storage.
+
+use super::types::{wave_type_to_llvm_type, TypeFlavor};
+use inkwell::context::Context;
+use inkwell::types::{BasicType, BasicTypeEnum, StructType};
+use parser::ast::{ASTNode, StatementNode, VariantNode, WaveType};
+use parser::hir::{HirExpressionType, TypedProgram};
+use parser::types::{parse_type, split_top_level_generic_args, token_type_to_wave_type};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+#[derive(Debug)]
+pub(crate) struct VariantDefinition {
+    pub name: String,
+    pub cases: Vec<Vec<WaveType>>,
+}
+
+pub(crate) fn declare_variant_types<'ctx>(
+    context: &'ctx Context,
+    program: &TypedProgram,
+    struct_types: &mut HashMap<String, StructType<'ctx>>,
+) -> Vec<VariantDefinition> {
+    let templates = program
+        .syntax()
+        .iter()
+        .filter_map(|node| match node {
+            ASTNode::Variant(variant) => Some((variant.name.clone(), variant)),
+            _ => None,
+        })
+        .collect::<HashMap<_, _>>();
+
+    let mut names = BTreeSet::new();
+    collect_node_variant_types(program.syntax(), &mut names);
+    for expression_type in program.expression_types() {
+        if let HirExpressionType::Resolved(ty) = expression_type {
+            collect_type_variants(ty, &mut names);
+        }
+    }
+    for construction in program.variant_constructions() {
+        collect_type_variants(&construction.variant_type, &mut names);
+        for payload in &construction.payload_types {
+            collect_type_variants(payload, &mut names);
+        }
+    }
+    for pattern in program.variant_patterns() {
+        collect_type_variants(&pattern.variant_type, &mut names);
+        for payload in &pattern.payload_types {
+            collect_type_variants(payload, &mut names);
+        }
+    }
+    for variant in templates
+        .values()
+        .filter(|variant| variant.generic_params.is_empty())
+    {
+        names.insert(variant.name.clone());
+    }
+
+    let mut definitions = BTreeMap::<String, Vec<Vec<WaveType>>>::new();
+    while let Some(name) = names
+        .iter()
+        .find(|name| !definitions.contains_key(*name))
+        .cloned()
+    {
+        let cases = specialize_variant(&name, &templates);
+        for case in &cases {
+            for payload in case {
+                collect_type_variants(payload, &mut names);
+            }
+        }
+        definitions.insert(name, cases);
+    }
+
+    let definitions = definitions
+        .into_iter()
+        .map(|(name, cases)| {
+            let llvm_name = format!("variant.{name}");
+            let ty = context.opaque_struct_type(&llvm_name);
+            if struct_types.insert(name.clone(), ty).is_some() {
+                panic!(
+                    "variant type '{}' conflicts with another LLVM aggregate",
+                    name
+                );
+            }
+            VariantDefinition { name, cases }
+        })
+        .collect::<Vec<_>>();
+    definitions
+}
+
+pub(crate) fn define_variant_types<'ctx>(
+    context: &'ctx Context,
+    definitions: &[VariantDefinition],
+    struct_types: &HashMap<String, StructType<'ctx>>,
+) {
+    for definition in definitions {
+        let variant_ty = *struct_types
+            .get(&definition.name)
+            .unwrap_or_else(|| panic!("variant type '{}' was not declared", definition.name));
+        let mut fields = Vec::<BasicTypeEnum<'ctx>>::with_capacity(definition.cases.len() + 1);
+        fields.push(context.i32_type().as_basic_type_enum());
+        for payloads in &definition.cases {
+            let payload_types = payloads
+                .iter()
+                .map(|payload| {
+                    wave_type_to_llvm_type(context, payload, struct_types, TypeFlavor::AbiC)
+                })
+                .collect::<Vec<_>>();
+            fields.push(
+                context
+                    .struct_type(&payload_types, false)
+                    .as_basic_type_enum(),
+            );
+        }
+        variant_ty.set_body(&fields, false);
+    }
+}
+
+fn specialize_variant(
+    concrete_name: &str,
+    templates: &HashMap<String, &VariantNode>,
+) -> Vec<Vec<WaveType>> {
+    if let Some(concrete) = templates
+        .get(concrete_name)
+        .filter(|variant| variant.generic_params.is_empty())
+    {
+        return concrete
+            .cases
+            .iter()
+            .map(|case| case.payload_types.clone())
+            .collect();
+    }
+    let (base, arguments) = split_variant_application(concrete_name)
+        .unwrap_or_else(|| (concrete_name.to_string(), Vec::new()));
+    let template = templates
+        .get(&base)
+        .unwrap_or_else(|| panic!("variant template '{}' not found", base));
+    if template.generic_params.len() != arguments.len() {
+        panic!(
+            "variant '{}' expects {} type arguments, found {}",
+            base,
+            template.generic_params.len(),
+            arguments.len()
+        );
+    }
+    let substitutions = template
+        .generic_params
+        .iter()
+        .cloned()
+        .zip(arguments)
+        .collect::<HashMap<_, _>>();
+    template
+        .cases
+        .iter()
+        .map(|case| {
+            case.payload_types
+                .iter()
+                .map(|payload| resolve_payload_type(payload, &substitutions, templates))
+                .collect()
+        })
+        .collect()
+}
+
+fn resolve_payload_type(
+    ty: &WaveType,
+    substitutions: &HashMap<String, WaveType>,
+    templates: &HashMap<String, &VariantNode>,
+) -> WaveType {
+    match ty {
+        WaveType::Pointer(inner) => WaveType::Pointer(Box::new(resolve_payload_type(
+            inner,
+            substitutions,
+            templates,
+        ))),
+        WaveType::Array(inner, length) => WaveType::Array(
+            Box::new(resolve_payload_type(inner, substitutions, templates)),
+            *length,
+        ),
+        WaveType::Struct(name) | WaveType::Variant(name) => {
+            if let Some(substitution) = substitutions.get(name) {
+                return substitution.clone();
+            }
+            let Some((base, arguments)) = split_variant_application(name) else {
+                return if templates.contains_key(name) {
+                    WaveType::Variant(name.clone())
+                } else {
+                    WaveType::Struct(name.clone())
+                };
+            };
+            let arguments = arguments
+                .iter()
+                .map(|argument| resolve_payload_type(argument, substitutions, templates))
+                .collect::<Vec<_>>();
+            let concrete = format!(
+                "{}<{}>",
+                base,
+                arguments
+                    .iter()
+                    .map(display_wave_type)
+                    .collect::<Vec<_>>()
+                    .join(",")
+            );
+            if templates.contains_key(&base) {
+                WaveType::Variant(concrete)
+            } else {
+                WaveType::Struct(concrete)
+            }
+        }
+        _ => ty.clone(),
+    }
+}
+
+fn split_variant_application(name: &str) -> Option<(String, Vec<WaveType>)> {
+    let (base, tail) = name.split_once('<')?;
+    let inner = tail.strip_suffix('>')?;
+    let arguments = split_top_level_generic_args(inner)?
+        .into_iter()
+        .map(|argument| token_type_to_wave_type(&parse_type(&argument)?))
+        .collect::<Option<Vec<_>>>()?;
+    Some((base.trim().to_string(), arguments))
+}
+
+fn display_wave_type(ty: &WaveType) -> String {
+    match ty {
+        WaveType::Int(bits) => format!("i{bits}"),
+        WaveType::Uint(bits) => format!("u{bits}"),
+        WaveType::Float(bits) => format!("f{bits}"),
+        WaveType::Bool => "bool".to_string(),
+        WaveType::Char => "char".to_string(),
+        WaveType::Byte => "byte".to_string(),
+        WaveType::String => "str".to_string(),
+        WaveType::Pointer(inner) => format!("ptr<{}>", display_wave_type(inner)),
+        WaveType::Array(inner, length) => format!("array<{},{}>", display_wave_type(inner), length),
+        WaveType::Void => "void".to_string(),
+        WaveType::Struct(name) | WaveType::Variant(name) => name.clone(),
+    }
+}
+
+fn collect_type_variants(ty: &WaveType, names: &mut BTreeSet<String>) {
+    match ty {
+        WaveType::Variant(name) => {
+            names.insert(name.clone());
+        }
+        WaveType::Pointer(inner) | WaveType::Array(inner, _) => collect_type_variants(inner, names),
+        _ => {}
+    }
+}
+
+fn collect_node_variant_types(nodes: &[ASTNode], names: &mut BTreeSet<String>) {
+    for node in nodes {
+        match node {
+            ASTNode::Function(function) => {
+                for parameter in &function.parameters {
+                    collect_type_variants(&parameter.param_type, names);
+                }
+                if let Some(return_type) = &function.return_type {
+                    collect_type_variants(return_type, names);
+                }
+                collect_node_variant_types(&function.body, names);
+            }
+            ASTNode::ExternFunction(function) => {
+                for (_, ty) in &function.params {
+                    collect_type_variants(ty, names);
+                }
+                collect_type_variants(&function.return_type, names);
+            }
+            ASTNode::Program(parameter) => collect_type_variants(&parameter.param_type, names),
+            ASTNode::Variable(variable) => collect_type_variants(&variable.type_name, names),
+            ASTNode::Statement(statement) => collect_statement_variant_types(statement, names),
+            ASTNode::Struct(structure) => {
+                for (_, ty) in &structure.fields {
+                    collect_type_variants(ty, names);
+                }
+                for method in &structure.methods {
+                    if let Some(return_type) = &method.return_type {
+                        collect_type_variants(return_type, names);
+                    }
+                    for parameter in &method.parameters {
+                        collect_type_variants(&parameter.param_type, names);
+                    }
+                    collect_node_variant_types(&method.body, names);
+                }
+            }
+            ASTNode::ProtoImpl(implementation) => {
+                for method in &implementation.methods {
+                    if let Some(return_type) = &method.return_type {
+                        collect_type_variants(return_type, names);
+                    }
+                    for parameter in &method.parameters {
+                        collect_type_variants(&parameter.param_type, names);
+                    }
+                    collect_node_variant_types(&method.body, names);
+                }
+            }
+            ASTNode::TypeAlias(alias) => collect_type_variants(&alias.target, names),
+            ASTNode::Enum(enumeration) => collect_type_variants(&enumeration.repr_type, names),
+            ASTNode::Variant(_) | ASTNode::Expression(_) => {}
+        }
+    }
+}
+
+fn collect_statement_variant_types(statement: &StatementNode, names: &mut BTreeSet<String>) {
+    match statement {
+        StatementNode::If {
+            body,
+            else_if_blocks,
+            else_block,
+            ..
+        } => {
+            collect_node_variant_types(body, names);
+            if let Some(blocks) = else_if_blocks {
+                for (_, body) in blocks.iter() {
+                    collect_node_variant_types(body, names);
+                }
+            }
+            if let Some(body) = else_block {
+                collect_node_variant_types(body, names);
+            }
+        }
+        StatementNode::While { body, .. } => collect_node_variant_types(body, names),
+        StatementNode::For {
+            initialization,
+            body,
+            ..
+        } => {
+            collect_node_variant_types(std::slice::from_ref(initialization.as_ref()), names);
+            collect_node_variant_types(body, names);
+        }
+        StatementNode::Match { arms, .. } => {
+            for arm in arms {
+                collect_node_variant_types(&arm.body, names);
+            }
+        }
+        _ => {}
+    }
+}

--- a/llvm/src/expression/rvalue/dispatch.rs
+++ b/llvm/src/expression/rvalue/dispatch.rs
@@ -29,7 +29,13 @@ pub(crate) fn gen_expr<'ctx, 'a>(
     match expr {
         Expression::Literal(lit) => literals::gen(env, lit, expected_type),
         Expression::Null => literals::gen_null(env, expected_type),
-        Expression::Variable(name) => variables::gen(env, name, expected_type),
+        Expression::Variable(name) => {
+            if env.program.variant_construction_of(expr).is_some() {
+                variants::gen_constructor(env, expr, &[])
+            } else {
+                variables::gen(env, name, expected_type)
+            }
+        }
 
         Expression::Deref(inner) => pointers::gen_deref(env, inner, expected_type),
         Expression::AddressOf(inner) => pointers::gen_addressof(env, inner, expected_type),
@@ -41,7 +47,13 @@ pub(crate) fn gen_expr<'ctx, 'a>(
             name,
             type_args,
             args,
-        } => calls::gen_function_call(env, name, type_args, args, expected_type),
+        } => {
+            if env.program.variant_construction_of(expr).is_some() {
+                variants::gen_constructor(env, expr, args)
+            } else {
+                calls::gen_function_call(env, name, type_args, args, expected_type)
+            }
+        }
         Expression::Cast { expr, target_type } => cast::gen(env, expr, target_type),
 
         Expression::AssignOperation {

--- a/llvm/src/expression/rvalue/mod.rs
+++ b/llvm/src/expression/rvalue/mod.rs
@@ -12,7 +12,7 @@
 
 //! Shared environment and entry point for expression value lowering.
 //!
-//! [`ExprGenEnv`] carries the LLVM construction state plus Wave semantic tables.
+//! `ExprGenEnv` carries the LLVM construction state plus Wave semantic tables.
 //! An optional expected type flows downward to resolve literals, null pointers,
 //! aggregates, and ABI-sensitive coercions without reconstructing types from AST
 //! shape.
@@ -45,6 +45,7 @@ pub mod pointers;
 pub mod structs;
 pub mod unary;
 pub mod variables;
+pub mod variants;
 
 pub struct ProtoInfo<'ctx> {
     pub vtable_ty: StructType<'ctx>,

--- a/llvm/src/expression/rvalue/variants.rs
+++ b/llvm/src/expression/rvalue/variants.rs
@@ -1,0 +1,127 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024–2026 Wave Foundation
+// Copyright (c) 2024–2026 LunaStev and contributors
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+
+//! Construction of typed variant values from frontend-resolved case metadata.
+
+use super::ExprGenEnv;
+use crate::codegen::types::{wave_type_to_llvm_type, TypeFlavor};
+use crate::statement::variable::{coerce_basic_value, wave_type_is_unsigned, CoercionMode};
+use inkwell::types::BasicType;
+use inkwell::values::{BasicValue, BasicValueEnum};
+use parser::ast::{Expression, WaveType};
+
+pub(crate) fn gen_constructor<'ctx, 'a>(
+    env: &mut ExprGenEnv<'ctx, 'a>,
+    expression: &Expression,
+    args: &[Expression],
+) -> BasicValueEnum<'ctx> {
+    let construction = env
+        .program
+        .variant_construction_of(expression)
+        .cloned()
+        .expect("variant constructor reached LLVM without typed HIR metadata");
+    let WaveType::Variant(name) = &construction.variant_type else {
+        panic!("variant constructor metadata has a non-variant type");
+    };
+    let variant_ty = *env
+        .struct_types
+        .get(name)
+        .unwrap_or_else(|| panic!("variant type '{}' not found", name));
+    let value_ptr = env
+        .builder
+        .build_alloca(variant_ty, &format!("variant.{}.value", name))
+        .unwrap();
+    env.builder
+        .build_store(value_ptr, variant_ty.const_zero())
+        .unwrap();
+
+    let tag_ptr = env
+        .builder
+        .build_struct_gep(variant_ty, value_ptr, 0, "variant.tag.ptr")
+        .unwrap();
+    env.builder
+        .build_store(
+            tag_ptr,
+            env.context
+                .i32_type()
+                .const_int(construction.discriminant as u64, false),
+        )
+        .unwrap();
+
+    let case_index = construction.discriminant + 1;
+    let payload_ty = variant_ty
+        .get_field_type_at_index(case_index)
+        .unwrap_or_else(|| {
+            panic!(
+                "variant '{}' has no payload slot for case '{}'",
+                name, construction.case_name
+            )
+        })
+        .into_struct_type();
+    if args.len() != construction.payload_types.len() {
+        panic!(
+            "variant constructor '{}::{}' payload count changed after semantic validation",
+            name, construction.case_name
+        );
+    }
+    let payload_ptr = env
+        .builder
+        .build_alloca(payload_ty, "variant.payload.value")
+        .unwrap();
+    env.builder
+        .build_store(payload_ptr, payload_ty.const_zero())
+        .unwrap();
+
+    for (index, (argument, payload_wave_type)) in
+        args.iter().zip(&construction.payload_types).enumerate()
+    {
+        let expected = wave_type_to_llvm_type(
+            env.context,
+            payload_wave_type,
+            env.struct_types,
+            TypeFlavor::AbiC,
+        );
+        let raw = env.gen(argument, Some(expected));
+        let value = coerce_basic_value(
+            env.context,
+            env.builder,
+            raw,
+            expected,
+            &format!("variant.payload.{}.cast", index),
+            CoercionMode::Implicit,
+            wave_type_is_unsigned(env.wave_type(argument).as_ref()),
+        );
+        let field_ptr = env
+            .builder
+            .build_struct_gep(payload_ty, payload_ptr, index as u32, "variant.payload.ptr")
+            .unwrap();
+        env.builder.build_store(field_ptr, value).unwrap();
+    }
+
+    let payload = env
+        .builder
+        .build_load(
+            payload_ty.as_basic_type_enum(),
+            payload_ptr,
+            "variant.payload",
+        )
+        .unwrap();
+    let case_ptr = env
+        .builder
+        .build_struct_gep(variant_ty, value_ptr, case_index, "variant.case.ptr")
+        .unwrap();
+    env.builder.build_store(case_ptr, payload).unwrap();
+    env.builder
+        .build_load(variant_ty.as_basic_type_enum(), value_ptr, "variant.value")
+        .unwrap()
+        .as_basic_value_enum()
+}

--- a/llvm/src/statement/control.rs
+++ b/llvm/src/statement/control.rs
@@ -25,11 +25,13 @@ use inkwell::basic_block::BasicBlock;
 use inkwell::module::Module;
 use inkwell::targets::TargetData;
 use inkwell::types::StringRadix;
-use inkwell::types::StructType;
-use inkwell::values::{AnyValue, BasicValueEnum, FunctionValue};
+use inkwell::types::{BasicType, StructType};
+use inkwell::values::{AnyValue, BasicValueEnum, FunctionValue, IntValue, PointerValue};
 use inkwell::{FloatPredicate, IntPredicate};
-use parser::ast::{ASTNode, Expression, Literal, MatchArm, MatchPattern, StatementNode, WaveType};
-use parser::hir::TypedProgram;
+use parser::ast::{
+    ASTNode, Expression, Literal, MatchArm, MatchPattern, Mutability, StatementNode, WaveType,
+};
+use parser::hir::{HirExpressionType, TypedProgram};
 use std::collections::{HashMap, HashSet};
 
 fn truthy_to_i1<'ctx>(
@@ -173,6 +175,237 @@ fn eval_match_case_const<'ctx>(
         MatchPattern::Binding(_) | MatchPattern::Variant { .. } => {
             panic!("variant pattern reached LLVM before variant lowering");
         }
+    }
+}
+
+struct VariantBinding<'ctx> {
+    name: String,
+    ptr: PointerValue<'ctx>,
+    ty: WaveType,
+}
+
+fn gen_variant_pattern_test<'ctx>(
+    context: &'ctx inkwell::context::Context,
+    builder: &'ctx inkwell::builder::Builder<'ctx>,
+    program: &TypedProgram,
+    pattern: &MatchPattern,
+    value_ptr: PointerValue<'ctx>,
+    value_type: &WaveType,
+    struct_types: &HashMap<String, StructType<'ctx>>,
+) -> (IntValue<'ctx>, Vec<VariantBinding<'ctx>>) {
+    match pattern {
+        MatchPattern::Wildcard => (context.bool_type().const_int(1, false), Vec::new()),
+        MatchPattern::Binding(name) => (
+            context.bool_type().const_int(1, false),
+            vec![VariantBinding {
+                name: name.clone(),
+                ptr: value_ptr,
+                ty: value_type.clone(),
+            }],
+        ),
+        MatchPattern::Variant { payloads, .. } => {
+            let metadata = program.variant_pattern_of(pattern).unwrap_or_else(|| {
+                panic!("variant pattern reached LLVM without typed HIR metadata")
+            });
+            let WaveType::Variant(name) = &metadata.variant_type else {
+                panic!("variant pattern metadata has a non-variant type");
+            };
+            let variant_ty = *struct_types
+                .get(name)
+                .unwrap_or_else(|| panic!("variant type '{}' not found", name));
+            let tag_ptr = builder
+                .build_struct_gep(variant_ty, value_ptr, 0, "variant.match.tag.ptr")
+                .unwrap();
+            let tag = builder
+                .build_load(
+                    context.i32_type().as_basic_type_enum(),
+                    tag_ptr,
+                    "variant.match.tag",
+                )
+                .unwrap()
+                .into_int_value();
+            let expected_tag = context
+                .i32_type()
+                .const_int(metadata.discriminant as u64, false);
+            let mut condition = builder
+                .build_int_compare(IntPredicate::EQ, tag, expected_tag, "variant.match.case")
+                .unwrap();
+            let case_index = metadata.discriminant + 1;
+            let payload_ty = variant_ty
+                .get_field_type_at_index(case_index)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "variant '{}' has no payload slot for case '{}'",
+                        name, metadata.case_name
+                    )
+                })
+                .into_struct_type();
+            let payload_ptr = builder
+                .build_struct_gep(
+                    variant_ty,
+                    value_ptr,
+                    case_index,
+                    "variant.match.payload.ptr",
+                )
+                .unwrap();
+            let mut bindings = Vec::new();
+            for (index, (payload_pattern, payload_wave_type)) in
+                payloads.iter().zip(&metadata.payload_types).enumerate()
+            {
+                let field_ptr = builder
+                    .build_struct_gep(
+                        payload_ty,
+                        payload_ptr,
+                        index as u32,
+                        "variant.match.field.ptr",
+                    )
+                    .unwrap();
+                let (nested_condition, mut nested_bindings) = gen_variant_pattern_test(
+                    context,
+                    builder,
+                    program,
+                    payload_pattern,
+                    field_ptr,
+                    payload_wave_type,
+                    struct_types,
+                );
+                condition = builder
+                    .build_and(condition, nested_condition, "variant.match.and")
+                    .unwrap();
+                bindings.append(&mut nested_bindings);
+            }
+            (condition, bindings)
+        }
+        MatchPattern::Int(_) | MatchPattern::Ident(_) => {
+            panic!("integer pattern reached variant LLVM lowering")
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn gen_variant_match_ir<'ctx>(
+    context: &'ctx inkwell::context::Context,
+    builder: &'ctx inkwell::builder::Builder<'ctx>,
+    module: &'ctx Module<'ctx>,
+    string_counter: &mut usize,
+    value: &Expression,
+    value_type: &WaveType,
+    arms: &[MatchArm],
+    variables: &mut HashMap<String, VariableInfo<'ctx>>,
+    loop_exit_stack: &mut Vec<BasicBlock<'ctx>>,
+    loop_continue_stack: &mut Vec<BasicBlock<'ctx>>,
+    current_function: FunctionValue<'ctx>,
+    global_consts: &HashMap<String, BasicValueEnum<'ctx>>,
+    struct_types: &HashMap<String, StructType<'ctx>>,
+    struct_field_indices: &HashMap<String, HashMap<String, u32>>,
+    struct_field_types: &HashMap<String, HashMap<String, WaveType>>,
+    target_data: &'ctx TargetData,
+    extern_c_info: &HashMap<String, ExternCInfo<'ctx>>,
+    program: &TypedProgram,
+) {
+    let WaveType::Variant(name) = value_type else {
+        panic!("variant match lowering received a non-variant value type");
+    };
+    let variant_ty = *struct_types
+        .get(name)
+        .unwrap_or_else(|| panic!("variant type '{}' not found", name));
+    let value = generate_expression_ir(
+        program,
+        context,
+        builder,
+        value,
+        variables,
+        module,
+        Some(variant_ty.as_basic_type_enum()),
+        global_consts,
+        struct_types,
+        struct_field_indices,
+        target_data,
+        extern_c_info,
+    );
+    let value_ptr = builder
+        .build_alloca(variant_ty, "variant.match.value")
+        .unwrap();
+    builder.build_store(value_ptr, value).unwrap();
+
+    let current_fn = builder.get_insert_block().unwrap().get_parent().unwrap();
+    let merge_block = context.append_basic_block(current_fn, "variant.match.end");
+    let fail_block = context.append_basic_block(current_fn, "variant.match.unreachable");
+    let test_blocks = (0..arms.len())
+        .map(|index| context.append_basic_block(current_fn, &format!("variant.match.test.{index}")))
+        .collect::<Vec<_>>();
+    if let Some(first) = test_blocks.first() {
+        builder.build_unconditional_branch(*first).unwrap();
+    } else {
+        builder.build_unconditional_branch(fail_block).unwrap();
+    }
+
+    let outer_variables = variables.clone();
+    let mut all_arms_terminate = true;
+    for (index, arm) in arms.iter().enumerate() {
+        builder.position_at_end(test_blocks[index]);
+        let (condition, bindings) = gen_variant_pattern_test(
+            context,
+            builder,
+            program,
+            &arm.pattern,
+            value_ptr,
+            value_type,
+            struct_types,
+        );
+        let body_block =
+            context.append_basic_block(current_fn, &format!("variant.match.arm.{index}"));
+        let next_block = test_blocks.get(index + 1).copied().unwrap_or(fail_block);
+        builder
+            .build_conditional_branch(condition, body_block, next_block)
+            .unwrap();
+
+        builder.position_at_end(body_block);
+        *variables = outer_variables.clone();
+        for binding in bindings {
+            variables.insert(
+                binding.name,
+                VariableInfo {
+                    ptr: binding.ptr,
+                    mutability: Mutability::Var,
+                    ty: binding.ty,
+                },
+            );
+        }
+        for statement in &arm.body {
+            super::generate_statement_ir(
+                context,
+                builder,
+                module,
+                string_counter,
+                statement,
+                variables,
+                loop_exit_stack,
+                loop_continue_stack,
+                current_function,
+                global_consts,
+                struct_types,
+                struct_field_indices,
+                struct_field_types,
+                target_data,
+                extern_c_info,
+                program,
+            );
+        }
+        if builder
+            .get_insert_block()
+            .is_some_and(|block| block.get_terminator().is_none())
+        {
+            all_arms_terminate = false;
+            builder.build_unconditional_branch(merge_block).unwrap();
+        }
+    }
+    *variables = outer_variables;
+    builder.position_at_end(fail_block);
+    builder.build_unreachable().unwrap();
+    builder.position_at_end(merge_block);
+    if all_arms_terminate {
+        builder.build_unreachable().unwrap();
     }
 }
 
@@ -495,6 +728,32 @@ pub(super) fn gen_match_ir<'ctx>(
     extern_c_info: &HashMap<String, ExternCInfo<'ctx>>,
     program: &TypedProgram,
 ) {
+    if let Some(HirExpressionType::Resolved(value_type @ WaveType::Variant(_))) =
+        program.type_of(value)
+    {
+        gen_variant_match_ir(
+            context,
+            builder,
+            module,
+            string_counter,
+            value,
+            value_type,
+            arms,
+            variables,
+            loop_exit_stack,
+            loop_continue_stack,
+            current_function,
+            global_consts,
+            struct_types,
+            struct_field_indices,
+            struct_field_types,
+            target_data,
+            extern_c_info,
+            program,
+        );
+        return;
+    }
+
     let current_fn = builder.get_insert_block().unwrap().get_parent().unwrap();
 
     let discr_any = generate_expression_ir(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -351,18 +351,15 @@ fn dispatch_build(global: &Global, build: &BuildRequest) -> Result<(), CliError>
         link_objects(&effective_global, &build, &plan.link_inputs, link_output)?;
 
         if build.run {
-            let status = ProcessCommand::new(link_output)
-                .args(&build.run_args)
+            let (program, args) = build_execute_command(&effective_global, &build, link_output);
+            let status = ProcessCommand::new(&program)
+                .args(&args)
                 .stdin(Stdio::inherit())
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())
                 .status()
                 .map_err(|e| {
-                    CliError::CommandFailed(format!(
-                        "failed to run `{}`: {}",
-                        link_output.display(),
-                        e
-                    ))
+                    CliError::CommandFailed(format!("failed to run `{}`: {}", program, e))
                 })?;
 
             if !status.success() {
@@ -1560,6 +1557,27 @@ fn validate_build_request(
     build: &BuildRequest,
     classified: &[ClassifiedInput],
 ) -> Result<(), CliError> {
+    let target = target_triple_for_global(global);
+    if is_wasm_target(&target) {
+        if build.run
+            && !build.run_args.is_empty()
+            && matches!(
+                target_spec_for_triple(&target).map(|spec| spec.codegen),
+                Some(CodegenTarget::Wasm32Unknown)
+            )
+        {
+            return Err(CliError::usage(
+                "run-time arguments require wasm32-wasip1; wasm32-unknown-unknown has no process argument ABI",
+            ));
+        }
+        if build.shared || build.static_link || build.pie.is_some() || build.linker_script.is_some()
+        {
+            return Err(CliError::usage(
+                "--shared, --static, --pie/--no-pie, and --linker-script are not supported for WebAssembly targets",
+            ));
+        }
+    }
+
     if build.shared && build.static_link {
         return Err(CliError::usage("cannot combine --shared and --static"));
     }
@@ -1830,6 +1848,8 @@ fn resolve_binary_output_path(
         .unwrap_or("a.out");
     let stem = if is_windows_gnu_target_global(global) {
         format!("{}.exe", stem)
+    } else if global.llvm.target.as_deref().is_some_and(is_wasm_target) {
+        format!("{}.wasm", stem)
     } else {
         stem.to_string()
     };
@@ -2338,12 +2358,103 @@ fn build_linker_args(
     }
 
     let target = target_triple_for_global(global);
-    if is_darwin_target(&target) {
+    if is_wasm_target(&target) {
+        build_wasm_lld_args(global, build, objects, output)
+    } else if is_darwin_target(&target) {
         build_darwin_lld_args(global, build, objects, output, &target)
     } else if is_windows_gnu_target(&target) {
         build_windows_gnu_linker_args(global, build, objects, output, &target)
     } else {
         build_elf_lld_args(global, build, objects, output, &target)
+    }
+}
+
+fn build_wasm_lld_args(
+    global: &Global,
+    build: &BuildRequest,
+    objects: &[String],
+    output: &Path,
+) -> (String, Vec<String>) {
+    let mut args = Vec::new();
+    for object in objects {
+        args.push(object.clone());
+    }
+    append_link_search_and_libs(&mut args, global);
+    append_lld_link_args(&mut args, &global.llvm.link_args);
+
+    if let Some(entry) = &build.entry {
+        args.push(format!("--entry={entry}"));
+    } else {
+        args.push("--no-entry".to_string());
+    }
+    args.push("--allow-undefined".to_string());
+    args.push("--export-if-defined=main".to_string());
+    args.push("--export-memory".to_string());
+    args.push("-o".to_string());
+    args.push(output.to_string_lossy().to_string());
+
+    (resolve_bundled_tool("wasm-ld"), args)
+}
+
+const WASM_UNKNOWN_RUNNER: &str = r#"
+import { readFile } from "node:fs/promises";
+const modulePath = process.argv[1];
+const bytes = await readFile(modulePath);
+const { instance } = await WebAssembly.instantiate(bytes, { env: {} });
+if (typeof instance.exports.main !== "function") {
+  throw new Error("WebAssembly module does not export main");
+}
+const status = instance.exports.main();
+if (Number.isInteger(status) && status !== 0) process.exit(status);
+"#;
+
+const WASI_RUNNER: &str = r#"
+import { readFile } from "node:fs/promises";
+import { WASI } from "node:wasi";
+const modulePath = process.argv[1];
+const args = process.argv.slice(1);
+const wasi = new WASI({
+  version: "preview1",
+  args,
+  env: process.env,
+  preopens: { ".": process.cwd() },
+});
+const module = await WebAssembly.compile(await readFile(modulePath));
+const instance = await WebAssembly.instantiate(module, wasi.getImportObject());
+wasi.start(instance);
+"#;
+
+fn build_execute_command(
+    global: &Global,
+    build: &BuildRequest,
+    output: &Path,
+) -> (String, Vec<String>) {
+    let target = target_triple_for_global(global);
+    let codegen = target_spec_for_triple(&target).map(|spec| spec.codegen);
+    match codegen {
+        Some(CodegenTarget::Wasm32Unknown) => {
+            let mut args = vec![
+                "--no-warnings".to_string(),
+                "--input-type=module".to_string(),
+                "--eval".to_string(),
+                WASM_UNKNOWN_RUNNER.to_string(),
+                output.to_string_lossy().to_string(),
+            ];
+            args.extend(build.run_args.iter().cloned());
+            ("node".to_string(), args)
+        }
+        Some(CodegenTarget::Wasm32WasiP1) => {
+            let mut args = vec![
+                "--no-warnings".to_string(),
+                "--input-type=module".to_string(),
+                "--eval".to_string(),
+                WASI_RUNNER.to_string(),
+                output.to_string_lossy().to_string(),
+            ];
+            args.extend(build.run_args.iter().cloned());
+            ("node".to_string(), args)
+        }
+        _ => (output.to_string_lossy().to_string(), build.run_args.clone()),
     }
 }
 
@@ -2366,7 +2477,10 @@ fn build_user_linker_args(
     args.push("-o".to_string());
     args.push(output.to_string_lossy().to_string());
 
-    if !global.llvm.no_default_libs && !is_windows_gnu_target_global(global) {
+    if !global.llvm.no_default_libs
+        && !is_windows_gnu_target_global(global)
+        && !is_wasm_target(&target_triple_for_global(global))
+    {
         args.push("-lc".to_string());
         args.push("-lm".to_string());
     }
@@ -2675,6 +2789,10 @@ fn is_darwin_target(target: &str) -> bool {
 
 fn is_linux_target(target: &str) -> bool {
     target_spec_for_triple(target).is_some_and(|spec| spec.os == "linux")
+}
+
+fn is_wasm_target(target: &str) -> bool {
+    target_spec_for_triple(target).is_some_and(|spec| spec.object_format == "wasm")
 }
 
 fn is_freebsd_target(target: &str) -> bool {
@@ -3140,7 +3258,9 @@ fn default_linker_name(global: &Global) -> String {
     }
 
     let target = target_triple_for_global(global);
-    if is_darwin_target(&target) {
+    if is_wasm_target(&target) {
+        resolve_bundled_tool("wasm-ld")
+    } else if is_darwin_target(&target) {
         resolve_bundled_tool("ld64.lld")
     } else if is_windows_gnu_target(&target) {
         resolve_bundled_tool_path("ld.lld")
@@ -3335,11 +3455,9 @@ fn print_dry_run_human(
 
     if build.run {
         if let Some(link_output) = &plan.link_output {
+            let (program, args) = build_execute_command(global, build, link_output);
             println!("  run:");
-            println!(
-                "    - {}",
-                shell_join(&link_output.to_string_lossy(), &build.run_args)
-            );
+            println!("    - {}", shell_join(&program, &args));
         }
     }
 }
@@ -3579,17 +3697,17 @@ fn print_dry_run_json(
     text.push_str("\"execute\":");
     if build.run {
         if let Some(link_output) = &plan.link_output {
-            let program = link_output.to_string_lossy().to_string();
+            let (program, args) = build_execute_command(global, build, link_output);
             text.push('{');
             append_json_field(&mut text, "program", &json_string(&program));
             text.push(',');
             text.push_str("\"args\":");
-            text.push_str(&json_owned_string_array(&build.run_args));
+            text.push_str(&json_owned_string_array(&args));
             text.push(',');
             append_json_field(
                 &mut text,
                 "command",
-                &json_string(&shell_join(&program, &build.run_args)),
+                &json_string(&shell_join(&program, &args)),
             );
             text.push('}');
         } else {

--- a/std/README.md
+++ b/std/README.md
@@ -20,6 +20,10 @@ licensed under the repository's [Mozilla Public License 2.0](../LICENSE).
 - Target providers under `std/sys/*` may use the small set of hosted C ABI
   bindings explicitly approved by `tools/check_std_policy.sh` when the OS does
   not expose an equivalent stable raw syscall contract.
+- `std/sys/wasm/*` maps its raw imports to WASI Preview 1 capabilities. The
+  provider covers descriptor I/O, clocks and sleep, preopened paths,
+  environment access, process exit, and linear-memory allocation. The allocator
+  is also available to browser-hosted `wasm32-unknown-unknown` modules.
 - Modules outside `std/libc/*` must not import `std::libc::*`; portable modules
   depend on the target-independent `std::sys::*` provider surface instead.
 

--- a/std/net/address.wave
+++ b/std/net/address.wave
@@ -31,8 +31,8 @@ pub struct SocketAddrV6 {
     scope_id: u32;
 }
 
-// A backend-neutral address container usable until payload variants are
-// available in every backend. IPv4 uses the first four octets.
+// A fixed-layout backend-neutral address used by native socket translation.
+// IPv4 uses the first four octets; family selects the active representation.
 pub struct IpAddr {
     family: i32;
     octets: array<u8, 16>;

--- a/std/sys/env.wave
+++ b/std/sys/env.wave
@@ -35,3 +35,6 @@ pub import("std::sys::windows::env")::{env_read};
 
 #[target(os="freebsd")]
 pub import("std::sys::freebsd::env")::{env_read};
+
+#[target(os="wasi")]
+pub import("std::sys::wasm::env")::{env_read};

--- a/std/sys/fs.wave
+++ b/std/sys/fs.wave
@@ -120,3 +120,13 @@ pub import("std::sys::freebsd::fs")::{
     open, close, dup, dup2, pipe, fsync, fcntl, read, write, getcwd,
     chdir, access, lseek, unlink, mkdir, rmdir, rename_path, Stat, stat, fstat,
 };
+
+#[target(os="wasi")]
+pub import("std::sys::wasm::fs")::{
+    FS_O_RDONLY, FS_O_WRONLY, FS_O_RDWR, FS_O_CREAT, FS_O_EXCL,
+    FS_O_TRUNC, FS_O_APPEND, FS_O_NONBLOCK,
+    FS_F_OK, FS_X_OK, FS_W_OK, FS_R_OK,
+    FS_SEEK_SET, FS_SEEK_CUR, FS_SEEK_END, FS_F_GETFL, FS_F_SETFL,
+    open, close, dup, dup2, pipe, fsync, fcntl, read, write, getcwd,
+    chdir, access, lseek, unlink, mkdir, rmdir, rename_path, Stat, stat, fstat,
+};

--- a/std/sys/memory.wave
+++ b/std/sys/memory.wave
@@ -58,3 +58,15 @@ pub import("std::sys::freebsd::memory")::{
     PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS,
     mmap, munmap, brk, sys_alloc, sys_free, sys_page_size,
 };
+
+#[target(os="wasi")]
+pub import("std::sys::wasm::memory")::{
+    PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS,
+    mmap, munmap, brk, sys_alloc, sys_free, sys_page_size,
+};
+
+#[target(arch="wasm32", os="unknown")]
+pub import("std::sys::wasm::memory")::{
+    PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS,
+    mmap, munmap, brk, sys_alloc, sys_free, sys_page_size,
+};

--- a/std/sys/process.wave
+++ b/std/sys/process.wave
@@ -50,3 +50,8 @@ pub import("std::sys::windows::process")::{
 pub import("std::sys::freebsd::process")::{
     exit, getpid, getppid, fork, execve, waitpid, kill,
 };
+
+#[target(os="wasi")]
+pub import("std::sys::wasm::process")::{
+    exit, getpid, getppid, fork, execve, waitpid, kill,
+};

--- a/std/sys/time.wave
+++ b/std/sys/time.wave
@@ -38,3 +38,6 @@ pub import("std::sys::windows::time")::{TimeSpec, nanosleep, clock_gettime};
 
 #[target(os="freebsd")]
 pub import("std::sys::freebsd::time")::{TimeSpec, nanosleep, clock_gettime};
+
+#[target(os="wasi")]
+pub import("std::sys::wasm::time")::{TimeSpec, nanosleep, clock_gettime};

--- a/std/sys/wasm/env.wave
+++ b/std/sys/wasm/env.wave
@@ -1,0 +1,27 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Copies the WASI environment into the same NUL-separated byte format used by
+// the other std::sys providers.
+
+extern(c, "environ_sizes_get") fun wasi_environ_sizes_get(
+    count: ptr<u32>, byte_count: ptr<u32>
+) -> u16;
+extern(c, "environ_get") fun wasi_environ_get(
+    entries: ptr<ptr<u8>>, data: ptr<u8>
+) -> u16;
+
+pub fun env_read(buf: ptr<u8>, cap: i64) -> i64 {
+    if (buf == null || cap <= 0 || cap > 4294967295) { return -22; }
+    var count: u32 = 0;
+    var byte_count: u32 = 0;
+    var error: u16 = wasi_environ_sizes_get(&count, &byte_count);
+    if (error != 0) { return -(error as i64); }
+    if (count > 1024 || byte_count as i64 > cap) { return -3; }
+    var entries: array<ptr<u8>, 1024>;
+    error = wasi_environ_get(&entries[0], buf);
+    if (error != 0) { return -(error as i64); }
+    return byte_count as i64;
+}

--- a/std/sys/wasm/fs.wave
+++ b/std/sys/wasm/fs.wave
@@ -1,0 +1,254 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Capability-oriented WASI Preview 1 filesystem provider. Relative paths are
+// resolved under preopen descriptor 3, which hosts normally map explicitly.
+
+import("std::sys::wasm::io")::{wasi_read, wasi_write};
+
+extern(c, "fd_close") fun wasi_fd_close(fd: u32) -> u16;
+extern(c, "fd_sync") fun wasi_fd_sync(fd: u32) -> u16;
+extern(c, "fd_seek") fun wasi_fd_seek(
+    fd: u32, offset: i64, whence: u8, position: ptr<u64>
+) -> u16;
+extern(c, "fd_filestat_get") fun wasi_fd_filestat_get(
+    fd: u32, result: ptr<WasiFileStat>
+) -> u16;
+extern(c, "path_open") fun wasi_path_open(
+    dir_fd: u32, dir_flags: u32, path: ptr<u8>, path_len: u32,
+    open_flags: u16, rights: u64, inheriting_rights: u64,
+    fd_flags: u16, result: ptr<u32>
+) -> u16;
+extern(c, "path_filestat_get") fun wasi_path_filestat_get(
+    dir_fd: u32, flags: u32, path: ptr<u8>, path_len: u32,
+    result: ptr<WasiFileStat>
+) -> u16;
+extern(c, "path_create_directory") fun wasi_path_create_directory(
+    dir_fd: u32, path: ptr<u8>, path_len: u32
+) -> u16;
+extern(c, "path_unlink_file") fun wasi_path_unlink_file(
+    dir_fd: u32, path: ptr<u8>, path_len: u32
+) -> u16;
+extern(c, "path_remove_directory") fun wasi_path_remove_directory(
+    dir_fd: u32, path: ptr<u8>, path_len: u32
+) -> u16;
+extern(c, "path_rename") fun wasi_path_rename(
+    old_dir_fd: u32, old_path: ptr<u8>, old_len: u32,
+    new_dir_fd: u32, new_path: ptr<u8>, new_len: u32
+) -> u16;
+
+pub const FS_O_RDONLY: i32 = 0;
+pub const FS_O_WRONLY: i32 = 1;
+pub const FS_O_RDWR: i32 = 2;
+pub const FS_O_CREAT: i32 = 64;
+pub const FS_O_EXCL: i32 = 128;
+pub const FS_O_TRUNC: i32 = 512;
+pub const FS_O_APPEND: i32 = 1024;
+pub const FS_O_NONBLOCK: i32 = 2048;
+pub const FS_F_OK: i32 = 0;
+pub const FS_X_OK: i32 = 1;
+pub const FS_W_OK: i32 = 2;
+pub const FS_R_OK: i32 = 4;
+pub const FS_SEEK_SET: i32 = 0;
+pub const FS_SEEK_CUR: i32 = 1;
+pub const FS_SEEK_END: i32 = 2;
+pub const FS_F_GETFL: i32 = 3;
+pub const FS_F_SETFL: i32 = 4;
+
+const WASI_PREOPEN_ROOT: u32 = 3;
+const WASI_RIGHT_READ: u64 = 2;
+const WASI_RIGHT_SEEK: u64 = 4;
+const WASI_RIGHT_SYNC: u64 = 16;
+const WASI_RIGHT_TELL: u64 = 32;
+const WASI_RIGHT_WRITE: u64 = 64;
+const WASI_RIGHT_FILESTAT_GET: u64 = 2097152;
+const WASI_O_CREAT: u16 = 1;
+const WASI_O_EXCL: u16 = 4;
+const WASI_O_TRUNC: u16 = 8;
+const WASI_FD_APPEND: u16 = 1;
+const WASI_FD_NONBLOCK: u16 = 4;
+const WASI_FILETYPE_DIRECTORY: u8 = 3;
+const WASI_FILETYPE_REGULAR: u8 = 4;
+const SYS_ERR_NOT_IMPLEMENTED: i64 = -38;
+
+struct WasiFileStat {
+    dev: u64;
+    ino: u64;
+    file_type: u8;
+    nlink: u64;
+    size: u64;
+    atime_ns: u64;
+    mtime_ns: u64;
+    ctime_ns: u64;
+}
+
+pub struct Stat {
+    mode: i16;
+    size: i64;
+    mtime: i64;
+}
+
+fun path_len(path: str) -> i64 {
+    var length: i64 = 0;
+    while (path[length] != 0) { length += 1; }
+    return length;
+}
+
+fun path_len_u32(path: str) -> i64 {
+    if ((path as ptr<u8>) == null) { return -22; }
+    var length: i64 = path_len(path);
+    if (length > 4294967295) { return -75; }
+    return length;
+}
+
+fun stat_from_wasi(native: WasiFileStat, result: ptr<Stat>) -> i64 {
+    if (result == null || native.size > 9223372036854775807) { return -75; }
+    deref result.size = native.size as i64;
+    deref result.mtime = (native.mtime_ns / 1000000000) as i64;
+    if (native.file_type == WASI_FILETYPE_DIRECTORY) {
+        deref result.mode = 16384 as i16;
+    } else if (native.file_type == WASI_FILETYPE_REGULAR) {
+        deref result.mode = 32768 as i16;
+    } else {
+        deref result.mode = 0;
+    }
+    return 0;
+}
+
+pub fun open(path: str, flags: i32, mode: i32) -> i64 {
+    var length: i64 = path_len_u32(path);
+    if (length < 0) { return length; }
+    var rights: u64 = WASI_RIGHT_SEEK | WASI_RIGHT_TELL | WASI_RIGHT_FILESTAT_GET;
+    if ((flags & FS_O_RDWR) != 0) {
+        rights = rights | WASI_RIGHT_READ | WASI_RIGHT_WRITE | WASI_RIGHT_SYNC;
+    } else if ((flags & FS_O_WRONLY) != 0) {
+        rights = rights | WASI_RIGHT_WRITE | WASI_RIGHT_SYNC;
+    } else {
+        rights = rights | WASI_RIGHT_READ;
+    }
+    var open_flags: u16 = 0;
+    if ((flags & FS_O_CREAT) != 0) { open_flags = open_flags | WASI_O_CREAT; }
+    if ((flags & FS_O_EXCL) != 0) { open_flags = open_flags | WASI_O_EXCL; }
+    if ((flags & FS_O_TRUNC) != 0) { open_flags = open_flags | WASI_O_TRUNC; }
+    var fd_flags: u16 = 0;
+    if ((flags & FS_O_APPEND) != 0) { fd_flags = fd_flags | WASI_FD_APPEND; }
+    if ((flags & FS_O_NONBLOCK) != 0) { fd_flags = fd_flags | WASI_FD_NONBLOCK; }
+    var fd: u32 = 0;
+    var error: u16 = wasi_path_open(
+        WASI_PREOPEN_ROOT, 0, path as ptr<u8>, length as u32,
+        open_flags, rights, 0, fd_flags, &fd
+    );
+    if (error != 0) { return -(error as i64); }
+    return fd as i64;
+}
+
+pub fun close(fd: i64) -> i64 {
+    if (fd < 0 || fd > 4294967295) { return -22; }
+    var error: u16 = wasi_fd_close(fd as u32);
+    if (error != 0) { return -(error as i64); }
+    return 0;
+}
+
+pub fun read(fd: i64, buf: ptr<u8>, len: i64) -> i64 { return wasi_read(fd, buf, len); }
+pub fun write(fd: i64, buf: ptr<u8>, len: i64) -> i64 { return wasi_write(fd, buf, len); }
+
+pub fun fsync(fd: i64) -> i64 {
+    if (fd < 0 || fd > 4294967295) { return -22; }
+    var error: u16 = wasi_fd_sync(fd as u32);
+    if (error != 0) { return -(error as i64); }
+    return 0;
+}
+
+pub fun lseek(fd: i64, offset: i64, whence: i32) -> i64 {
+    if (fd < 0 || fd > 4294967295 || whence < 0 || whence > 2) { return -22; }
+    var position: u64 = 0;
+    var error: u16 = wasi_fd_seek(fd as u32, offset, whence as u8, &position);
+    if (error != 0) { return -(error as i64); }
+    if (position > 9223372036854775807) { return -75; }
+    return position as i64;
+}
+
+pub fun access(path: str, mode: i32) -> i64 {
+    var native: WasiFileStat;
+    var length: i64 = path_len_u32(path);
+    if (length < 0) { return length; }
+    var error: u16 = wasi_path_filestat_get(
+        WASI_PREOPEN_ROOT, 0, path as ptr<u8>, length as u32, &native
+    );
+    if (error != 0) { return -(error as i64); }
+    return 0;
+}
+
+pub fun stat(path: str, result: ptr<Stat>) -> i64 {
+    if (result == null) { return -22; }
+    var native: WasiFileStat;
+    var length: i64 = path_len_u32(path);
+    if (length < 0) { return length; }
+    var error: u16 = wasi_path_filestat_get(
+        WASI_PREOPEN_ROOT, 0, path as ptr<u8>, length as u32, &native
+    );
+    if (error != 0) { return -(error as i64); }
+    return stat_from_wasi(native, result);
+}
+
+pub fun fstat(fd: i64, result: ptr<Stat>) -> i64 {
+    if (fd < 0 || fd > 4294967295 || result == null) { return -22; }
+    var native: WasiFileStat;
+    var error: u16 = wasi_fd_filestat_get(fd as u32, &native);
+    if (error != 0) { return -(error as i64); }
+    return stat_from_wasi(native, result);
+}
+
+pub fun mkdir(path: str, mode: i32) -> i64 {
+    var length: i64 = path_len_u32(path);
+    if (length < 0) { return length; }
+    var error: u16 = wasi_path_create_directory(
+        WASI_PREOPEN_ROOT, path as ptr<u8>, length as u32
+    );
+    if (error != 0) { return -(error as i64); }
+    return 0;
+}
+
+pub fun unlink(path: str) -> i64 {
+    var length: i64 = path_len_u32(path);
+    if (length < 0) { return length; }
+    var error: u16 = wasi_path_unlink_file(WASI_PREOPEN_ROOT, path as ptr<u8>, length as u32);
+    if (error != 0) { return -(error as i64); }
+    return 0;
+}
+
+pub fun rmdir(path: str) -> i64 {
+    var length: i64 = path_len_u32(path);
+    if (length < 0) { return length; }
+    var error: u16 = wasi_path_remove_directory(WASI_PREOPEN_ROOT, path as ptr<u8>, length as u32);
+    if (error != 0) { return -(error as i64); }
+    return 0;
+}
+
+pub fun rename_path(old_path: str, new_path: str) -> i64 {
+    var old_len: i64 = path_len_u32(old_path);
+    var new_len: i64 = path_len_u32(new_path);
+    if (old_len < 0) { return old_len; }
+    if (new_len < 0) { return new_len; }
+    var error: u16 = wasi_path_rename(
+        WASI_PREOPEN_ROOT, old_path as ptr<u8>, old_len as u32,
+        WASI_PREOPEN_ROOT, new_path as ptr<u8>, new_len as u32
+    );
+    if (error != 0) { return -(error as i64); }
+    return 0;
+}
+
+pub fun getcwd(buf: ptr<u8>, size: i64) -> i64 {
+    if (buf == null || size < 2) { return -22; }
+    deref buf[0] = 46;
+    deref buf[1] = 0;
+    return 1;
+}
+
+pub fun chdir(path: str) -> i64 { return SYS_ERR_NOT_IMPLEMENTED; }
+pub fun dup(fd: i64) -> i64 { return SYS_ERR_NOT_IMPLEMENTED; }
+pub fun dup2(oldfd: i64, newfd: i64) -> i64 { return SYS_ERR_NOT_IMPLEMENTED; }
+pub fun pipe(fds: ptr<i32>) -> i64 { return SYS_ERR_NOT_IMPLEMENTED; }
+pub fun fcntl(fd: i64, cmd: i32, arg: i64) -> i64 { return SYS_ERR_NOT_IMPLEMENTED; }

--- a/std/sys/wasm/io.wave
+++ b/std/sys/wasm/io.wave
@@ -1,0 +1,39 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Raw WASI Preview 1 descriptor I/O. The compiler maps these C imports to the
+// wasi_snapshot_preview1 module.
+
+pub struct WasiIoVec {
+    data: ptr<u8>;
+    len: u32;
+}
+
+extern(c, "fd_read") fun wasi_fd_read(
+    fd: u32, vectors: ptr<WasiIoVec>, count: u32, read_count: ptr<u32>
+) -> u16;
+extern(c, "fd_write") fun wasi_fd_write(
+    fd: u32, vectors: ptr<WasiIoVec>, count: u32, write_count: ptr<u32>
+) -> u16;
+
+pub fun wasi_read(fd: i64, data: ptr<u8>, len: i64) -> i64 {
+    if (fd < 0 || fd > 4294967295 || len < 0 || len > 4294967295) { return -22; }
+    if (len > 0 && data == null) { return -22; }
+    var vector: WasiIoVec = WasiIoVec { data: data, len: len as u32 };
+    var count: u32 = 0;
+    var error: u16 = wasi_fd_read(fd as u32, &vector, 1, &count);
+    if (error != 0) { return -(error as i64); }
+    return count as i64;
+}
+
+pub fun wasi_write(fd: i64, data: ptr<u8>, len: i64) -> i64 {
+    if (fd < 0 || fd > 4294967295 || len < 0 || len > 4294967295) { return -22; }
+    if (len > 0 && data == null) { return -22; }
+    var vector: WasiIoVec = WasiIoVec { data: data, len: len as u32 };
+    var count: u32 = 0;
+    var error: u16 = wasi_fd_write(fd as u32, &vector, 1, &count);
+    if (error != 0) { return -(error as i64); }
+    return count as i64;
+}

--- a/std/sys/wasm/memory.wave
+++ b/std/sys/wasm/memory.wave
@@ -1,0 +1,72 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// A small single-threaded bump allocator backed directly by WebAssembly linear
+// memory. Individual frees are no-ops; callers can still use the portable
+// allocation API while a reclaiming allocator is developed separately.
+
+extern(c, "llvm.wasm.memory.size.i32") fun wasm_memory_size(index: i32) -> i32;
+extern(c, "llvm.wasm.memory.grow.i32") fun wasm_memory_grow(index: i32, pages: i32) -> i32;
+
+pub const PROT_READ: i32 = 1;
+pub const PROT_WRITE: i32 = 2;
+pub const MAP_PRIVATE: i32 = 2;
+pub const MAP_ANONYMOUS: i32 = 32;
+
+const WASM_PAGE_SIZE: u64 = 65536;
+static next_address: u64 = 0;
+static memory_limit: u64 = 0;
+
+fun align16(value: u64) -> u64 {
+    return (value + 15) & 18446744073709551600;
+}
+
+fun initialize_allocator() -> bool {
+    if (memory_limit != 0) { return true; }
+    var pages: i32 = wasm_memory_size(0);
+    if (pages < 0) { return false; }
+    next_address = pages as u64 * WASM_PAGE_SIZE;
+    memory_limit = next_address;
+    return true;
+}
+
+pub fun sys_alloc(size: i64) -> ptr<u8> {
+    if (size <= 0 || size > 4294967295) { return null; }
+    if (!initialize_allocator()) { return null; }
+    var start: u64 = align16(next_address);
+    var requested: u64 = size as u64;
+    if (start > 4294967295 || requested > 4294967296 - start) { return null; }
+    var needed: u64 = start + requested;
+    if (needed > memory_limit) {
+        var missing: u64 = needed - memory_limit;
+        var page_count: u64 = (missing + WASM_PAGE_SIZE - 1) / WASM_PAGE_SIZE;
+        if (page_count > 65535) { return null; }
+        var previous: i32 = wasm_memory_grow(0, page_count as i32);
+        if (previous < 0) { return null; }
+        memory_limit = (previous as u64 + page_count) * WASM_PAGE_SIZE;
+    }
+    next_address = needed;
+    return start as ptr<u8>;
+}
+
+pub fun sys_free(p: ptr<u8>, size: i64) -> i64 {
+    if (p == null) { return 0; }
+    if (size <= 0) { return -22; }
+    return 0;
+}
+
+pub fun mmap(
+    addr: ptr<i8>, length: i64, prot: i32, flags: i32, fd: i64, offset: i64
+) -> ptr<i8> {
+    if (addr != null || fd != -1 || offset != 0) { return null; }
+    return sys_alloc(length) as ptr<i8>;
+}
+
+pub fun munmap(addr: ptr<i8>, length: i64) -> i64 {
+    return sys_free(addr as ptr<u8>, length);
+}
+
+pub fun brk(addr: ptr<i8>) -> ptr<i8> { return null; }
+pub fun sys_page_size() -> i64 { return WASM_PAGE_SIZE as i64; }

--- a/std/sys/wasm/process.wave
+++ b/std/sys/wasm/process.wave
@@ -1,0 +1,26 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// WASI Preview 1 has process exit but intentionally has no POSIX process tree.
+
+extern(c, "proc_exit") fun wasi_proc_exit(code: u32);
+
+const SYS_ERR_NOT_IMPLEMENTED: i64 = -38;
+
+pub fun exit(code: i32) -> ! {
+    wasi_proc_exit(code as u32);
+    while (true) { }
+}
+
+pub fun getpid() -> i64 { return SYS_ERR_NOT_IMPLEMENTED; }
+pub fun getppid() -> i64 { return SYS_ERR_NOT_IMPLEMENTED; }
+pub fun fork() -> i64 { return SYS_ERR_NOT_IMPLEMENTED; }
+pub fun execve(path: str, argv: ptr<ptr<i8>>, envp: ptr<ptr<i8>>) -> i64 {
+    return SYS_ERR_NOT_IMPLEMENTED;
+}
+pub fun waitpid(pid: i64, status: ptr<i32>, options: i32) -> i64 {
+    return SYS_ERR_NOT_IMPLEMENTED;
+}
+pub fun kill(pid: i64, sig: i32) -> i64 { return SYS_ERR_NOT_IMPLEMENTED; }

--- a/std/sys/wasm/time.wave
+++ b/std/sys/wasm/time.wave
@@ -1,0 +1,88 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024-2026 Wave Foundation
+// Copyright (c) 2024-2026 LunaStev and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// WASI Preview 1 clocks and relative sleep through poll_oneoff.
+
+extern(c, "clock_time_get") fun wasi_clock_time_get(
+    clock_id: u32, precision: u64, timestamp: ptr<u64>
+) -> u16;
+extern(c, "poll_oneoff") fun wasi_poll_oneoff(
+    subscriptions: ptr<WasiSubscription>, events: ptr<WasiEvent>,
+    count: u32, event_count: ptr<u32>
+) -> u16;
+
+struct WasiSubscriptionClock {
+    clock_id: u32;
+    timeout: u64;
+    precision: u64;
+    flags: u16;
+}
+
+struct WasiSubscription {
+    userdata: u64;
+    event_type: u8;
+    clock: WasiSubscriptionClock;
+}
+
+struct WasiEventFd {
+    byte_count: u64;
+    flags: u16;
+}
+
+struct WasiEvent {
+    userdata: u64;
+    error: u16;
+    event_type: u8;
+    fd: WasiEventFd;
+}
+
+pub struct TimeSpec {
+    sec: i64;
+    nsec: i64;
+}
+
+pub fun clock_gettime(clock_id: i32, tp: ptr<TimeSpec>) -> i64 {
+    if (tp == null || clock_id < 0 || clock_id > 3) { return -22; }
+    var timestamp: u64 = 0;
+    var error: u16 = wasi_clock_time_get(clock_id as u32, 1, &timestamp);
+    if (error != 0) { return -(error as i64); }
+    if (timestamp > 9223372036854775807) { return -75; }
+    deref tp.sec = (timestamp / 1000000000) as i64;
+    deref tp.nsec = (timestamp % 1000000000) as i64;
+    return 0;
+}
+
+pub fun nanosleep(req: ptr<TimeSpec>, rem: ptr<TimeSpec>) -> i64 {
+    if (req == null) { return -22; }
+    if (deref req.sec < 0 || deref req.nsec < 0 || deref req.nsec >= 1000000000) {
+        return -22;
+    }
+    if (deref req.sec > 18446744073) { return -75; }
+    if (deref req.sec == 18446744073 && deref req.nsec > 709551615) { return -75; }
+
+    var timeout: u64 = deref req.sec as u64 * 1000000000 + deref req.nsec as u64;
+    var clock: WasiSubscriptionClock = WasiSubscriptionClock {
+        clock_id: 1,
+        timeout: timeout,
+        precision: 1,
+        flags: 0
+    };
+    var subscription: WasiSubscription = WasiSubscription {
+        userdata: 1,
+        event_type: 0,
+        clock: clock
+    };
+    var event: WasiEvent;
+    var count: u32 = 0;
+    var error: u16 = wasi_poll_oneoff(&subscription, &event, 1, &count);
+    if (error != 0) { return -(error as i64); }
+    if (count != 1) { return -5; }
+    if (event.error != 0) { return -(event.error as i64); }
+    if (rem != null) {
+        deref rem.sec = 0;
+        deref rem.nsec = 0;
+    }
+    return 0;
+}

--- a/tests/cases/test129.wave
+++ b/tests/cases/test129.wave
@@ -1,0 +1,169 @@
+variant Result<T> {
+    Ok(T),
+    Err(i32),
+    Empty
+}
+
+variant Inner<T> {
+    Value(T),
+    None
+}
+
+variant Outer<T> {
+    Wrap(Inner<T>),
+    Other(T)
+}
+
+struct Box<T> {
+    value: T;
+}
+
+variant MaybeBox<T> {
+    Some(Box<T>),
+    None
+}
+
+variant Either<T, E> {
+    Left(T),
+    Right(E)
+}
+
+variant Link {
+    Next(i32, ptr<Link>),
+    End
+}
+
+struct Envelope {
+    value: Result<i64>;
+}
+
+type I64Result = Result<i64>;
+
+const EMPTY_RESULT: Result<i64> = Result::Empty;
+static STATIC_ENVELOPE: Envelope = Envelope { value: Result::Ok(77) };
+static STATIC_RESULTS: array<Result<i64>, 2> = [Result::Ok(8), Result::Empty];
+static STATIC_NESTED: Outer<i32> = Outer::Wrap(Inner::Value(13));
+
+fun make_ok<T>(value: T) -> Result<T> {
+    return Result::Ok(value);
+}
+
+fun result_value(value: Result<i64>) -> i64 {
+    var result: i64 = -99;
+    match value {
+        Result::Ok(item) => { result = item; }
+        Result::Err(code) => { result = -(code as i64); }
+        Result::Empty => { result = 0; }
+    }
+    return result;
+}
+
+fun direct_result_value(value: I64Result) -> i64 {
+    match value {
+        Result::Ok(item) => { return item; }
+        Result::Err(code) => { return -(code as i64); }
+        Result::Empty => { return 0; }
+    }
+}
+
+fun result_has_value(value: Result<i64>) -> bool {
+    var present: bool = false;
+    match value {
+        Result::Ok(_) => { present = true; }
+        _ => { present = false; }
+    }
+    return present;
+}
+
+fun either_value(value: Either<i32, i64>) -> i64 {
+    var result: i64 = 0;
+    match value {
+        Either::Left(item) => { result = item as i64; }
+        Either::Right(item) => { result = item; }
+    }
+    return result;
+}
+
+fun nested_value(value: Outer<i32>) -> i32 {
+    var result: i32 = -1;
+    match value {
+        Outer::Wrap(Inner::Value(item)) => { result = item; }
+        Outer::Wrap(Inner::None) => { result = 10; }
+        Outer::Other(item) => { result = item + 100; }
+    }
+    return result;
+}
+
+fun boxed_value(value: MaybeBox<i32>) -> i32 {
+    var result: i32 = -1;
+    match value {
+        MaybeBox::Some(boxed) => {
+            boxed.value += 1;
+            result = boxed.value;
+        }
+        MaybeBox::None => { result = 0; }
+    }
+    return result;
+}
+
+fun link_sum(value: ptr<Link>) -> i32 {
+    var result: i32 = 0;
+    match deref value {
+        Link::Next(item, next) => { result = item + link_sum(next); }
+        Link::End => { result = 0; }
+    }
+    return result;
+}
+
+fun main() -> i32 {
+    var ok: Result<i64> = Result::Ok(9000000000);
+    var error: Result<i64> = Result::Err(7);
+    var empty: Result<i64> = Result::Empty;
+    if (result_value(ok) != 9000000000) { return 1; }
+    if (result_value(error) != -7) { return 2; }
+    if (result_value(empty) != 0) { return 3; }
+
+    var produced: Result<i64> = make_ok<i64>(17);
+    if (result_value(produced) != 17) { return 4; }
+
+    error = Result::Ok(11);
+    if (result_value(error) != 11) { return 5; }
+
+    var nested: Outer<i32> = Outer::Wrap(Inner::Value(42));
+    var nested_none: Outer<i32> = Outer::Wrap(Inner::None);
+    var other: Outer<i32> = Outer::Other(3);
+    if (nested_value(nested) != 42) { return 6; }
+    if (nested_value(nested_none) != 10) { return 7; }
+    if (nested_value(other) != 103) { return 8; }
+
+    var boxed: Box<i32> = Box<i32> { value: 8 };
+    var maybe_boxed: MaybeBox<i32> = MaybeBox::Some(boxed);
+    if (boxed_value(maybe_boxed) != 9) { return 9; }
+    if (boxed.value != 8) { return 10; }
+
+    var no_box: MaybeBox<i32> = MaybeBox::None;
+    if (boxed_value(no_box) != 0) { return 11; }
+
+    var end: Link = Link::End;
+    var second: Link = Link::Next(2, &end);
+    var first: Link = Link::Next(1, &second);
+    if (link_sum(&first) != 3) { return 12; }
+
+    var envelope: Envelope = Envelope { value: Result::Ok(55) };
+    if (result_value(envelope.value) != 55) { return 13; }
+
+    var results: array<Result<i64>, 2> = [Result::Ok(6), Result::Empty];
+    if (result_value(results[0]) != 6 || result_value(results[1]) != 0) { return 14; }
+
+    if (result_value(EMPTY_RESULT) != 0) { return 15; }
+    if (result_value(STATIC_ENVELOPE.value) != 77) { return 16; }
+    if (result_value(STATIC_RESULTS[0]) != 8 || result_value(STATIC_RESULTS[1]) != 0) { return 17; }
+    if (nested_value(STATIC_NESTED) != 13) { return 18; }
+    if (direct_result_value(Result::Ok(23)) != 23) { return 19; }
+    if (!result_has_value(Result::Ok(1)) || result_has_value(Result::Err(1))) { return 20; }
+
+    var left: Either<i32, i64> = Either::Left(5);
+    var right: Either<i32, i64> = Either::Right(9000000001);
+    if (either_value(left) != 5 || either_value(right) != 9000000001) { return 21; }
+    return 0;
+}

--- a/tests/cases/test130/main.wave
+++ b/tests/cases/test130/main.wave
@@ -1,0 +1,18 @@
+import("./option")::{Option};
+
+fun unwrap(value: Option<i32>) -> i32 {
+    var result: i32 = -1;
+    match value {
+        Option::Some(item) => { result = item; }
+        Option::None => { result = 0; }
+    }
+    return result;
+}
+
+fun main() -> i32 {
+    var some: Option<i32> = Option::Some(31);
+    var none: Option<i32> = Option::None;
+    if (unwrap(some) != 31) { return 1; }
+    if (unwrap(none) != 0) { return 2; }
+    return 0;
+}

--- a/tests/cases/test130/option.wave
+++ b/tests/cases/test130/option.wave
@@ -1,0 +1,4 @@
+pub variant Option<T> {
+    Some(T),
+    None
+}

--- a/tests/codegen_regressions.rs
+++ b/tests/codegen_regressions.rs
@@ -2048,6 +2048,185 @@ fn vex_cli_print_json_contracts_are_machine_readable() {
 }
 
 #[test]
+fn wasm32_target_plans_a_webassembly_module() {
+    let dir = temp_case_dir("wasm32-module-plan");
+    let source = write_wave(
+        &dir,
+        "module.wave",
+        r#"
+fun add(a: i32, b: i32) -> i32 {
+    return a + b;
+}
+
+fun main() -> i32 {
+    return add(20, 22);
+}
+"#,
+    );
+    let out_dir = dir.join("out");
+    let (plan, stderr) = run_wavec_capture([
+        OsStr::new("build"),
+        source.as_os_str(),
+        OsStr::new("--target"),
+        OsStr::new("wasm32-unknown-unknown"),
+        OsStr::new("--dry-run"),
+        OsStr::new("--error-format=json"),
+        OsStr::new("--out-dir"),
+        out_dir.as_os_str(),
+    ]);
+    assert!(stderr.trim().is_empty(), "unexpected stderr:\n{stderr}");
+    assert!(
+        plan.contains("\"target\":\"wasm32-unknown-unknown\""),
+        "{plan}"
+    );
+    assert!(plan.contains("\"program\":\"wasm-ld\""), "{plan}");
+    assert!(plan.contains("--no-entry"), "{plan}");
+    assert!(plan.contains("--allow-undefined"), "{plan}");
+    assert!(plan.contains("--export-if-defined=main"), "{plan}");
+    assert!(plan.contains("--export-memory"), "{plan}");
+    assert!(
+        plan.contains(&json_string_for_test(
+            &out_dir.join("module.wasm").to_string_lossy()
+        )),
+        "{plan}"
+    );
+
+    let (run_plan, stderr) = run_wavec_capture([
+        OsStr::new("build"),
+        source.as_os_str(),
+        OsStr::new("--target"),
+        OsStr::new("wasm32-unknown-unknown"),
+        OsStr::new("--run"),
+        OsStr::new("--dry-run"),
+        OsStr::new("--error-format=json"),
+    ]);
+    assert!(stderr.trim().is_empty(), "{stderr}");
+    assert!(run_plan.contains("\"program\":\"node\""), "{run_plan}");
+    assert!(run_plan.contains("--input-type=module"), "{run_plan}");
+
+    let asm_source = write_wave(
+        &dir,
+        "inline_asm.wave",
+        "fun main() {\n    asm {\n        \"nop\"\n    }\n}\n",
+    );
+    let asm_error = run_wavec_expect_failure([
+        OsStr::new("build"),
+        asm_source.as_os_str(),
+        OsStr::new("--target"),
+        OsStr::new("wasm32-unknown-unknown"),
+        OsStr::new("--emit=ir"),
+        OsStr::new("--out-dir"),
+        out_dir.as_os_str(),
+    ]);
+    assert!(
+        asm_error.contains("inline assembly is not supported for webassembly wasm32 unknown"),
+        "{asm_error}"
+    );
+}
+
+#[test]
+fn wasm32_c_abi_and_wasi_import_contracts_are_explicit() {
+    let dir = temp_case_dir("wasm32-abi-contracts");
+    let host_source = write_wave(
+        &dir,
+        "host.wave",
+        r#"
+struct Pair {
+    x: i32;
+    y: i32;
+}
+
+extern(c, "host_transform") fun transform(value: Pair) -> Pair;
+
+export(c, "wave_transform") fun apply(value: Pair) -> Pair {
+    return transform(value);
+}
+
+fun main() -> i32 { return 0; }
+"#,
+    );
+    let host_out = dir.join("host-out");
+    run_wavec([
+        OsStr::new("build"),
+        host_source.as_os_str(),
+        OsStr::new("--target"),
+        OsStr::new("wasm32-unknown-unknown"),
+        OsStr::new("--emit=ir"),
+        OsStr::new("--out-dir"),
+        host_out.as_os_str(),
+    ]);
+    let host_ir = fs::read_to_string(host_out.join("host.ll")).unwrap();
+    assert!(
+        host_ir.contains("ptr sret(%Pair) align 4") && host_ir.contains("ptr byval(%Pair) align 4"),
+        "{host_ir}"
+    );
+    assert!(
+        host_ir.contains("\"wasm-import-module\"=\"env\"")
+            && host_ir.contains("\"wasm-import-name\"=\"host_transform\""),
+        "{host_ir}"
+    );
+    assert!(
+        host_ir.contains("\"wasm-export-name\"=\"wave_transform\""),
+        "{host_ir}"
+    );
+
+    let wasi_source = write_wave(
+        &dir,
+        "wasi.wave",
+        r#"
+extern(c, "fd_write") fun fd_write(fd: u32, vectors: ptr<u8>, count: u32, written: ptr<u32>) -> u16;
+fun main() -> i32 { return 0; }
+"#,
+    );
+    let wasi_out = dir.join("wasi-out");
+    run_wavec([
+        OsStr::new("build"),
+        wasi_source.as_os_str(),
+        OsStr::new("--target"),
+        OsStr::new("wasm32-wasip1"),
+        OsStr::new("--emit=ir"),
+        OsStr::new("--out-dir"),
+        wasi_out.as_os_str(),
+    ]);
+    let wasi_ir = fs::read_to_string(wasi_out.join("wasi.ll")).unwrap();
+    assert!(
+        wasi_ir.contains("target triple = \"wasm32-wasip1\""),
+        "{wasi_ir}"
+    );
+    assert!(
+        wasi_ir.contains("\"wasm-import-module\"=\"wasi_snapshot_preview1\"")
+            && wasi_ir.contains("\"wasm-import-name\"=\"fd_write\""),
+        "{wasi_ir}"
+    );
+    assert!(wasi_ir.contains("define void @_start()"), "{wasi_ir}");
+
+    let (spec, stderr) = run_wavec_capture([
+        OsStr::new("print"),
+        OsStr::new("target-spec"),
+        OsStr::new("--target"),
+        OsStr::new("wasm32-wasip1"),
+        OsStr::new("--format=json"),
+    ]);
+    assert!(stderr.trim().is_empty(), "{stderr}");
+    assert!(spec.contains("\"os\":\"wasi\""), "{spec}");
+    assert!(spec.contains("\"env\":\"p1\""), "{spec}");
+    assert!(spec.contains("\"hosted\":true"), "{spec}");
+
+    let (run_plan, stderr) = run_wavec_capture([
+        OsStr::new("build"),
+        wasi_source.as_os_str(),
+        OsStr::new("--target"),
+        OsStr::new("wasm32-wasip1"),
+        OsStr::new("--run"),
+        OsStr::new("--dry-run"),
+        OsStr::new("--error-format=json"),
+    ]);
+    assert!(stderr.trim().is_empty(), "{stderr}");
+    assert!(run_plan.contains("\"program\":\"node\""), "{run_plan}");
+    assert!(run_plan.contains("node:wasi"), "{run_plan}");
+}
+
+#[test]
 fn vex_cli_json_errors_and_dry_run_are_stable() {
     let bad = run_wavec_raw([
         OsStr::new("--error-format=json"),
@@ -2990,6 +3169,8 @@ fn advertised_target_options_reach_object_codegen_without_backend_diagnostics() 
                 [0x64, 0x86]
             };
             assert!(object.starts_with(&machine), "{target}: {target_spec}");
+        } else if target_spec.contains("\"object_format\":\"wasm\"") {
+            assert!(object.starts_with(b"\0asm"), "{target}: {target_spec}");
         } else {
             panic!("target spec has an unknown object format: {target_spec}");
         }

--- a/tests/codegen_regressions.rs
+++ b/tests/codegen_regressions.rs
@@ -2048,6 +2048,7 @@ fn vex_cli_print_json_contracts_are_machine_readable() {
 }
 
 #[test]
+#[cfg(feature = "llvm-target-wasm")]
 fn wasm32_target_plans_a_webassembly_module() {
     let dir = temp_case_dir("wasm32-module-plan");
     let source = write_wave(
@@ -2079,7 +2080,10 @@ fun main() -> i32 {
         plan.contains("\"target\":\"wasm32-unknown-unknown\""),
         "{plan}"
     );
-    assert!(plan.contains("\"program\":\"wasm-ld\""), "{plan}");
+    assert!(
+        plan.contains("\"program\":") && plan.contains("wasm-ld"),
+        "{plan}"
+    );
     assert!(plan.contains("--no-entry"), "{plan}");
     assert!(plan.contains("--allow-undefined"), "{plan}");
     assert!(plan.contains("--export-if-defined=main"), "{plan}");
@@ -2125,6 +2129,7 @@ fun main() -> i32 {
 }
 
 #[test]
+#[cfg(feature = "llvm-target-wasm")]
 fn wasm32_c_abi_and_wasi_import_contracts_are_explicit() {
     let dir = temp_case_dir("wasm32-abi-contracts");
     let host_source = write_wave(

--- a/tools/check_std_policy.sh
+++ b/tools/check_std_policy.sh
@@ -11,7 +11,7 @@ echo "[check] std policy validation"
 echo "[check] rule: extern(c) only in std/libc/** and approved hosted providers"
 extern_hits="$(rg -n 'extern\(c([,)])' std --glob '*.wave' || true)"
 if [[ -n "$extern_hits" ]]; then
-  non_libc_extern="$(printf '%s\n' "$extern_hits" | rg -v '^std/(libc/|sys/(linux|macos|freebsd)/((amd64|arm64|riscv64)/memory|resolver|interfaces|vector_io|event)\.wave:)' || true)"
+  non_libc_extern="$(printf '%s\n' "$extern_hits" | rg -v '^std/(libc/|sys/(linux|macos|freebsd)/((amd64|arm64|riscv64)/memory|resolver|interfaces|vector_io|event)\.wave:|sys/wasm/(env|fs|io|memory|process|time)\.wave:)' || true)"
   if [[ -n "$non_libc_extern" ]]; then
     echo "[FAIL] extern(c) found outside approved C ABI providers:"
     printf '%s\n' "$non_libc_extern"

--- a/tools/run_wasi_smoke.mjs
+++ b/tools/run_wasi_smoke.mjs
@@ -1,0 +1,24 @@
+// Runs a WASI Preview 1 command with the repository root preopened as fd 3.
+import { readFile } from "node:fs/promises";
+import { WASI } from "node:wasi";
+
+const modulePath = process.argv[2];
+const preopenPath = process.argv[3] ?? process.cwd();
+if (!modulePath) {
+  console.error("usage: node tools/run_wasi_smoke.mjs <module.wasm> [preopen-dir]");
+  process.exit(2);
+}
+
+const wasi = new WASI({
+  version: "preview1",
+  args: [],
+  env: process.env,
+  preopens: { ".": preopenPath },
+});
+const module = await WebAssembly.compile(await readFile(modulePath));
+const instance = await WebAssembly.instantiate(module, wasi.getImportObject());
+const leaked = Object.keys(instance.exports).filter((name) => name.startsWith("__wave_"));
+if (leaked.length !== 0) {
+  throw new Error(`private Wave functions leaked into exports: ${leaked.join(", ")}`);
+}
+wasi.start(instance);

--- a/tools/run_wasm_smoke.mjs
+++ b/tools/run_wasm_smoke.mjs
@@ -1,0 +1,43 @@
+// Instantiates the compiler's minimal browser-hosted WebAssembly fixture.
+import { readFile } from "node:fs/promises";
+
+const modulePath = process.argv[2];
+if (!modulePath) {
+  console.error("usage: node tools/run_wasm_smoke.mjs <module.wasm>");
+  process.exit(2);
+}
+
+const bytes = await readFile(modulePath);
+const imports = {
+  env: {
+    host_add(a, b) {
+      return a + b;
+    },
+  },
+};
+const { instance } = await WebAssembly.instantiate(bytes, imports);
+const {
+  wave_add: add,
+  wave_features: exerciseFeatures,
+  main,
+  memory,
+} = instance.exports;
+const leaked = Object.keys(instance.exports).filter((name) => name.startsWith("__wave_"));
+if (leaked.length !== 0 || "add" in instance.exports) {
+  throw new Error(`private Wave functions leaked into exports: ${leaked.join(", ")}`);
+}
+
+if (typeof add !== "function" || add(7, 5) !== 12) {
+  throw new Error("exported add function returned an unexpected value");
+}
+if (typeof exerciseFeatures !== "function" || exerciseFeatures(5) !== 20) {
+  throw new Error("WebAssembly language feature smoke test failed");
+}
+if (typeof main !== "function" || main() !== 42) {
+  throw new Error("exported main function returned an unexpected value");
+}
+if (!(memory instanceof WebAssembly.Memory)) {
+  throw new Error("module did not export linear memory");
+}
+
+console.log("WebAssembly smoke test passed");


### PR DESCRIPTION
## Summary

- advance the development version to `v0.2.1-pre-beta-dev` and prevent development builds from being published as releases
- complete initial `wasm32-unknown-unknown` and `wasm32-wasip1` backend, linker, runner, browser-host, WASI standard-library, example, and CI coverage
- lower payload variants end to end through typed HIR and LLVM, including generic, nested, recursive-pointer, imported, aliased, array/struct, constant, and static uses
- keep existing enums separate and reject payload variants at direct C ABI boundaries until an external representation is designed
- harden signedness coercions, entry-point ABI validation, date/time overflow handling, memory/buffer behavior, and regression observability found during cross-target validation

## Validation

- `cargo fmt --all --check`
- `cargo check --locked --jobs 2`
- `cargo clippy --locked --all-targets --jobs 2 -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --jobs 2`
- compiler unit and regression tests
- Wave language corpus and standard-library examples
- cross-target LLVM emission for the advertised native and WebAssembly targets

## Follow-up work

- #449 aggregate constant projections
- #450 compact payload variant layout
- #451 WebAssembly standard-library capability diagnostics
- #452 entry-point parameter ABI validation
- #453 browser WebAssembly host-import diagnostics
- #454 cross-target payload variant regression matrix
- #455 environment-aware network example execution

Closes #349
Closes #366
Closes #367
Closes #373
Closes #403
Closes #408
