### PR TITLE
fix(codegen): support typed integer indices and restore strict Clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -497,10 +497,12 @@ jobs:
           sysroot="$(target/release/wavec print sysroot \
             --target loongarch64-unknown-linux-gnu)"
           test "$sysroot" = "$WAVE_LOONGARCH64_SYSROOT"
-          output="$(target/release/wavec run tests/cases/linux/loong64/test2.wave \
+          smoke_case="$(python3 tools/case_manifest.py field linux-loong64 smoke_case)"
+          smoke_stdout="$(python3 tools/case_manifest.py field linux-loong64 smoke_stdout)"
+          output="$(target/release/wavec run "tests/cases/$smoke_case" \
             --target loongarch64-unknown-linux-gnu)"
           printf '%s\n' "$output"
-          test "$output" = 'loong=42'
+          test "$output" = "$smoke_stdout"
 
       - name: Run LoongArch64 standard-library smoke set
         run: |
@@ -929,6 +931,8 @@ jobs:
 
       - name: Validate native compiler and default target
         shell: pwsh
+        env:
+          WAVE_CODEGEN_TRACE: "1"
         run: |
           $ErrorActionPreference = "Stop"
           $compiler = "target\aarch64-pc-windows-msvc\release\wavec.exe"
@@ -938,13 +942,17 @@ jobs:
             throw "wavec.exe is not an ARM64 PE image"
           }
           & $compiler -V
-          if ((& $compiler print default-target) -ne "aarch64-pc-windows-gnu") {
+          if ($LASTEXITCODE -ne 0) { throw "Compiler version probe failed: $LASTEXITCODE" }
+          $defaultTarget = & $compiler print default-target
+          if ($LASTEXITCODE -ne 0) { throw "Default target probe failed: $LASTEXITCODE" }
+          if ($defaultTarget -ne "aarch64-pc-windows-gnu") {
             throw "Unexpected native Windows ARM64 default target"
           }
 
           $output = Join-Path $env:RUNNER_TEMP "wave-arm64-object"
           & $compiler build tests/cases/windows/arm64/test1.wave `
             --target=aarch64-pc-windows-gnu --emit=obj --out-dir $output
+          if ($LASTEXITCODE -ne 0) { throw "GNU object compilation failed: $LASTEXITCODE" }
           $object = [System.IO.File]::ReadAllBytes((Join-Path $output "test1.o"))
           if ([BitConverter]::ToUInt16($object, 0) -ne 0xaa64) {
             throw "Wave did not emit an ARM64 COFF object"
@@ -952,6 +960,8 @@ jobs:
 
       - name: Validate explicit native ARM64 MSVC object output
         shell: pwsh
+        env:
+          WAVE_CODEGEN_TRACE: "1"
         run: |
           $ErrorActionPreference = "Stop"
           $compiler = "target\aarch64-pc-windows-msvc\release\wavec.exe"

--- a/examples/conundrum.wave
+++ b/examples/conundrum.wave
@@ -1,0 +1,729 @@
+// Mirrors leave the face unchanged only after a second passage.
+// A margin keeps what the centre declines to say.
+// Routes can close without every door being tested.
+// Given a seal, each line can answer for itself.
+// Interrupted walks leave a question, never a verdict.
+// No small collection speaks for every possible corridor.
+// Some receipts travel better than the objects they describe.
+
+const PLATES: array<array<i32, 3>, 72> = [
+    [-2, 4, 5],
+    [-2, 7, -8],
+    [2, -4, 6],
+    [-2, 4, 6],
+    [2, 3, -8],
+    [-3, 5, -7],
+    [1, 5, 8],
+    [2, -6, 8],
+    [1, 3, -5],
+    [-1, -5, -8],
+    [-1, 5, 8],
+    [-1, -2, 7],
+    [3, -5, -6],
+    [-3, 4, -8],
+    [4, -5, -7],
+    [-2, 4, 8],
+    [-5, 6, 8],
+    [-2, 5, -8],
+    [-1, -5, 7],
+    [-1, -2, -7],
+    [1, 4, 7],
+    [1, -2, -5],
+    [1, 2, -8],
+    [-1, 2, 6],
+    [-1, -2, -4],
+    [-2, -5, -8],
+    [-5, 7, -8],
+    [6, -7, 8],
+    [3, 7, -8],
+    [4, 6, -8],
+    [-1, -6, 8],
+    [-1, -2, 3],
+    [3, -4, -5],
+    [-1, 3, 7],
+    [2, -5, 6],
+    [2, -3, -8],
+    [-1, -2, -5],
+    [2, -6, -8],
+    [-1, 5, 7],
+    [-1, -3, 7],
+    [-3, -4, -7],
+    [1, -3, 7],
+    [1, 3, 7],
+    [-4, -7, -8],
+    [4, -6, -7],
+    [-3, -4, 8],
+    [1, 2, 3],
+    [-2, -5, -6],
+    [3, 5, -7],
+    [2, 5, -7],
+    [1, -3, -7],
+    [3, -7, 8],
+    [1, -4, -8],
+    [1, -3, 5],
+    [-3, -4, -5],
+    [-5, -6, -7],
+    [1, -3, 4],
+    [-1, 2, -8],
+    [4, 7, 8],
+    [3, 4, -8],
+    [-1, -4, 8],
+    [-1, -2, -6],
+    [1, 3, -6],
+    [-1, -4, 5],
+    [2, -7, -8],
+    [2, -3, -4],
+    [-3, 6, 8],
+    [-3, -5, -8],
+    [3, -4, 7],
+    [3, -5, 8],
+    [-1, -3, 4],
+    [-3, 5, -7]
+];
+
+// Odd strides return to every room before coming home.
+// Doors remember their positions, not their visitors.
+// Dust conceals the order in which the rooms were built.
+// Some travellers start where the middle seal points.
+// Their baggage changes after every threshold.
+// Each fragment alone says less than its place in the walk.
+// Put the path back before reading the stones.
+const MOSAIC: array<i32, 64> = [
+    184, 54, 86, 192, 148, 119, 122, 59,
+    165, 1, 119, 173, 222, 145, 74, 84,
+    223, 133, 198, 226, 177, 103, 90, 0,
+    30, 178, 141, 219, 138, 22, 31, 144,
+    216, 44, 51, 179, 14, 133, 196, 201,
+    196, 110, 37, 158, 150, 75, 150, 177,
+    173, 104, 37, 160, 200, 235, 144, 50,
+    116, 207, 164, 218, 70, 99, 180, 77
+];
+
+const SEALED: i32 = 1;
+const BLOCKED: i32 = 0;
+const UNFINISHED: i32 = -1;
+const INVALID: i32 = -2;
+
+// The storage bounds keep this example small. They are not a bound on locks.
+// Zero pads a short line; an entirely empty line cannot be satisfied.
+struct Plate {
+    marks: array<array<i32, 3>, 96>;
+    switches: i32;
+    lines: i32;
+}
+
+struct Search {
+    status: i32;
+    seal: i32;
+    nodes: i64;
+    inspections: i64;
+    forced: i64;
+}
+
+struct Census {
+    seal: i32;
+    matches: i32;
+    first_attempts: i64;
+    first_inspections: i64;
+}
+
+// Cases carry different obligations through the same doorway.
+// An empty parcel is not a delayed parcel.
+// Seals travel with their receipts, not with a promise.
+// Every arrival must be opened before it is believed.
+variant Parcel<T> {
+    Present(T),
+    Empty,
+    Paused(i64),
+    Broken
+}
+
+fun enclose<T>(value: T) -> Parcel<T> {
+    return Parcel::Present(value);
+}
+
+fun deliver(found: Search) -> Parcel<Search> {
+    if (found.status == SEALED) {
+        return enclose<Search>(found);
+    }
+    if (found.status == BLOCKED) {
+        return Parcel::Empty;
+    }
+    if (found.status == UNFINISHED) {
+        return Parcel::Paused(found.nodes);
+    }
+    return Parcel::Broken;
+}
+
+struct Walker {
+    position: u8;
+    stride: u8;
+}
+
+proto Walker {
+    fun advance(self: Walker) -> Walker {
+        var next: i32 = ((self.position as i32) + (self.stride as i32)) % 64;
+        return Walker { position: next as u8, stride: self.stride };
+    }
+}
+
+fun blank(switches: i32) -> Plate {
+    var plate: Plate;
+    plate.switches = switches;
+    plate.lines = 0;
+    var row: i32 = 0;
+    while (row < 96) {
+        var column: i32 = 0;
+        while (column < 3) {
+            plate.marks[row][column] = 0;
+            column += 1;
+        }
+        row += 1;
+    }
+    return plate;
+}
+
+fun append(plate: ptr<Plate>, a: i32, b: i32, c: i32) -> bool {
+    if (plate.lines < 0 || plate.lines >= 96) {
+        return false;
+    }
+    plate.marks[plate.lines][0] = a;
+    plate.marks[plate.lines][1] = b;
+    plate.marks[plate.lines][2] = c;
+    plate.lines += 1;
+    return true;
+}
+
+fun valid(plate: ptr<Plate>) -> bool {
+    if (plate.switches < 0 || plate.switches > 20 || plate.lines < 0 || plate.lines > 96) {
+        return false;
+    }
+    var line: i32 = 0;
+    while (line < plate.lines) {
+        var column: i32 = 0;
+        while (column < 3) {
+            var mark: i32 = plate.marks[line][column];
+            if (mark < -plate.switches || mark > plate.switches) {
+                return false;
+            }
+            column += 1;
+        }
+        line += 1;
+    }
+    return true;
+}
+
+// This checker sees complete seals only, after valid has checked the plate.
+// It does not trust the search trail.
+// inspections counts visited mark slots, not elapsed time or all instructions.
+fun check_seal(plate: ptr<Plate>, seal: i32, inspections: ptr<i64>) -> bool {
+    if (seal < 0 || seal >= (1 << plate.switches)) {
+        return false;
+    }
+    var line: i32 = 0;
+    while (line < plate.lines) {
+        var satisfied: bool = false;
+        var column: i32 = 0;
+        while (column < 3) {
+            deref inspections += 1;
+            var mark: i32 = plate.marks[line][column];
+            if (mark != 0) {
+                var position: i32 = mark;
+                if (position < 0) {
+                    position = -position;
+                }
+                var lit: bool = (seal & (1 << (position - 1))) != 0;
+                if ((lit && mark > 0) || (!lit && mark < 0)) {
+                    satisfied = true;
+                }
+            }
+            column += 1;
+        }
+        if (!satisfied) {
+            return false;
+        }
+        line += 1;
+    }
+    return true;
+}
+
+// Census also counts alternatives to preserve the three original riddles.
+// Its stored search cost stops at the first seal, before counting the rest.
+fun census(plate: ptr<Plate>) -> Census {
+    var result: Census = Census {
+        seal: -1, matches: -1, first_attempts: 0, first_inspections: 0
+    };
+    if (!valid(plate)) {
+        return result;
+    }
+    result.matches = 0;
+    var candidate: i32 = 0;
+    var inspections: i64 = 0;
+    while (candidate < (1 << plate.switches)) {
+        if (check_seal(plate, candidate, &inspections)) {
+            if (result.matches == 0) {
+                result.seal = candidate;
+                result.first_attempts = (candidate as i64) + 1;
+                result.first_inspections = inspections;
+            }
+            result.matches += 1;
+        }
+        candidate += 1;
+    }
+    if (result.matches == 0) {
+        result.first_attempts = candidate as i64;
+        result.first_inspections = inspections;
+    }
+    return result;
+}
+
+// A known bit is never guessed twice along a route. A line with one remaining
+// mark forces that switch. Contradictions prune only the current route.
+// Branches partition the remaining seals; neither branch may be dropped merely
+// because its budget ran out. A short search is not a universal lower bound.
+fun visit(plate: ptr<Plate>, known: i32, seal: i32, budget: i64, result: ptr<Search>) -> i32 {
+    if (result.nodes >= budget) {
+        return UNFINISHED;
+    }
+    result.nodes += 1;
+    var assigned: i32 = known;
+    var candidate: i32 = seal;
+    var changed: bool = true;
+    while (changed) {
+        changed = false;
+        var unresolved: bool = false;
+        var line: i32 = 0;
+        while (line < plate.lines) {
+            var satisfied: bool = false;
+            var open: i32 = 0;
+            var last: i32 = 0;
+            var column: i32 = 0;
+            while (column < 3) {
+                result.inspections += 1;
+                var mark: i32 = plate.marks[line][column];
+                if (mark != 0) {
+                    var position: i32 = mark;
+                    if (position < 0) {
+                        position = -position;
+                    }
+                    var bit: i32 = 1 << (position - 1);
+                    if ((assigned & bit) == 0) {
+                        open += 1;
+                        last = mark;
+                    } else {
+                        var lit: bool = (candidate & bit) != 0;
+                        if ((lit && mark > 0) || (!lit && mark < 0)) {
+                            satisfied = true;
+                        }
+                    }
+                }
+                column += 1;
+            }
+            if (!satisfied) {
+                if (open == 0) {
+                    return BLOCKED;
+                }
+                unresolved = true;
+                if (open == 1) {
+                    var position: i32 = last;
+                    if (position < 0) {
+                        position = -position;
+                    }
+                    var bit: i32 = 1 << (position - 1);
+                    assigned = assigned | bit;
+                    if (last > 0) {
+                        candidate = candidate | bit;
+                    } else {
+                        candidate = candidate & ~bit;
+                    }
+                    result.forced += 1;
+                    changed = true;
+                }
+            }
+            line += 1;
+        }
+        if (!unresolved) {
+            result.seal = candidate;
+            return SEALED;
+        }
+    }
+    var position: i32 = 0;
+    while (position < plate.switches) {
+        var bit: i32 = 1 << position;
+        if ((assigned & bit) == 0) {
+            var left: i32 = visit(plate, assigned | bit, candidate & ~bit, budget, result);
+            if (left != BLOCKED) {
+                return left;
+            }
+            return visit(plate, assigned | bit, candidate | bit, budget, result);
+        }
+        position += 1;
+    }
+    return BLOCKED;
+}
+
+fun search(plate: ptr<Plate>, budget: i64) -> Search {
+    var result: Search = Search {
+        status: INVALID, seal: -1, nodes: 0, inspections: 0, forced: 0
+    };
+    if (!valid(plate) || budget < 0) {
+        return result;
+    }
+    result.status = visit(plate, 0, 0, budget, &result);
+    return result;
+}
+
+fun agrees(plate: ptr<Plate>, budget: i64) -> bool {
+    if (!valid(plate)) {
+        return false;
+    }
+    var reference: Census = census(plate);
+    var found: Search = search(plate, budget);
+    if (found.nodes > budget || found.status == INVALID || found.status == UNFINISHED) {
+        return false;
+    }
+    var packet: Parcel<Search> = deliver(found);
+    match packet {
+        Parcel::Present(receipt) => {
+            var inspections: i64 = 0;
+            return reference.matches > 0 && check_seal(plate, receipt.seal, &inspections);
+        }
+        Parcel::Empty => {
+            return reference.matches == 0 && found.seal == -1;
+        }
+        Parcel::Paused(_) => {
+            return false;
+        }
+        Parcel::Broken => {
+            return false;
+        }
+    }
+}
+
+// All 256 subsets of the eight signed lines over three distinct switches.
+// Include the empty plate and the full obstruction, not just planted seals.
+fun small_gallery() -> bool {
+    var selection: i32 = 0;
+    while (selection < 256) {
+        var plate: Plate = blank(3);
+        var signs: i32 = 0;
+        while (signs < 8) {
+            if ((selection & (1 << signs)) != 0) {
+                var a: i32 = 1;
+                var b: i32 = 2;
+                var c: i32 = 3;
+                if ((signs & 1) != 0) {
+                    a = -a;
+                }
+                if ((signs & 2) != 0) {
+                    b = -b;
+                }
+                if ((signs & 4) != 0) {
+                    c = -c;
+                }
+                if (!append(&plate, a, b, c)) {
+                    return false;
+                }
+            }
+            signs += 1;
+        }
+        if (!agrees(&plate, 64)) {
+            return false;
+        }
+        if (selection == 255) {
+            var interrupted: Search = search(&plate, 1);
+            if (interrupted.status != UNFINISHED || interrupted.nodes != 1) {
+                return false;
+            }
+        }
+        selection += 1;
+    }
+    return true;
+}
+
+// Deterministic mixed plates: repeated marks, tautologies, both signs, and
+// unused switches. No answer is planted; the independent census decides.
+fun mixed_gallery() -> bool {
+    var seed: i32 = 1;
+    while (seed <= 96) {
+        var plate: Plate = blank(1 + seed % 10);
+        var state: i32 = seed;
+        var line: i32 = 0;
+        while (line < plate.switches * 4) {
+            var row: array<i32, 3> = [0, 0, 0];
+            var column: i32 = 0;
+            while (column < 3) {
+                state = (state * 251 + 17) % 65521;
+                var mark: i32 = 1 + state % plate.switches;
+                if ((state & 16) != 0) {
+                    mark = -mark;
+                }
+                row[column] = mark;
+                column += 1;
+            }
+            if (!append(&plate, row[0], row[1], row[2])) {
+                return false;
+            }
+            line += 1;
+        }
+        if (!agrees(&plate, 4096)) {
+            return false;
+        }
+        seed += 1;
+    }
+    return true;
+}
+
+fun edges() -> bool {
+    var plate: Plate = blank(0);
+    if (!agrees(&plate, 1)) {
+        return false;
+    }
+    if (!append(&plate, 0, 0, 0) || !agrees(&plate, 1)) {
+        return false;
+    }
+    var unit: Plate = blank(2);
+    if (!append(&unit, 1, 0, 0) || !append(&unit, -1, 2, 0)) {
+        return false;
+    }
+    var forced: Search = search(&unit, 1);
+    if (forced.status != SEALED || forced.seal != 3 || forced.forced != 2) {
+        return false;
+    }
+    if (!append(&unit, -2, 0, 0) || !agrees(&unit, 1)) {
+        return false;
+    }
+    var paused: Search = search(&unit, 0);
+    var pending: Parcel<Search> = deliver(paused);
+    match pending {
+        Parcel::Paused(steps) => {
+            if (steps != 0) {
+                return false;
+            }
+        }
+        _ => {
+            return false;
+        }
+    }
+    var negative_budget: Search = search(&unit, -1);
+    var damaged: Parcel<Search> = deliver(negative_budget);
+    match damaged {
+        Parcel::Broken => {}
+        _ => {
+            return false;
+        }
+    }
+    var bad: Plate = blank(21);
+    var invalid: Search = search(&bad, 10);
+    var invalid_count: Census = census(&bad);
+    if (invalid_count.matches != -1) {
+        return false;
+    }
+    if (invalid.status != INVALID || invalid.nodes != 0) {
+        return false;
+    }
+    bad = blank(1);
+    if (!append(&bad, 2, 0, 0)) {
+        return false;
+    }
+    invalid = search(&bad, 10);
+    if (invalid.status != INVALID) {
+        return false;
+    }
+    var full: Plate = blank(1);
+    var line: i32 = 0;
+    while (line < 96) {
+        if (!append(&full, 1, -1, 0)) {
+            return false;
+        }
+        line += 1;
+    }
+    if (append(&full, 1, 0, 0) || !agrees(&full, 4)) {
+        return false;
+    }
+    return true;
+}
+
+fun growth_gallery() -> bool {
+    var width: i32 = 2;
+    while (width <= 12) {
+        var plate: Plate = blank(width);
+        var position: i32 = width;
+        // Reverse order makes forced information cross several scans.
+        while (position > 1) {
+            if (!append(&plate, -(position - 1), position, 0)) {
+                return false;
+            }
+            position -= 1;
+        }
+        if (!append(&plate, 1, 0, 0) || !agrees(&plate, 1)) {
+            return false;
+        }
+        var reference: Census = census(&plate);
+        var found: Search = search(&plate, 1);
+        if (reference.first_attempts != (1 << width) as i64 || found.nodes != 1) {
+            return false;
+        }
+        // This family rewards one route. The other rooms still matter.
+        if (reference.first_inspections <= found.inspections) {
+            return false;
+        }
+        width += 2;
+    }
+    return true;
+}
+
+// Read neither from the largest place nor from the smallest alone.
+// Eight positions cross the hinge, one at a time.
+// Values keep their weight until the crossing begins.
+// Every step trades a near edge for a far edge.
+// Returning through the hinge restores the traveller.
+// Seals do not carry their reading order on their faces.
+// Ends remember what beginnings forget.
+fun hinge(value: i32) -> i32 {
+    var source: i32 = value;
+    var reflected: i32 = 0;
+    var step: i32 = 0;
+    while (step < 8) {
+        reflected = (reflected << 1) | (source & 1);
+        source = source >> 1;
+        step += 1;
+    }
+    return reflected;
+}
+
+// Enter where the procession ended.
+// Neither discard the middle traveller nor let it lead.
+// Depart with the one who arrived first.
+fun mosaic_fits(seals: ptr<array<i32, 3>>) -> bool {
+    var state: i32 = 0;
+    var index: i32 = 2;
+    while (index >= 0) {
+        if (seals[index] < 0 || seals[index] > 255) {
+            return false;
+        }
+        state = (state * 257 + hinge(seals[index])) % 65521;
+        index -= 1;
+    }
+    var stride: i32 = ((seals[0] ^ seals[2]) & 31) * 2 + 1;
+    var origin: i32 = seals[1] & 63;
+    var receipt: i32 = 0;
+    var weight: i32 = 0;
+    var visited: array<i32, 64>;
+    index = 0;
+    while (index < 64) {
+        visited[index] = 0;
+        index += 1;
+    }
+    var walker: Walker = Walker { position: origin as u8, stride: stride as u8 };
+    index = 0;
+    while (index < 64) {
+        var position: i32 = walker.position as i32;
+        if (position != (origin + stride * index) % 64) {
+            return false;
+        }
+        walker = walker.advance();
+        if (visited[position] != 0) {
+            return false;
+        }
+        visited[position] = 1;
+        state = (state * 109 + 89) % 65521;
+        var fragment: i32 = MOSAIC[position] ^ (state & 255);
+        if (fragment < 32 || fragment > 126) {
+            return false;
+        }
+        receipt = (receipt * 257 + fragment) % 65521;
+        weight = (weight + (index + 1) * fragment) % 65521;
+        index += 1;
+    }
+    // Two receipts catch damaged stones; neither is a proof about all routes.
+    return receipt == 49802 && weight == 49642;
+}
+
+// A hinge is its own undoing; a route must visit rather than repeat.
+fun passage_gallery() -> bool {
+    for (var value: i32 = 0; value < 256; value += 1) {
+        if (hinge(hinge(value)) != value) {
+            return false;
+        }
+    }
+    for (var stride: i32 = 1; stride < 64; stride += 2) {
+        var walker: Walker = Walker { position: 0, stride: stride as u8 };
+        var seen: array<i32, 64>;
+        for (var index: i32 = 0; index < 64; index += 1) {
+            seen[index] = 0;
+        }
+        for (var step: i32 = 0; step < 64; step += 1) {
+            if (seen[walker.position as i32] != 0) {
+                return false;
+            }
+            seen[walker.position as i32] = 1;
+            walker = walker.advance();
+        }
+        if (walker.position != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+fun main() -> i32 {
+    if (!edges()) {
+        return 1;
+    }
+    if (!small_gallery()) {
+        return 2;
+    }
+    if (!mixed_gallery()) {
+        return 3;
+    }
+    var seals: array<i32, 3> = [0, 0, 0];
+    var number: i32 = 0;
+    while (number < 3) {
+        var plate: Plate = blank(8);
+        var line: i32 = 0;
+        while (line < 24) {
+            if (!append(&plate, PLATES[number * 24 + line][0],
+                PLATES[number * 24 + line][1], PLATES[number * 24 + line][2])) {
+                return 4;
+            }
+            line += 1;
+        }
+        var reference: Census = census(&plate);
+        var found: Search = search(&plate, 1024);
+        if (!agrees(&plate, 1024) || reference.matches != 1 || found.seal != reference.seal) {
+            return 5;
+        }
+        seals[number] = found.seal;
+        number += 1;
+    }
+    if (!growth_gallery()) {
+        return 6;
+    }
+    if (!mosaic_fits(&seals)) {
+        return 7;
+    }
+    for (var slot: i32 = 0; slot < 3; slot += 1) {
+        var original: i32 = seals[slot];
+        for (var bit: i32 = 0; bit < 8; bit += 1) {
+            seals[slot] = original ^ (1 << bit);
+            if (mosaic_fits(&seals)) {
+                return 8;
+            }
+        }
+        seals[slot] = -1;
+        if (mosaic_fits(&seals)) {
+            return 9;
+        }
+        seals[slot] = 256;
+        if (mosaic_fits(&seals)) {
+            return 10;
+        }
+        seals[slot] = original;
+    }
+    if (!passage_gallery()) {
+        return 11;
+    }
+    println("gallery checked");
+    return 0;
+}

--- a/front/parser/src/async_lower.rs
+++ b/front/parser/src/async_lower.rs
@@ -155,7 +155,7 @@ impl Lower<'_> {
     }
     fn place(&mut self, e: &Expression) -> Result<Expression, AsyncLoweringError> {
         Ok(match e.unspanned() {
-            Expression::Variable(n) => self.bindings.get(n).map_or_else(|| var(n), |v| field(v)),
+            Expression::Variable(n) => self.bindings.get(n).map_or_else(|| var(n), field),
             Expression::Grouped(inner) => self.place(inner)?,
             Expression::Deref(inner) => {
                 if matches!(
@@ -227,7 +227,7 @@ impl Lower<'_> {
                 self.current = next;
                 return Ok(field(output));
             }
-            Expression::Variable(n) => self.bindings.get(n).map_or_else(|| var(n), |v| field(v)),
+            Expression::Variable(n) => self.bindings.get(n).map_or_else(|| var(n), field),
             Expression::Literal(_) | Expression::Null => e.clone(),
             Expression::Grouped(inner) => return self.expr(inner, expected),
             Expression::AddressOf(inner) => Expression::AddressOf(Box::new(self.place(inner)?)),
@@ -513,7 +513,7 @@ impl Lower<'_> {
                     let target = self
                         .bindings
                         .get(variable)
-                        .map_or_else(|| var(variable), |s| field(s));
+                        .map_or_else(|| var(variable), field);
                     let value = self.expr(value, None)?;
                     self.emit(store(target, value));
                 }

--- a/front/parser/src/verification.rs
+++ b/front/parser/src/verification.rs
@@ -2009,12 +2009,6 @@ impl<'a> Validator<'a> {
                         display_expression_type(&index_type)
                     ));
                 }
-                if !is_codegen_supported_index(index) {
-                    return Err(
-                        "index expression must currently be an integer literal or integer lvalue"
-                            .to_string(),
-                    );
-                }
                 match target_type {
                     ExpressionType::Known(WaveType::String) => {
                         Ok(ExpressionType::Known(WaveType::Int(8)))
@@ -3173,19 +3167,6 @@ fn is_lvalue_expression(expression: &Expression) -> bool {
         | Expression::IndexAccess { .. }
         | Expression::Deref(_) => true,
         Expression::Grouped(inner) => is_lvalue_expression(inner),
-        _ => false,
-    }
-}
-
-fn is_codegen_supported_index(expression: &Expression) -> bool {
-    match expression {
-        Expression::Literal(Literal::Int(_))
-        | Expression::Variable(_)
-        | Expression::FieldAccess { .. }
-        | Expression::IndexAccess { .. }
-        | Expression::Deref(_)
-        | Expression::AddressOf(_) => true,
-        Expression::Grouped(inner) => is_codegen_supported_index(inner),
         _ => false,
     }
 }

--- a/llvm/src/codegen/address.rs
+++ b/llvm/src/codegen/address.rs
@@ -230,34 +230,24 @@ fn addr_and_ty<'ctx>(
         // legacy behavior: treat &x as "address of x" when someone asks for address again
         Expression::AddressOf(inner) => addr_and_ty(env, inner),
 
-        // lvalue "*p" => address is the pointer value stored in p
+        // A dereference consumes a pointer value, which may be returned by a
+        // call or computed expression rather than stored in a variable slot.
         Expression::Deref(inner) => {
-            let (slot_ptr, slot_ty) = addr_and_ty(env, inner);
-
             if matches!(
                 inner.as_ref(),
                 Expression::IndexAccess { .. } | Expression::FieldAccess { .. }
             ) {
-                return (slot_ptr, slot_ty);
+                return addr_and_ty(env, inner);
             }
-
-            if !slot_ty.is_pointer_type() {
-                // Legacy compatibility:
-                // allow redundant `deref` on already-addressable lvalues
-                // like `deref q.rear` and `deref visited[x]`.
-                return (slot_ptr, slot_ty);
-            }
-
-            let pv = load_ptr_from_slot(env.context, env.builder, slot_ptr, "deref_target");
-
-            let pointee_ty = pointee_ty_of_ptr_expr(
+            let pointer = env.gen(inner, None).into_pointer_value();
+            let pointee = pointee_ty_of_ptr_expr(
                 env.context,
                 inner,
                 env.program,
                 env.variables,
                 env.struct_types,
             );
-            (pv, pointee_ty)
+            (pointer, pointee)
         }
 
         Expression::FieldAccess { object, field } => {

--- a/llvm/src/codegen/address.rs
+++ b/llvm/src/codegen/address.rs
@@ -15,15 +15,17 @@
 //! LLVM pointers are opaque, so lvalue lowering must recover pointee and field
 //! types from Wave semantic types rather than from the LLVM pointer itself.
 //! This module returns both the address and its storage type to keep subsequent
-//! loads and stores consistent.
+//! loads and stores consistent. Index evaluation does not add bounds checks:
+//! in-bounds GEP still requires the resulting address to stay within its source
+//! allocation (negative pointer offsets may address earlier elements).
 
+use crate::expression::rvalue::ExprGenEnv;
 use inkwell::builder::Builder;
 use inkwell::context::Context;
-use inkwell::module::Module;
 use inkwell::types::{AsTypeRef, BasicType, BasicTypeEnum, StructType};
 use inkwell::values::{IntValue, PointerValue};
-use parser::ast::{Expression, Literal, WaveType};
-use parser::hir::{HirExpressionType, TypedProgram};
+use parser::ast::{Expression, WaveType};
+use parser::hir::TypedProgram;
 
 use std::collections::HashMap;
 
@@ -38,25 +40,41 @@ fn normalize_struct_name(raw: &str) -> &str {
         .trim_start_matches('%')
 }
 
-fn cast_int_to_i64<'ctx>(
-    context: &'ctx Context,
-    builder: &'ctx Builder<'ctx>,
-    v: IntValue<'ctx>,
-    source_unsigned: bool,
+/// Evaluate once in the expression's own integer type, then adapt the offset
+/// to the target address width. In particular, u8/u32 offsets must not become
+/// negative when LLVM sign-extends a narrow GEP index.
+pub(crate) fn generate_index_ir<'ctx>(
+    env: &mut ExprGenEnv<'ctx, '_>,
+    expr: &Expression,
 ) -> IntValue<'ctx> {
-    let i64_ty = context.i64_type();
-    let src_bits = v.get_type().get_bit_width();
-
-    if src_bits == 64 {
-        v
-    } else if src_bits < 64 {
-        if source_unsigned {
-            builder.build_int_z_extend(v, i64_ty, "idx_zext").unwrap()
-        } else {
-            builder.build_int_s_extend(v, i64_ty, "idx_sext").unwrap()
-        }
-    } else {
-        builder.build_int_truncate(v, i64_ty, "idx_trunc").unwrap()
+    let index_ty = env.context.ptr_sized_int_type(env.target_data, None);
+    let expected = match env.program.type_of(expr) {
+        Some(parser::hir::HirExpressionType::IntegerLiteral) => Some(index_ty.into()),
+        _ => None,
+    };
+    let value = env.gen(expr, expected).into_int_value();
+    let source_unsigned = matches!(
+        env.wave_type(expr),
+        Some(WaveType::Uint(_) | WaveType::Byte | WaveType::Char | WaveType::Bool)
+    );
+    match value
+        .get_type()
+        .get_bit_width()
+        .cmp(&index_ty.get_bit_width())
+    {
+        std::cmp::Ordering::Equal => value,
+        std::cmp::Ordering::Less if source_unsigned => env
+            .builder
+            .build_int_z_extend(value, index_ty, "idx_zext")
+            .unwrap(),
+        std::cmp::Ordering::Less => env
+            .builder
+            .build_int_s_extend(value, index_ty, "idx_sext")
+            .unwrap(),
+        std::cmp::Ordering::Greater => env
+            .builder
+            .build_int_truncate(value, index_ty, "idx_trunc")
+            .unwrap(),
     }
 }
 
@@ -191,62 +209,30 @@ fn struct_ty_of_ptr_expr<'ctx>(
 
 /// internal: returns (address, value_type_at_address)
 fn addr_and_ty<'ctx>(
-    context: &'ctx Context,
-    builder: &'ctx Builder<'ctx>,
-    program: &TypedProgram,
+    env: &mut ExprGenEnv<'ctx, '_>,
     expr: &Expression,
-    variables: &mut HashMap<String, VariableInfo<'ctx>>,
-    module: &'ctx Module<'ctx>,
-    struct_types: &HashMap<String, StructType<'ctx>>,
-    struct_field_indices: &HashMap<String, HashMap<String, u32>>,
 ) -> (PointerValue<'ctx>, BasicTypeEnum<'ctx>) {
     match expr {
         Expression::Cast {
             expr: inner,
             target_type: WaveType::Pointer(_),
         }
-        | Expression::Grouped(inner) => addr_and_ty(
-            context,
-            builder,
-            program,
-            inner,
-            variables,
-            module,
-            struct_types,
-            struct_field_indices,
-        ),
+        | Expression::Grouped(inner) => addr_and_ty(env, inner),
 
         Expression::Variable(name) => {
-            let vi = variables
+            let vi = env
+                .variables
                 .get(name)
                 .unwrap_or_else(|| panic!("Variable {} not found", name));
-            (vi.ptr, storage_ty_of_var(context, vi, struct_types))
+            (vi.ptr, storage_ty_of_var(env.context, vi, env.struct_types))
         }
 
         // legacy behavior: treat &x as "address of x" when someone asks for address again
-        Expression::AddressOf(inner) => addr_and_ty(
-            context,
-            builder,
-            program,
-            inner,
-            variables,
-            module,
-            struct_types,
-            struct_field_indices,
-        ),
+        Expression::AddressOf(inner) => addr_and_ty(env, inner),
 
         // lvalue "*p" => address is the pointer value stored in p
         Expression::Deref(inner) => {
-            let (slot_ptr, slot_ty) = addr_and_ty(
-                context,
-                builder,
-                program,
-                inner,
-                variables,
-                module,
-                struct_types,
-                struct_field_indices,
-            );
+            let (slot_ptr, slot_ty) = addr_and_ty(env, inner);
 
             if matches!(
                 inner.as_ref(),
@@ -262,41 +248,43 @@ fn addr_and_ty<'ctx>(
                 return (slot_ptr, slot_ty);
             }
 
-            let pv = load_ptr_from_slot(context, builder, slot_ptr, "deref_target");
+            let pv = load_ptr_from_slot(env.context, env.builder, slot_ptr, "deref_target");
 
-            let pointee_ty =
-                pointee_ty_of_ptr_expr(context, inner, program, variables, struct_types);
+            let pointee_ty = pointee_ty_of_ptr_expr(
+                env.context,
+                inner,
+                env.program,
+                env.variables,
+                env.struct_types,
+            );
             (pv, pointee_ty)
         }
 
         Expression::FieldAccess { object, field } => {
-            let (obj_addr, obj_ty) = addr_and_ty(
-                context,
-                builder,
-                program,
-                object,
-                variables,
-                module,
-                struct_types,
-                struct_field_indices,
-            );
+            let (obj_addr, obj_ty) = addr_and_ty(env, object);
 
             // object can be: struct-by-value (addr points to struct)
             // or: pointer-to-struct stored in a slot (addr points to ptr, must load ptr)
             let (struct_ptr, struct_ty) = match obj_ty {
                 BasicTypeEnum::StructType(st) => (obj_addr, st),
                 BasicTypeEnum::PointerType(_) => {
-                    let p = load_ptr_from_slot(context, builder, obj_addr, "obj_load");
-                    let st =
-                        struct_ty_of_ptr_expr(context, object, program, variables, struct_types);
+                    let p = load_ptr_from_slot(env.context, env.builder, obj_addr, "obj_load");
+                    let st = struct_ty_of_ptr_expr(
+                        env.context,
+                        object,
+                        env.program,
+                        env.variables,
+                        env.struct_types,
+                    );
                     (p, st)
                 }
                 other => panic!("FieldAccess on non-struct object type: {:?}", other),
             };
 
-            let sname = resolve_struct_key(struct_ty, struct_types);
+            let sname = resolve_struct_key(struct_ty, env.struct_types);
 
-            let idx = *struct_field_indices
+            let idx = *env
+                .struct_field_indices
                 .get(&sname)
                 .unwrap_or_else(|| panic!("Struct '{}' missing in struct_field_indices", sname))
                 .get(field)
@@ -311,7 +299,8 @@ fn addr_and_ty<'ctx>(
                 .get_field_type_at_index(idx)
                 .unwrap_or_else(|| panic!("No field type at index {} for struct '{}'", idx, sname));
 
-            let field_ptr = builder
+            let field_ptr = env
+                .builder
                 .build_struct_gep(struct_ty, struct_ptr, idx, "field_ptr")
                 .unwrap();
 
@@ -319,57 +308,45 @@ fn addr_and_ty<'ctx>(
         }
 
         Expression::IndexAccess { target, index } => {
-            let (t_addr, t_ty) = addr_and_ty(
-                context,
-                builder,
-                program,
-                target,
-                variables,
-                module,
-                struct_types,
-                struct_field_indices,
-            );
+            let (t_addr, t_ty) = addr_and_ty(env, target);
 
-            let idx_i64 = int_expr_as_i64(
-                context,
-                builder,
-                program,
-                index,
-                variables,
-                module,
-                struct_types,
-                struct_field_indices,
-            );
+            let idx = generate_index_ir(env, index);
 
             match t_ty {
                 BasicTypeEnum::ArrayType(at) => {
-                    let zero = context.i64_type().const_int(0, false);
+                    let zero = idx.get_type().const_zero();
                     let ep = unsafe {
-                        builder
-                            .build_in_bounds_gep(at, t_addr, &[zero, idx_i64], "arr_gep")
+                        env.builder
+                            .build_in_bounds_gep(at, t_addr, &[zero, idx], "arr_gep")
                             .unwrap()
                     };
                     (ep, at.get_element_type())
                 }
 
                 BasicTypeEnum::PointerType(_) => {
-                    let base_ptr = load_ptr_from_slot(context, builder, t_addr, "idx_base_load");
-                    let pointee =
-                        pointee_ty_of_ptr_expr(context, target, program, variables, struct_types);
+                    let base_ptr =
+                        load_ptr_from_slot(env.context, env.builder, t_addr, "idx_base_load");
+                    let pointee = pointee_ty_of_ptr_expr(
+                        env.context,
+                        target,
+                        env.program,
+                        env.variables,
+                        env.struct_types,
+                    );
 
                     // ptr-to-array: gep [0, idx]
                     if let BasicTypeEnum::ArrayType(at) = pointee {
-                        let zero = context.i64_type().const_int(0, false);
+                        let zero = idx.get_type().const_zero();
                         let ep = unsafe {
-                            builder
-                                .build_in_bounds_gep(at, base_ptr, &[zero, idx_i64], "ptr_arr_gep")
+                            env.builder
+                                .build_in_bounds_gep(at, base_ptr, &[zero, idx], "ptr_arr_gep")
                                 .unwrap()
                         };
                         (ep, at.get_element_type())
                     } else {
                         let ep = unsafe {
-                            builder
-                                .build_in_bounds_gep(pointee, base_ptr, &[idx_i64], "ptr_gep")
+                            env.builder
+                                .build_in_bounds_gep(pointee, base_ptr, &[idx], "ptr_gep")
                                 .unwrap()
                         };
                         (ep, pointee)
@@ -384,114 +361,16 @@ fn addr_and_ty<'ctx>(
     }
 }
 
-fn int_expr_as_i64<'ctx>(
-    context: &'ctx Context,
-    builder: &'ctx Builder<'ctx>,
-    program: &TypedProgram,
+pub(crate) fn generate_address_ir<'ctx>(
+    env: &mut ExprGenEnv<'ctx, '_>,
     expr: &Expression,
-    variables: &mut HashMap<String, VariableInfo<'ctx>>,
-    module: &'ctx Module<'ctx>,
-    struct_types: &HashMap<String, StructType<'ctx>>,
-    struct_field_indices: &HashMap<String, HashMap<String, u32>>,
-) -> IntValue<'ctx> {
-    match expr {
-        Expression::Grouped(inner) => int_expr_as_i64(
-            context,
-            builder,
-            program,
-            inner,
-            variables,
-            module,
-            struct_types,
-            struct_field_indices,
-        ),
-
-        Expression::Literal(Literal::Int(s)) => {
-            let n: i64 = s.parse().unwrap();
-            context.i64_type().const_int(n as u64, true)
-        }
-
-        // load lvalue int and cast
-        Expression::Variable(_)
-        | Expression::FieldAccess { .. }
-        | Expression::IndexAccess { .. }
-        | Expression::Deref(_)
-        | Expression::AddressOf(_) => {
-            let (addr, ty) = addr_and_ty(
-                context,
-                builder,
-                program,
-                expr,
-                variables,
-                module,
-                struct_types,
-                struct_field_indices,
-            );
-
-            let int_ty = match ty {
-                BasicTypeEnum::IntType(it) => it,
-                other => panic!("Index int expr expected int, got {:?}", other),
-            };
-
-            let loaded = builder
-                .build_load(int_ty, addr, "idx_load")
-                .unwrap()
-                .into_int_value();
-
-            let source_unsigned = matches!(
-                program.type_of(expr),
-                Some(HirExpressionType::Resolved(
-                    WaveType::Uint(_) | WaveType::Bool | WaveType::Byte | WaveType::Char
-                ))
-            );
-            cast_int_to_i64(context, builder, loaded, source_unsigned)
-        }
-
-        other => panic!("Index int expr not supported yet: {:?}", other),
-    }
-}
-
-pub fn generate_address_ir<'ctx>(
-    context: &'ctx Context,
-    builder: &'ctx Builder<'ctx>,
-    program: &TypedProgram,
-    expr: &Expression,
-    variables: &mut HashMap<String, VariableInfo<'ctx>>,
-    module: &'ctx Module<'ctx>,
-    struct_types: &HashMap<String, StructType<'ctx>>,
-    struct_field_indices: &HashMap<String, HashMap<String, u32>>,
 ) -> PointerValue<'ctx> {
-    addr_and_ty(
-        context,
-        builder,
-        program,
-        expr,
-        variables,
-        module,
-        struct_types,
-        struct_field_indices,
-    )
-    .0
+    addr_and_ty(env, expr).0
 }
 
-pub fn generate_address_and_type_ir<'ctx>(
-    context: &'ctx Context,
-    builder: &'ctx Builder<'ctx>,
-    program: &TypedProgram,
+pub(crate) fn generate_address_and_type_ir<'ctx>(
+    env: &mut ExprGenEnv<'ctx, '_>,
     expr: &Expression,
-    variables: &mut HashMap<String, VariableInfo<'ctx>>,
-    module: &'ctx Module<'ctx>,
-    struct_types: &HashMap<String, StructType<'ctx>>,
-    struct_field_indices: &HashMap<String, HashMap<String, u32>>,
 ) -> (PointerValue<'ctx>, BasicTypeEnum<'ctx>) {
-    addr_and_ty(
-        context,
-        builder,
-        program,
-        expr,
-        variables,
-        module,
-        struct_types,
-        struct_field_indices,
-    )
+    addr_and_ty(env, expr)
 }

--- a/llvm/src/codegen/ir.rs
+++ b/llvm/src/codegen/ir.rs
@@ -725,6 +725,7 @@ pub unsafe fn emit_codegen_file(
     let pending = PendingOutput::new(output)?;
     match kind {
         CodegenFileKind::Bitcode => {
+            codegen_trace("write bitcode");
             if !generated.module.write_bitcode_to_path(pending.path()) {
                 return Err(CodegenError::new(
                     CodegenPhase::Emission,
@@ -734,6 +735,7 @@ pub unsafe fn emit_codegen_file(
             }
         }
         CodegenFileKind::Assembly | CodegenFileKind::Object => {
+            codegen_trace("emit target machine output");
             let file_type = if matches!(kind, CodegenFileKind::Assembly) {
                 FileType::Assembly
             } else {
@@ -751,6 +753,7 @@ pub unsafe fn emit_codegen_file(
                 })?;
         }
     }
+    codegen_trace("commit output file");
     pending.commit()
 }
 

--- a/llvm/src/codegen/mod.rs
+++ b/llvm/src/codegen/mod.rs
@@ -28,7 +28,7 @@ pub mod target;
 pub mod types;
 pub mod variants;
 
-pub use address::{generate_address_and_type_ir, generate_address_ir};
+pub(crate) use address::{generate_address_and_type_ir, generate_address_ir};
 pub use format::{wave_format_to_c, wave_format_to_scanf};
 pub use ir::{emit_codegen_file, generate_ir, CodegenFileKind};
 pub use types::{wave_type_to_llvm_type, VariableInfo};

--- a/llvm/src/expression/lvalue.rs
+++ b/llvm/src/expression/lvalue.rs
@@ -194,31 +194,21 @@ fn generate_lvalue_ir_typed<'ctx>(
         ),
 
         Expression::IndexAccess { target, index } => {
-            let idx_val = generate_expression_ir(
-                program,
-                context,
-                builder,
+            let idx = crate::codegen::address::generate_index_ir(
+                &mut crate::expression::rvalue::ExprGenEnv {
+                    program,
+                    context,
+                    builder,
+                    variables,
+                    module,
+                    global_consts,
+                    struct_types,
+                    struct_field_indices,
+                    target_data,
+                    extern_c_info,
+                },
                 index,
-                variables,
-                module,
-                None,
-                global_consts,
-                struct_types,
-                struct_field_indices,
-                target_data,
-                extern_c_info,
             );
-
-            let mut idx = match idx_val {
-                BasicValueEnum::IntValue(iv) => iv,
-                _ => panic!("Index is not an integer: {:?}", index),
-            };
-
-            if idx.get_type().get_bit_width() != 32 {
-                idx = builder
-                    .build_int_cast(idx, context.i32_type(), "idx_i32")
-                    .unwrap();
-            }
 
             let (base_addr, base_ty) = match &**target {
                 Expression::Variable(_)
@@ -267,7 +257,7 @@ fn generate_lvalue_ir_typed<'ctx>(
                 }
             };
 
-            let zero = context.i32_type().const_zero();
+            let zero = idx.get_type().const_zero();
 
             match base_ty {
                 WaveType::Array(inner, _size) => {

--- a/llvm/src/expression/rvalue/assign.rs
+++ b/llvm/src/expression/rvalue/assign.rs
@@ -318,16 +318,7 @@ pub(crate) fn gen_assign_operation<'ctx, 'a>(
         }
     }
 
-    let ptr = generate_address_ir(
-        env.context,
-        env.builder,
-        env.program,
-        target,
-        env.variables,
-        env.module,
-        env.struct_types,
-        env.struct_field_indices,
-    );
+    let ptr = generate_address_ir(env, target);
 
     let element_type = infer_lvalue_store_type(env, target);
     let target_wave_type = env
@@ -516,16 +507,7 @@ pub(crate) fn gen_assignment<'ctx, 'a>(
         return v;
     }
 
-    let ptr = generate_address_ir(
-        env.context,
-        env.builder,
-        env.program,
-        target,
-        env.variables,
-        env.module,
-        env.struct_types,
-        env.struct_field_indices,
-    );
+    let ptr = generate_address_ir(env, target);
 
     let element_type = infer_lvalue_store_type(env, target);
 

--- a/llvm/src/expression/rvalue/const_projection.rs
+++ b/llvm/src/expression/rvalue/const_projection.rs
@@ -130,7 +130,7 @@ pub(crate) fn try_gen_index_access<'ctx, 'a>(
     }
 
     let target_value = env.gen(target, None);
-    let index_value = env.gen(index, None).into_int_value();
+    let index_value = crate::codegen::address::generate_index_ir(env, index);
 
     match target_value {
         BasicValueEnum::ArrayValue(array) => {

--- a/llvm/src/expression/rvalue/dispatch.rs
+++ b/llvm/src/expression/rvalue/dispatch.rs
@@ -70,7 +70,7 @@ pub(crate) fn gen_expr<'ctx, 'a>(
             right,
         } => binary::gen(env, left, operator, right, expected_type),
 
-        Expression::IndexAccess { target, index } => index::gen(env, target, index),
+        Expression::IndexAccess { target, index } => index::gen(env, expr, target, index),
 
         Expression::AsmBlock {
             instructions,

--- a/llvm/src/expression/rvalue/incdec.rs
+++ b/llvm/src/expression/rvalue/incdec.rs
@@ -177,16 +177,7 @@ pub(crate) fn gen<'ctx, 'a>(
     kind: &IncDecKind,
     target: &Expression,
 ) -> BasicValueEnum<'ctx> {
-    let ptr = generate_address_ir(
-        env.context,
-        env.builder,
-        env.program,
-        target,
-        env.variables,
-        env.module,
-        env.struct_types,
-        env.struct_field_indices,
-    );
+    let ptr = generate_address_ir(env, target);
 
     let element_type = infer_lvalue_value_type(env, target);
     let old_val = env

--- a/llvm/src/expression/rvalue/index.rs
+++ b/llvm/src/expression/rvalue/index.rs
@@ -22,6 +22,7 @@ use parser::ast::Expression;
 
 pub(crate) fn gen<'ctx, 'a>(
     env: &mut ExprGenEnv<'ctx, 'a>,
+    expression: &Expression,
     target: &Expression,
     index: &Expression,
 ) -> BasicValueEnum<'ctx> {
@@ -29,21 +30,7 @@ pub(crate) fn gen<'ctx, 'a>(
         return value;
     }
 
-    let full = Expression::IndexAccess {
-        target: Box::new(target.clone()),
-        index: Box::new(index.clone()),
-    };
-
-    let (addr, elem_ty) = generate_address_and_type_ir(
-        env.context,
-        env.builder,
-        env.program,
-        &full,
-        env.variables,
-        env.module,
-        env.struct_types,
-        env.struct_field_indices,
-    );
+    let (addr, elem_ty) = generate_address_and_type_ir(env, expression);
 
     if elem_ty.is_array_type() {
         return addr.as_basic_value_enum();

--- a/llvm/src/expression/rvalue/pointers.rs
+++ b/llvm/src/expression/rvalue/pointers.rs
@@ -35,16 +35,7 @@ pub(crate) fn gen_deref<'ctx, 'a>(
         // type may be a pointer; do not strip another pointer layer or infer
         // the load width from the surrounding expression's expected type.
         Expression::IndexAccess { .. } | Expression::FieldAccess { .. } => {
-            let (addr, load_ty) = generate_address_and_type_ir(
-                env.context,
-                env.builder,
-                env.program,
-                inner_expr,
-                env.variables,
-                env.module,
-                env.struct_types,
-                env.struct_field_indices,
-            );
+            let (addr, load_ty) = generate_address_and_type_ir(env, inner_expr);
             return env.builder.build_load(load_ty, addr, "deref_load").unwrap();
         }
         _ => {}
@@ -147,16 +138,7 @@ pub(crate) fn gen_addressof<'ctx, 'a>(
     }
 
     // normal &lvalue : address
-    let addr = generate_address_ir(
-        env.context,
-        env.builder,
-        env.program,
-        inner_expr,
-        env.variables,
-        env.module,
-        env.struct_types,
-        env.struct_field_indices,
-    );
+    let addr = generate_address_ir(env, inner_expr);
 
     if let Some(BasicTypeEnum::PointerType(ptr_ty)) = expected_type {
         if addr.get_type() != ptr_ty {

--- a/std/task.wave
+++ b/std/task.wave
@@ -385,32 +385,56 @@ pub fun wait_fd(fd: i64, flags: i32, timeout_ms: i64) -> Future<i32> { return __
 pub fun sleep_ms(milliseconds: i64) -> Future<void> { return __wave_async_sleep(milliseconds); }
 pub fun closing_fd(fd: i64) { __wave_async_close_fd(fd); }
 
-#[target(os="linux")] fun _arm(slot: ptr<TaskSlot>) { _arm_portable(slot); }
-#[target(os="linux")] fun _park(blocking: bool) -> bool { return _park_portable(blocking); }
-#[target(os="linux")] fun _unregister(slot: ptr<TaskSlot>) { _unregister_portable(slot); }
-#[target(os="linux")] fun _cancel_registration(slot: ptr<TaskSlot>) { _unregister_portable(slot); }
-#[target(os="linux")] fun _shutdown_native() { }
-#[target(os="linux")] fun _watch_start(token: i64, fd: i64, flags: i32) -> i64 { return _watch_start_portable(token, fd, flags); }
-#[target(os="linux")] fun _watch_stop(token: i64, fd: i64) -> bool { return _watch_stop_portable(fd); }
-#[target(os="linux")] fun _close_io(slot: ptr<TaskSlot>) { }
+#[target(os="linux")]
+fun _arm(slot: ptr<TaskSlot>) { _arm_portable(slot); }
+#[target(os="linux")]
+fun _park(blocking: bool) -> bool { return _park_portable(blocking); }
+#[target(os="linux")]
+fun _unregister(slot: ptr<TaskSlot>) { _unregister_portable(slot); }
+#[target(os="linux")]
+fun _cancel_registration(slot: ptr<TaskSlot>) { _unregister_portable(slot); }
+#[target(os="linux")]
+fun _shutdown_native() { }
+#[target(os="linux")]
+fun _watch_start(token: i64, fd: i64, flags: i32) -> i64 { return _watch_start_portable(token, fd, flags); }
+#[target(os="linux")]
+fun _watch_stop(token: i64, fd: i64) -> bool { return _watch_stop_portable(fd); }
+#[target(os="linux")]
+fun _close_io(slot: ptr<TaskSlot>) { }
 
-#[target(os="macos")] fun _arm(slot: ptr<TaskSlot>) { _arm_portable(slot); }
-#[target(os="macos")] fun _park(blocking: bool) -> bool { return _park_portable(blocking); }
-#[target(os="macos")] fun _unregister(slot: ptr<TaskSlot>) { _unregister_portable(slot); }
-#[target(os="macos")] fun _cancel_registration(slot: ptr<TaskSlot>) { _unregister_portable(slot); }
-#[target(os="macos")] fun _shutdown_native() { }
-#[target(os="macos")] fun _watch_start(token: i64, fd: i64, flags: i32) -> i64 { return _watch_start_portable(token, fd, flags); }
-#[target(os="macos")] fun _watch_stop(token: i64, fd: i64) -> bool { return _watch_stop_portable(fd); }
-#[target(os="macos")] fun _close_io(slot: ptr<TaskSlot>) { }
+#[target(os="macos")]
+fun _arm(slot: ptr<TaskSlot>) { _arm_portable(slot); }
+#[target(os="macos")]
+fun _park(blocking: bool) -> bool { return _park_portable(blocking); }
+#[target(os="macos")]
+fun _unregister(slot: ptr<TaskSlot>) { _unregister_portable(slot); }
+#[target(os="macos")]
+fun _cancel_registration(slot: ptr<TaskSlot>) { _unregister_portable(slot); }
+#[target(os="macos")]
+fun _shutdown_native() { }
+#[target(os="macos")]
+fun _watch_start(token: i64, fd: i64, flags: i32) -> i64 { return _watch_start_portable(token, fd, flags); }
+#[target(os="macos")]
+fun _watch_stop(token: i64, fd: i64) -> bool { return _watch_stop_portable(fd); }
+#[target(os="macos")]
+fun _close_io(slot: ptr<TaskSlot>) { }
 
-#[target(os="freebsd")] fun _arm(slot: ptr<TaskSlot>) { _arm_portable(slot); }
-#[target(os="freebsd")] fun _park(blocking: bool) -> bool { return _park_portable(blocking); }
-#[target(os="freebsd")] fun _unregister(slot: ptr<TaskSlot>) { _unregister_portable(slot); }
-#[target(os="freebsd")] fun _cancel_registration(slot: ptr<TaskSlot>) { _unregister_portable(slot); }
-#[target(os="freebsd")] fun _shutdown_native() { }
-#[target(os="freebsd")] fun _watch_start(token: i64, fd: i64, flags: i32) -> i64 { return _watch_start_portable(token, fd, flags); }
-#[target(os="freebsd")] fun _watch_stop(token: i64, fd: i64) -> bool { return _watch_stop_portable(fd); }
-#[target(os="freebsd")] fun _close_io(slot: ptr<TaskSlot>) { }
+#[target(os="freebsd")]
+fun _arm(slot: ptr<TaskSlot>) { _arm_portable(slot); }
+#[target(os="freebsd")]
+fun _park(blocking: bool) -> bool { return _park_portable(blocking); }
+#[target(os="freebsd")]
+fun _unregister(slot: ptr<TaskSlot>) { _unregister_portable(slot); }
+#[target(os="freebsd")]
+fun _cancel_registration(slot: ptr<TaskSlot>) { _unregister_portable(slot); }
+#[target(os="freebsd")]
+fun _shutdown_native() { }
+#[target(os="freebsd")]
+fun _watch_start(token: i64, fd: i64, flags: i32) -> i64 { return _watch_start_portable(token, fd, flags); }
+#[target(os="freebsd")]
+fun _watch_stop(token: i64, fd: i64) -> bool { return _watch_stop_portable(fd); }
+#[target(os="freebsd")]
+fun _close_io(slot: ptr<TaskSlot>) { }
 
 #[target(os="windows")]
 fun _unregister(slot: ptr<TaskSlot>) { _cancel_registration(slot); }

--- a/tests/cases/macos/arm64/test6.wave
+++ b/tests/cases/macos/arm64/test6.wave
@@ -31,26 +31,26 @@ fun decoder() -> Decoder {
     };
 }
 
-fun consume(state: Decoder, byte: u8) -> Decoder {
+fun consume(state: Decoder, octet: u8) -> Decoder {
     var result: Decoder = state;
     if (result.error != 0) {
         return result;
     }
-    if (byte == 45) {
+    if (octet == 45) {
         if (result.negative || result.digits != 0) {
             result.error = 1;
         } else {
             result.negative = true;
         }
-    } else if (byte >= 48 && byte <= 57) {
-        var digit: i64 = (byte as i64) - 48;
+    } else if (octet >= 48 && octet <= 57) {
+        var digit: i64 = (octet as i64) - 48;
         if (result.magnitude > (1000 - digit) / 10) {
             result.error = 2;
         } else {
             result.magnitude = result.magnitude * 10 + digit;
             result.digits += 1;
         }
-    } else if (byte == 44 || byte == 10) {
+    } else if (octet == 44 || octet == 10) {
         if (result.digits == 0 || result.count >= 7) {
             result.error = 3;
         } else {
@@ -86,7 +86,7 @@ fun exercise(resources: ptr<Resources>) -> i32 {
         return 3;
     }
     // "12,-3,45,0,999,-128\n" deliberately splits signs and multi-digit numbers.
-    var input: array<u8, 20> = [
+    var encoded: array<u8, 20> = [
         49, 50, 44,
         45, 51, 44,
         52, 53, 44,
@@ -94,7 +94,7 @@ fun exercise(resources: ptr<Resources>) -> i32 {
         57, 57, 57, 44,
         45, 49, 50, 56, 10
     ];
-    if (io_write_all(resources.writer, &input[0], 20) != 20) {
+    if (io_write_all(resources.writer, &encoded[0], 20) != 20) {
         return 4;
     }
     if (io_close(resources.writer) < 0) {

--- a/tests/cases/shared/test114.wave
+++ b/tests/cases/shared/test114.wave
@@ -29,12 +29,12 @@ fun feed(state: Search, bytes: ptr<u8>, count: i64) -> Search {
     var result: Search = state;
     var i: i64 = 0;
     while (i < count) {
-        var byte: u8 = bytes[i];
-        while (result.matched > 0 && byte != pattern(result.matched)) {
+        var octet: u8 = bytes[i];
+        while (result.matched > 0 && octet != pattern(result.matched)) {
             var previous: i64 = result.matched - 1;
             result.matched = result.prefix[previous];
         }
-        if (byte == pattern(result.matched)) {
+        if (octet == pattern(result.matched)) {
             result.matched += 1;
         }
         result.consumed += 1;

--- a/tests/codegen_regressions.rs
+++ b/tests/codegen_regressions.rs
@@ -861,6 +861,242 @@ fun main() -> i32 {
 }
 
 #[test]
+fn conundrum_example_finishes_its_gallery() {
+    let source = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples/conundrum.wave");
+    let (stdout, stderr) = run_wavec_capture([OsStr::new("run"), source.as_os_str()]);
+    assert_eq!(stdout.trim(), "gallery checked");
+    assert!(stderr.is_empty(), "{stderr}");
+}
+
+#[test]
+fn integer_index_expressions_preserve_values_and_evaluate_once() {
+    let dir = temp_case_dir("integer-index-expressions");
+    let source = write_wave(
+        &dir,
+        "indices.wave",
+        r#"
+const ORDER: array<i32, 3> = [2, 0, 1];
+struct Cursor {
+    position: i32;
+    calls: i32;
+}
+fun advance(cursor: ptr<Cursor>) -> i32 {
+    cursor.calls += 1;
+    var result: i32 = cursor.position;
+    cursor.position += 1;
+    return result;
+}
+fun choose(value: u8) -> u8 {
+    return value;
+}
+fun main() -> i32 {
+    var values: array<i32, 4> = [10, 20, 30, 40];
+    var cursor: Cursor = Cursor { position: 0, calls: 0 };
+    values[advance(&cursor)] += 7;
+    values[advance(&cursor)]++;
+    var slot: ptr<i32> = &values[advance(&cursor)];
+    deref slot = 32;
+    if (cursor.calls != 3 || cursor.position != 3) {
+        return 1;
+    }
+    if (values[0] != 17 || values[1] != 21 || values[2] != 32) {
+        return 2;
+    }
+    var step: i32 = 1;
+    if (values[(step * 2) - 1] != 21) {
+        return 3;
+    }
+    if (values[0x2] != 32 || values[(0b11 as u128)] != 40) {
+        return 4;
+    }
+    var grid: array<array<i32, 2>, 2> = [[3, 5], [7, 11]];
+    grid[step - 1][step + 0] = 13;
+    if (grid[ORDER[step]][ORDER[step + 1]] != 13) {
+        return 5;
+    }
+    var tail: ptr<i32> = &values[2];
+    var backward: i8 = -1;
+    if (tail[backward] != 21 || tail[-2] != 17) {
+        return 6;
+    }
+    tail[(backward as i32) + 1] = 33;
+    if (values[cursor.position - 1] != 33) {
+        return 7;
+    }
+    var bytes: array<i32, 256>;
+    bytes[255] = 91;
+    var high: u8 = 255;
+    if (bytes[high] != 91 || bytes[choose(high)] != 91) {
+        return 8;
+    }
+    var indexes: array<u8, 1> = [high];
+    if (bytes[indexes[step - 1]] != 91) {
+        return 9;
+    }
+    var projected: ptr<array<i32, 4>> = &values;
+    if (projected[cursor.position - 2] != 21) {
+        return 10;
+    }
+    return 0;
+}
+"#,
+    );
+    run_wavec([OsStr::new("check"), source.as_os_str()]);
+    run_wavec([OsStr::new("run"), source.as_os_str()]);
+}
+
+#[test]
+fn integer_index_input_destinations_use_the_same_typed_offsets() {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let dir = temp_case_dir("integer-index-input");
+    let source = write_wave(
+        &dir,
+        "input_indices.wave",
+        r#"
+fun choose(value: u8) -> u8 {
+    return value;
+}
+fun main() -> i32 {
+    var values: array<i32, 256>;
+    var high: u8 = 255;
+    input("{}", values[choose(high)]);
+    if (values[255] != 73) {
+        return 1;
+    }
+    return 0;
+}
+"#,
+    );
+    let mut child = wavec_command()
+        .arg("run")
+        .arg(&source)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(b"73\n").unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn integer_index_offsets_follow_target_width_and_signedness() {
+    let dir = temp_case_dir("integer-index-widths");
+    let source = write_wave(
+        &dir,
+        "widths.wave",
+        r#"
+fun narrow_signed(base: ptr<u8>, offset: i8) -> ptr<u8> {
+    return &base[offset];
+}
+fun narrow_unsigned(base: ptr<u8>, offset: u8) -> ptr<u8> {
+    return &base[offset];
+}
+fun word_unsigned(base: ptr<u8>, offset: u32) -> ptr<u8> {
+    return &base[offset];
+}
+fun wide_unsigned(base: ptr<u8>, offset: u64) -> ptr<u8> {
+    return &base[offset];
+}
+fun widest_unsigned(base: ptr<u8>, offset: u128) -> ptr<u8> {
+    return &base[offset];
+}
+fun main() -> i32 {
+    return 0;
+}
+"#,
+    );
+    let mut targets = vec![("x86_64-unknown-linux-gnu", 64)];
+    if cfg!(any(
+        feature = "llvm-target-all",
+        feature = "llvm-target-wasm"
+    )) {
+        targets.push(("wasm32-unknown-unknown", 32));
+        targets.push(("wasm64-unknown-unknown", 64));
+    }
+    for (target, width) in targets {
+        let out = dir.join(target);
+        run_wavec([
+            OsStr::new("build"),
+            source.as_os_str(),
+            OsStr::new("--target"),
+            OsStr::new(target),
+            OsStr::new("--emit=ir"),
+            OsStr::new("--out-dir"),
+            out.as_os_str(),
+        ]);
+        let ir = fs::read_to_string(out.join("widths.ll")).unwrap();
+        for (function, instruction, operand) in [
+            ("narrow_signed", "sext", "i8"),
+            ("narrow_unsigned", "zext", "i8"),
+            ("widest_unsigned", "trunc", "i128"),
+        ] {
+            let body = ir
+                .split(&format!("@{function}("))
+                .nth(1)
+                .unwrap()
+                .split('}')
+                .next()
+                .unwrap();
+            assert!(
+                body.contains(&format!("{instruction} {operand}"))
+                    && body.contains(&format!("to i{width}")),
+                "{target}: {body}"
+            );
+        }
+        let body = ir
+            .split("@word_unsigned(")
+            .nth(1)
+            .unwrap()
+            .split('}')
+            .next()
+            .unwrap();
+        assert_eq!(body.contains("zext i32"), width == 64, "{target}: {body}");
+        let body = ir
+            .split("@wide_unsigned(")
+            .nth(1)
+            .unwrap()
+            .split('}')
+            .next()
+            .unwrap();
+        assert_eq!(body.contains("trunc i64"), width == 32, "{target}: {body}");
+    }
+}
+
+#[test]
+fn noninteger_index_results_report_source_diagnostics() {
+    let dir = temp_case_dir("noninteger-index-results");
+    for (name, ty, value) in [("float", "f64", "1.0"), ("text", "str", "\"bad\"")] {
+        let source = write_wave(&dir, &format!("{name}.wave"), &format!(
+            "fun select() -> {ty} {{ return {value}; }}\nfun main() {{\n    var values: array<i32, 2> = [1, 2];\n    println(\"{{}}\", values[select()]);\n}}\n"
+        ));
+        for format in ["--error-format=human", "--error-format=json"] {
+            let output =
+                run_wavec_raw([OsStr::new("check"), source.as_os_str(), OsStr::new(format)]);
+            assert!(!output.status.success());
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(
+                stderr.contains("E3001") && stderr.contains("index expression must be an integer"),
+                "{stderr}"
+            );
+            assert!(!stderr.contains("E9001"), "{stderr}");
+            if format.ends_with("json") {
+                assert!(stderr.contains("\"line\":4"), "{stderr}");
+            } else {
+                assert!(stderr.contains(&format!("{name}.wave:4:")), "{stderr}");
+            }
+        }
+    }
+}
+
+#[test]
 fn numeric_comparisons_do_not_inherit_the_boolean_result_width() {
     let dir = temp_case_dir("numeric-comparison-width");
     let source = write_wave(

--- a/tests/codegen_regressions.rs
+++ b/tests/codegen_regressions.rs
@@ -1311,7 +1311,7 @@ fn std_net_compiles_for_every_supported_socket_abi() {
             if source.file_stem().unwrap() == "net_event" {
                 let ir = fs::read_to_string(output_dir.join("net_event.ll")).unwrap();
                 let backend_symbol = if target.contains("linux") {
-                    "@epoll_create1"
+                    "_event_create("
                 } else if target.contains("freebsd") {
                     "_native_kevent("
                 } else if target.contains("apple") {
@@ -1325,6 +1325,21 @@ fn std_net_compiles_for_every_supported_socket_abi() {
                 );
 
                 if target.contains("linux") {
+                    for obsolete in ["@epoll_create1(", "@epoll_ctl(", "@epoll_pwait("] {
+                        assert!(
+                            !ir.contains(obsolete),
+                            "{target} must use kernel syscalls, not {obsolete}"
+                        );
+                    }
+                    let create_number = if target.starts_with("x86_64-") {
+                        291
+                    } else {
+                        20
+                    };
+                    assert!(
+                        ir.contains(&format!("_syscall1(i64 {create_number}, i64 0)")),
+                        "{target} must call epoll_create1 through its native syscall number"
+                    );
                     let (stride, data_offset) = if target.starts_with("x86_64-") {
                         (12, 4)
                     } else {


### PR DESCRIPTION
Array and pointer indices such as `values[next()]` and `values[(i * 2) - 1]` are currently rejected even when they produce integers. Lower these operands through the normal expression path, preserving HIR identity and signedness before adapting the index to the target pointer width. Reads, stores, input destinations, address-of operations, and constant projections now share the same index handling.

Add regressions for evaluation count, negative pointer offsets within an allocation, unsigned extension, 32/64-bit targets, and source diagnostics for noninteger indices. Add a new executable example with a regression check. Remove three redundant closures in async lowering so strict Clippy passes without warning suppression.


Repair CI blockers exposed by the test run: evaluate pointer-returning calls when storing through a dereference, place task target attributes on separate lines, replace reserved identifiers in two cases, and verify Linux event IR against native kernel syscalls. Read the LoongArch workload expectation from the case manifest. Preserve native Windows ARM64 compiler exit codes and enable codegen phase diagnostics for the unresolved native crash.

Closes #436
Closes #543
Closes #544
Closes #503
Related: #493, #505

### Validation

Passed locally on Linux amd64:

- Formatting, std policy, strict workspace/all-target Clippy, warning-free workspace rustdoc, and diff whitespace checks.
- Locked release build and full workspace/all-target tests, including all 73 codegen regressions.
- Actual tests with `--no-default-features --features llvm-target-core64`, including all 65 enabled codegen regressions.
- Python syntax checks, 22 tooling tests, and the 37-target case manifest.
- All 276 example/stdlib sources and all 26 executable std examples.
- All 607 case sources through frontend checking.

The local Linux amd64 runtime suite passed 147 of 148 cases without skips. Its HTTP server test encountered an existing service on port 8080 and received that service's response; this run cannot validate that server case. Network-dependent Rust and std tests passed with local socket access enabled.

The CI run at head `834368d33f2595dfb8db1ef48dc2cd9e6850dade` completed with **22 successful / 4 failed checks**. Remaining work is tracked separately:

- Native Windows ARM64 compiler and cases: #493. The new trace locates the access violation during module construction, before object emission; it does not fix the crash.
- Native macOS ARM64 cases: #570, pipe registration fails in the streaming workload.
- Windows GNU amd64 build: #504 (mixed-path assertion) and #571 (MSVC linker-path assertion).
- The MSVC plan also exposes a separate entry-argument routing defect: #572.

Further implementation is paused at the maintainer's request. No tests were removed or newly skipped to hide these failures.
