### PR TITLE
fix: bound JSON nesting depth to prevent stack overflow (#540)

### DIFF
--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -387,8 +387,19 @@ def run_and_classify(name, rel_path, cmd):
             timeout=TIMEOUT_SEC
         )
 
-        if looks_like_fail(result.stderr):
-            print(f"{RED}→ FAIL (exit={result.returncode}){RESET}")
+        if result.returncode != expected_exit:
+            if looks_like_fail(result.stderr):
+                print(f"{RED}→ FAIL (exit={result.returncode}, expected {expected_exit}){RESET}")
+                if result.stdout.strip():
+                    print(f"{BLUE}--- STDOUT ---{RESET}")
+                    print(result.stdout.rstrip())
+                if result.stderr.strip():
+                    print(f"{YELLOW}--- STDERR ---{RESET}")
+                    print(result.stderr.rstrip())
+                print()
+                return 0, None
+            # Exit code doesn't match expected - still a failure
+            print(f"{RED}→ FAIL (exit={result.returncode}, expected {expected_exit}){RESET}")
             if result.stdout.strip():
                 print(f"{BLUE}--- STDOUT ---{RESET}")
                 print(result.stdout.rstrip())

--- a/utils/src/json.rs
+++ b/utils/src/json.rs
@@ -66,14 +66,17 @@ pub fn parse(input: &str) -> Result<Json, String> {
     Ok(v)
 }
 
+const MAX_DEPTH: usize = 256;
+
 struct Parser<'a> {
     s: &'a [u8],
     i: usize,
+    depth: usize,
 }
 
 impl<'a> Parser<'a> {
     fn new(s: &'a [u8]) -> Self {
-        Self { s, i: 0 }
+        Self { s, i: 0, depth: 0 }
     }
 
     fn eof(&self) -> bool {
@@ -243,6 +246,16 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_object(&mut self) -> Result<Vec<(String, Json)>, String> {
+        if self.depth >= MAX_DEPTH {
+            return Err("maximum nesting depth exceeded".into());
+        }
+        self.depth += 1;
+        let result = self.parse_object_inner();
+        self.depth -= 1;
+        result
+    }
+
+    fn parse_object_inner(&mut self) -> Result<Vec<(String, Json)>, String> {
         self.expect(b'{')?;
         self.skip_ws();
         let mut out = Vec::new();

--- a/utils/src/json.rs
+++ b/utils/src/json.rs
@@ -224,6 +224,16 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_array(&mut self) -> Result<Vec<Json>, String> {
+        if self.depth >= MAX_DEPTH {
+            return Err("maximum nesting depth exceeded".into());
+        }
+        self.depth += 1;
+        let result = self.parse_array_inner();
+        self.depth -= 1;
+        result
+    }
+
+    fn parse_array_inner(&mut self) -> Result<Vec<Json>, String> {
         self.expect(b'[')?;
         self.skip_ws();
         let mut out = Vec::new();


### PR DESCRIPTION
## Summary

Two fixes in this PR:

### Fix 1: Bound JSON nesting depth to prevent stack overflow (#540)

parse_value recursively calls parse_array/parse_object without tracking a depth limit. Nested metadata can consume call stack proportional to input nesting.

- Add MAX_DEPTH = 256 constant and depth: usize field to Parser
- Check depth >= MAX_DEPTH at the start of parse_array and parse_object
- Return Err("maximum nesting depth exceeded") when limit reached

### Fix 2: Stop classifying valid program stderr as compiler failure (#538)

run_and_classify checked looks_like_fail(result.stderr) before comparing the expected exit status. Any stderr containing phrases such as stack overflow, SyntaxError, or error[E was rejected, even when the program deliberately printed that text and exited with the expected status.

Fix: check exit code first. If the program exits with the expected status, it succeeded — don't reject based on stderr content alone. The compiler/child output is combined, so a real compiler failure would show as a non-zero exit code, not just stderr text.