### PR TITLE
test(regressions): support mixed Windows/Unix path separators in JSON assertions

### DIFF
--- a/tests/codegen_regressions.rs
+++ b/tests/codegen_regressions.rs
@@ -362,8 +362,20 @@ fn json_string_for_test(value: &str) -> String {
 }
 
 fn json_contains_path_components(json: &str, components: &[&str]) -> bool {
-    json_contains_path_value(json, &components.join("/"))
+    if components.is_empty() {
+        return true;
+    }
+    // Check direct matches first (all forward slash or all backslash)
+    if json_contains_path_value(json, &components.join("/"))
         || json_contains_path_value(json, &components.join("\\"))
+    {
+        return true;
+    }
+
+    // Handle mixed separators or escaped separators by checking normalized token runs
+    let normalized_json = json.replace("\\\\", "/").replace('\\', "/");
+    let normalized_target = components.join("/");
+    normalized_json.contains(&normalized_target)
 }
 
 fn json_contains_path_value(json: &str, value: &str) -> bool {
@@ -391,6 +403,10 @@ fn json_path_matching_accepts_unix_and_escaped_windows_separators() {
     assert!(json_contains_path_components(
         r#"{"args":["C:\\wave\\crt\\riscv64-unknown-linux-gnu\\crt1.o"]}"#,
         &components
+    ));
+    assert!(json_contains_path_components(
+        r#"{"args":["D:\\sysroot\\usr/lib\\crt1.o"]}"#,
+        &["sysroot", "usr", "lib", "crt1.o"]
     ));
     assert!(json_contains_path_value(
         r#"{"args":["-LD:\\wave\\sysroot\\lib"]}"#,


### PR DESCRIPTION
## Summary
Improve `json_contains_path_components` in `tests/codegen_regressions.rs` to properly normalize mixed path separators and escaped delimiters when asserting against compiler/linker plan JSON outputs.

## Motivation
Resolves #504. In Windows test environments, link plans generated for FreeBSD targets can contain mixed path separators in CRT arguments that failed rigid forward-slash or backslash-only matching assertions.

## Target and compatibility impact
None (test suite assertion helper improvement only).

## Validation
- Ran `cargo test --test codegen_regressions` on modified test cases.
- Validated with Unix, Windows, and mixed separator paths.

## Checklist
- [x] Commits include a DCO `Signed-off-by` line.
- [x] Tests cover new behavior or the PR explains why no test is needed.
- [x] User-facing changes include documentation or diagnostics updates.
- [x] The change preserves the license boundary between the compiler and `std/`.