### PR TITLE
fix: stabilize linker outputs, test cleanup, and Darwin pipes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,8 +79,8 @@ jobs:
 
       - name: Validate Python tooling
         run: |
-          python3 -m py_compile x.py tools/check_wave_corpus.py tools/case_manifest.py tools/populate_case_matrix.py tools/run_tests.py tools/test_contracts.py tools/test_case_manifest.py tools/test_test_contracts.py
-          python3 -m unittest tools.test_case_manifest tools.test_test_contracts
+          python3 -m py_compile x.py tools/check_wave_corpus.py tools/case_manifest.py tools/populate_case_matrix.py tools/run_tests.py tools/test_contracts.py tools/test_case_manifest.py tools/test_test_contracts.py tools/process_tree.py tools/test_process_tree.py
+          python3 -m unittest tools.test_case_manifest tools.test_test_contracts tools.test_process_tree
 
       - name: Test Windows ARM64 dependency archive validation
         shell: pwsh
@@ -220,8 +220,8 @@ jobs:
 
       - name: Validate Python tooling
         run: |
-          python3 -m py_compile x.py tools/check_wave_corpus.py tools/case_manifest.py tools/populate_case_matrix.py tools/run_tests.py tools/test_contracts.py tools/test_case_manifest.py tools/test_test_contracts.py
-          python3 -m unittest tools.test_case_manifest tools.test_test_contracts
+          python3 -m py_compile x.py tools/check_wave_corpus.py tools/case_manifest.py tools/populate_case_matrix.py tools/run_tests.py tools/test_contracts.py tools/test_case_manifest.py tools/test_test_contracts.py tools/process_tree.py tools/test_process_tree.py
+          python3 -m unittest tools.test_case_manifest tools.test_test_contracts tools.test_process_tree
 
       - name: Build release compiler
         run: cargo build --locked --release --verbose
@@ -303,8 +303,8 @@ jobs:
 
       - name: Validate Python tooling
         run: |
-          python3 -m py_compile x.py tools/check_wave_corpus.py tools/case_manifest.py tools/populate_case_matrix.py tools/run_tests.py tools/test_contracts.py tools/test_case_manifest.py tools/test_test_contracts.py
-          python3 -m unittest tools.test_case_manifest tools.test_test_contracts
+          python3 -m py_compile x.py tools/check_wave_corpus.py tools/case_manifest.py tools/populate_case_matrix.py tools/run_tests.py tools/test_contracts.py tools/test_case_manifest.py tools/test_test_contracts.py tools/process_tree.py tools/test_process_tree.py
+          python3 -m unittest tools.test_case_manifest tools.test_test_contracts tools.test_process_tree
 
       - name: Build release compiler
         run: cargo build --locked --release --verbose
@@ -574,8 +574,8 @@ jobs:
 
       - name: Validate Python tooling
         run: |
-          python3 -m py_compile x.py tools/check_wave_corpus.py tools/case_manifest.py tools/populate_case_matrix.py tools/run_tests.py tools/test_contracts.py tools/test_case_manifest.py tools/test_test_contracts.py
-          python3 -m unittest tools.test_case_manifest tools.test_test_contracts
+          python3 -m py_compile x.py tools/check_wave_corpus.py tools/case_manifest.py tools/populate_case_matrix.py tools/run_tests.py tools/test_contracts.py tools/test_case_manifest.py tools/test_test_contracts.py tools/process_tree.py tools/test_process_tree.py
+          python3 -m unittest tools.test_case_manifest tools.test_test_contracts tools.test_process_tree
 
       - name: Build release compiler
         run: cargo build --locked --release --verbose
@@ -639,8 +639,8 @@ jobs:
 
       - name: Validate Python tooling
         run: |
-          python3 -m py_compile x.py tools/check_wave_corpus.py tools/case_manifest.py tools/populate_case_matrix.py tools/run_tests.py tools/test_contracts.py tools/test_case_manifest.py tools/test_test_contracts.py
-          python3 -m unittest tools.test_case_manifest tools.test_test_contracts
+          python3 -m py_compile x.py tools/check_wave_corpus.py tools/case_manifest.py tools/populate_case_matrix.py tools/run_tests.py tools/test_contracts.py tools/test_case_manifest.py tools/test_test_contracts.py tools/process_tree.py tools/test_process_tree.py
+          python3 -m unittest tools.test_case_manifest tools.test_test_contracts tools.test_process_tree
 
       - name: Build release compiler
         run: cargo build --locked --release --verbose
@@ -769,8 +769,8 @@ jobs:
           PYTHONUTF8: "1"
           PYTHONIOENCODING: "utf-8"
         run: |
-          python -m py_compile x.py tools/check_wave_corpus.py tools/case_manifest.py tools/populate_case_matrix.py tools/run_tests.py tools/test_contracts.py tools/test_case_manifest.py tools/test_test_contracts.py
-          python -m unittest tools.test_case_manifest tools.test_test_contracts
+          python -m py_compile x.py tools/check_wave_corpus.py tools/case_manifest.py tools/populate_case_matrix.py tools/run_tests.py tools/test_contracts.py tools/test_case_manifest.py tools/test_test_contracts.py tools/process_tree.py tools/test_process_tree.py
+          python -m unittest tools.test_case_manifest tools.test_test_contracts tools.test_process_tree
 
       - name: Build release compiler
         shell: msys2 {0}
@@ -915,6 +915,9 @@ jobs:
         run: >-
           cargo build --locked --release --target aarch64-pc-windows-msvc
           --no-default-features --features llvm-target-aarch64 --jobs 2
+
+      - name: Check native Windows process supervision
+        run: python -m unittest tools.test_process_tree
 
       - name: Run native ARM64 unit and frontend driver tests
         run: >-

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -921,6 +921,12 @@ jobs:
           cargo test --locked --lib --test frontend_regressions --target aarch64-pc-windows-msvc
           --no-default-features --features llvm-target-aarch64 --jobs 2
 
+      - name: Check native MSVC companion artifact publication
+        run: >-
+          cargo test --locked --test codegen_regressions --target aarch64-pc-windows-msvc
+          --no-default-features --features llvm-target-aarch64 --jobs 2
+          msvc_link_companions_keep_final_names_and_survive_failed_replacement
+
       - name: Install Wave stdlib
         shell: pwsh
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -858,6 +858,8 @@ jobs:
     name: Build Windows ARM64 natively
     runs-on: windows-11-vs2026-arm
     timeout-minutes: 90
+    env:
+      CARGO_PROFILE_RELEASE_DEBUG: "1"
 
     steps:
       - uses: actions/checkout@v4
@@ -866,6 +868,12 @@ jobs:
         uses: dtolnay/rust-toolchain@1.89.0
         with:
           components: rustfmt, clippy
+
+      # The pinned ARM64 LLDB links against Python 3.11.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          architecture: "arm64"
 
       - name: Install pinned native LLVM 21
         shell: pwsh
@@ -915,6 +923,26 @@ jobs:
         run: >-
           cargo build --locked --release --target aarch64-pc-windows-msvc
           --no-default-features --features llvm-target-aarch64 --jobs 2
+
+      - name: Diagnose native ARM64 code generation
+        id: native_codegen
+        timeout-minutes: 10
+        run: >-
+          python tools/diagnose_windows_arm64.py
+          --wavec target/aarch64-pc-windows-msvc/release/wavec.exe
+          --llvm-bin "$env:WAVE_WINDOWS_LLVM_BIN"
+          --output "$env:RUNNER_TEMP/wave-arm64-diagnostics"
+
+      - name: Save native ARM64 crash diagnostics
+        if: ${{ failure() && steps.native_codegen.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-arm64-codegen-diagnostics
+          path: |
+            ${{ runner.temp }}/wave-arm64-diagnostics/
+            target/aarch64-pc-windows-msvc/release/wavec.exe
+            target/aarch64-pc-windows-msvc/release/wavec.pdb
+          retention-days: 7
 
       - name: Check native Windows process supervision
         run: python -m unittest tools.test_process_tree

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,8 +95,8 @@ RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --no-deps --jobs 2
 cargo clippy --locked --workspace --all-targets -- -D warnings
 python3 -m py_compile x.py tools/check_wave_corpus.py tools/case_manifest.py \
   tools/populate_case_matrix.py tools/run_tests.py tools/test_contracts.py \
-  tools/test_case_manifest.py tools/test_test_contracts.py
-python3 -m unittest tools.test_case_manifest tools.test_test_contracts
+  tools/test_case_manifest.py tools/test_test_contracts.py tools/process_tree.py tools/test_process_tree.py
+python3 -m unittest tools.test_case_manifest tools.test_test_contracts tools.test_process_tree
 cargo build --locked --release --jobs 2
 cargo test --locked --workspace --all-targets --verbose
 python3 tools/check_wave_corpus.py --wavec target/release/wavec --run-std-examples
@@ -206,7 +206,7 @@ Wave uses:
 - Locked Rust tests: `cargo test --locked --workspace --all-targets`
 - Automated `.wave` language cases and std examples via
   `python3 tools/check_wave_corpus.py`
-- Python tooling unit tests: `python3 -m unittest tools.test_case_manifest tools.test_test_contracts`
+- Python tooling unit tests: `python3 -m unittest tools.test_case_manifest tools.test_test_contracts tools.test_process_tree`
 
 Contributors should:
 

--- a/llvm/src/codegen/ir.rs
+++ b/llvm/src/codegen/ir.rs
@@ -908,11 +908,18 @@ fn build_module(
             )
         })?;
 
-    codegen_trace("set target metadata");
+    codegen_trace("set target triple");
     module.set_triple(&triple);
 
+    codegen_trace("get target data");
     let td_val: TargetData = tm.get_target_data();
-    module.set_data_layout(&td_val.get_data_layout());
+    codegen_trace("get target data layout");
+    let data_layout = td_val.get_data_layout();
+    codegen_trace("set module data layout");
+    module.set_data_layout(&data_layout);
+    codegen_trace("release target data layout");
+    drop(data_layout);
+    codegen_trace("set target ABI metadata");
     if abi_target.architecture() == super::arch::Architecture::Riscv64 {
         if let Some(abi) = backend.abi.as_deref() {
             module.add_metadata_flag(
@@ -937,6 +944,7 @@ fn build_module(
     let mut struct_field_indices: HashMap<String, HashMap<String, u32>> = HashMap::new();
     let mut struct_field_types: HashMap<String, HashMap<String, WaveType>> = HashMap::new();
     // (1) struct opaque + field index map
+    codegen_trace("declare aggregate types");
     for ast in ast_nodes {
         if let ASTNode::Struct(struct_node) = ast {
             if !struct_node.generic_params.is_empty() {
@@ -979,6 +987,7 @@ fn build_module(
 
     define_variant_types(context, &variant_definitions, &struct_types);
 
+    codegen_trace("lower global initializers");
     for ast in ast_nodes {
         if let ASTNode::Enum(e) = ast {
             add_enum_consts_to_globals(context, e, &mut global_consts);
@@ -1143,6 +1152,7 @@ fn build_module(
         })
         .collect();
 
+    codegen_trace("declare functions");
     for entry in &function_nodes {
         let FunctionNode {
             name,
@@ -1282,6 +1292,7 @@ fn build_module(
         }
     }
 
+    codegen_trace("declare extern functions");
     for ext in &extern_functions {
         if !is_supported_extern_abi(&ext.abi, abi_target) {
             return Err(CodegenError::new(
@@ -1318,6 +1329,9 @@ fn build_module(
 
     for entry in &function_nodes {
         let func_node = entry.node;
+        if std::env::var_os("WAVE_CODEGEN_TRACE").is_some() {
+            eprintln!("[wavec-codegen] lower function body: {}", entry.symbol);
+        }
         let function = *functions
             .get(&entry.symbol)
             .expect("validated function lowering invariant");
@@ -1414,12 +1428,14 @@ fn build_module(
         }
     }
 
+    codegen_trace("build ABI wrappers");
     for export in &export_wrappers {
         build_export_c_wrapper(context, builder, td, export);
     }
 
     build_wasi_start_wrapper(context, builder, module, abi_target)?;
 
+    codegen_trace("verify module");
     module
         .verify()
         .map_err(|e| CodegenError::new(CodegenPhase::Lowering, "verify LLVM module", e))?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2300,8 +2300,19 @@ fn link_objects(
         validate_loongarch64_link_inputs(target_abi, &validation_inputs)
             .map_err(|error| CliError::CommandFailed(error.to_string()))?;
     }
-    let pending = PendingOutput::new(output)?;
-    let (bin, args) = build_linker_args(global, build, objects, pending.path());
+    enum LinkOutput {
+        Single(PendingOutput),
+        Msvc(crate::link_outputs::MsvcOutputs),
+    }
+    let (pending, bin, args) = if llvm::backend::is_windows_msvc_target(&target) {
+        let (bin, mut args) = build_linker_args(global, build, objects, output);
+        let pending = crate::link_outputs::MsvcOutputs::prepare(output, &mut args)?;
+        (LinkOutput::Msvc(pending), bin, args)
+    } else {
+        let pending = PendingOutput::new(output)?;
+        let (bin, args) = build_linker_args(global, build, objects, pending.path());
+        (LinkOutput::Single(pending), bin, args)
+    };
     let mut command = ProcessCommand::new(&bin);
     configure_bundled_llvm_tool_env(&mut command, &bin);
 
@@ -2314,7 +2325,10 @@ fn link_objects(
     })?;
 
     if out.status.success() {
-        return pending.commit().map_err(CliError::from);
+        return match pending {
+            LinkOutput::Single(output) => output.commit().map_err(CliError::from),
+            LinkOutput::Msvc(outputs) => outputs.commit().map_err(CliError::from),
+        };
     }
 
     let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -388,9 +388,6 @@ fn effective_global_for_build(global: &Global, build: &BuildRequest) -> Global {
     if build.no_start_files {
         out.llvm.link_args.push("-nostartfiles".to_string());
     }
-    if let Some(entry) = &build.entry {
-        out.llvm.link_args.push(format!("-Wl,-e,{}", entry));
-    }
     if let Some(script) = &build.linker_script {
         out.llvm
             .link_args
@@ -2607,7 +2604,17 @@ fn build_user_linker_args(
         args.push(obj.clone());
     }
     append_link_search_and_libs(&mut args, global);
-    args.extend(global.llvm.link_args.iter().cloned());
+    let name = linker.rsplit(['/', '\\']).next().unwrap_or(linker);
+    let name = name.strip_suffix(".exe").unwrap_or(name);
+    let direct_linker = matches!(name, "ld" | "ld.lld" | "ld64.lld" | "wasm-ld")
+        || name.ends_with("-ld")
+        || name.ends_with("-ld.lld");
+    if direct_linker {
+        append_lld_link_args(&mut args, &global.llvm.link_args);
+    } else {
+        args.extend(global.llvm.link_args.iter().cloned());
+    }
+    append_entry_args(&mut args, build, !direct_linker);
     append_common_link_mode_args(&mut args, build, LinkerDialect::Gnu);
 
     args.push("-o".to_string());
@@ -2658,6 +2665,7 @@ fn build_darwin_lld_args(
     }
     append_link_search_and_libs(&mut args, global);
     append_lld_link_args(&mut args, &global.llvm.link_args);
+    append_entry_args(&mut args, build, false);
     append_common_link_mode_args(&mut args, build, LinkerDialect::Darwin);
 
     args.push("-o".to_string());
@@ -2704,6 +2712,7 @@ fn build_windows_gnu_linker_args(
     append_windows_mingw_search_paths(&mut args);
     append_link_search_and_libs(&mut args, global);
     append_lld_link_args(&mut args, &global.llvm.link_args);
+    append_entry_args(&mut args, build, false);
     append_common_link_mode_args(&mut args, build, LinkerDialect::Gnu);
 
     if !global.llvm.no_default_libs {
@@ -2776,6 +2785,7 @@ fn build_elf_lld_args(
     }
     append_link_search_and_libs(&mut args, global);
     append_lld_link_args(&mut args, &global.llvm.link_args);
+    append_entry_args(&mut args, build, false);
     append_common_link_mode_args(&mut args, build, LinkerDialect::Gnu);
 
     if !global.llvm.no_default_libs && is_hosted_elf_target(target) {
@@ -2789,6 +2799,16 @@ fn build_elf_lld_args(
     args.push(output.to_string_lossy().to_string());
 
     (resolve_bundled_tool("ld.lld"), args)
+}
+
+fn append_entry_args(args: &mut Vec<String>, build: &BuildRequest, compiler_driver: bool) {
+    if let Some(entry) = &build.entry {
+        if compiler_driver {
+            args.push(format!("-Wl,-e,{entry}"));
+        } else {
+            args.extend(["-e".to_string(), entry.clone()]);
+        }
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 pub mod cli;
 pub mod errors;
 pub mod flags;
+mod link_outputs;
 pub mod link_validation;
 pub mod module_resolver;
 pub mod runner;

--- a/src/link_outputs.rs
+++ b/src/link_outputs.rs
@@ -1,0 +1,317 @@
+// This file is part of the Wave language project.
+// Copyright (c) 2024–2026 Wave Foundation
+// Copyright (c) 2024–2026 LunaStev and contributors
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// SPDX-License-Identifier: MPL-2.0
+// AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+
+//! Publish an MSVC image and its linker-created companions as one output set.
+//!
+//! Staging keeps each final basename: import libraries embed the DLL basename,
+//! so renaming only a randomly named temporary DLL after linking is insufficient.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+struct Output {
+    staged: PathBuf,
+    destination: PathBuf,
+    backup: PathBuf,
+    backed_up: bool,
+    published: bool,
+}
+
+pub(crate) struct MsvcOutputs {
+    outputs: Vec<Output>,
+    directories: Vec<(PathBuf, PathBuf)>,
+    preserve_backups: bool,
+}
+
+impl MsvcOutputs {
+    pub(crate) fn prepare(output: &Path, args: &mut Vec<String>) -> io::Result<Self> {
+        let mut set = Self {
+            outputs: Vec::new(),
+            directories: Vec::new(),
+            preserve_backups: false,
+        };
+        let image = set.stage(output)?;
+        for arg in args.iter_mut() {
+            if option_value(arg, "OUT").is_some() {
+                *arg = format!("/OUT:{}", image.display());
+            }
+        }
+        // LINK derives the .exp basename from the import library, when it emits
+        // that companion. Both share their final directory and basename here.
+        let library = option_path(args, "IMPLIB").unwrap_or_else(|| output.with_extension("lib"));
+        set.rewrite_path(args, "IMPLIB", &library)?;
+        set.stage(&library.with_extension("exp"))?;
+        let pdb = option_path(args, "PDB").unwrap_or_else(|| output.with_extension("pdb"));
+        if !pdb
+            .to_str()
+            .is_some_and(|name| name.eq_ignore_ascii_case("NONE"))
+        {
+            set.rewrite_path(args, "PDB", &pdb)?;
+            if !args
+                .iter()
+                .any(|arg| option_value(arg, "PDBALTPATH").is_some())
+            {
+                let final_pdb = set.outputs.last().unwrap().destination.to_string_lossy();
+                args.push(format!("/PDBALTPATH:{final_pdb}"));
+            }
+        }
+        for (option, default) in [
+            ("ILK", output.with_extension("ilk")),
+            ("MAP", output.with_extension("map")),
+            (
+                "MANIFESTFILE",
+                PathBuf::from(format!("{}.manifest", output.display())),
+            ),
+        ] {
+            if args.iter().any(|arg| {
+                option_value(arg, option).is_some()
+                    || arg.eq_ignore_ascii_case(&format!("/{option}"))
+            }) {
+                let destination = option_path(args, option).unwrap_or(default);
+                set.rewrite_path(args, option, &destination)?;
+            } else {
+                // Implicit companions remain beside the staged image.
+                set.stage(&default)?;
+            }
+        }
+        Ok(set)
+    }
+
+    fn rewrite_path(
+        &mut self,
+        args: &mut Vec<String>,
+        option: &str,
+        destination: &Path,
+    ) -> io::Result<()> {
+        let staged = self.stage(destination)?;
+        args.retain(|arg| {
+            option_value(arg, option).is_none() && !arg.eq_ignore_ascii_case(&format!("/{option}"))
+        });
+        args.push(format!("/{option}:{}", staged.display()));
+        Ok(())
+    }
+
+    fn stage(&mut self, destination: &Path) -> io::Result<PathBuf> {
+        let filename = destination.file_name().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "link output must name a file")
+        })?;
+        let parent = destination
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or(Path::new("."));
+        fs::create_dir_all(parent)?;
+        let parent = fs::canonicalize(parent)?;
+        let destination = parent.join(filename);
+        if self
+            .outputs
+            .iter()
+            .any(|out| out.destination == destination)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "link outputs share the same destination: {}",
+                    destination.display()
+                ),
+            ));
+        }
+        let directory =
+            if let Some((_, staged)) = self.directories.iter().find(|(path, _)| path == &parent) {
+                staged.clone()
+            } else {
+                static NEXT: AtomicU64 = AtomicU64::new(0);
+                let mut selected = None;
+                for _ in 0..128 {
+                    let path = parent.join(format!(
+                        ".wave-link-{}-{}",
+                        std::process::id(),
+                        NEXT.fetch_add(1, Ordering::Relaxed)
+                    ));
+                    match fs::create_dir(&path) {
+                        Ok(()) => {
+                            selected = Some(path);
+                            break;
+                        }
+                        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+                        Err(e) => return Err(e),
+                    }
+                }
+                let staged = selected.ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::AlreadyExists,
+                        "link staging directory collision",
+                    )
+                })?;
+                self.directories.push((parent, staged.clone()));
+                staged
+            };
+        let staged = directory.join(filename);
+        let backup_dir = directory.join(".backups");
+        fs::create_dir_all(&backup_dir)?;
+        let backup = backup_dir.join(self.outputs.len().to_string());
+        self.outputs.push(Output {
+            staged: staged.clone(),
+            destination,
+            backup,
+            backed_up: false,
+            published: false,
+        });
+        Ok(staged)
+    }
+
+    pub(crate) fn commit(mut self) -> io::Result<()> {
+        if fs::metadata(&self.outputs[0].staged)?.len() == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "linker emitted an empty image",
+            ));
+        }
+        for output in &self.outputs {
+            if !output.staged.exists() {
+                continue;
+            }
+            if !output.staged.is_file() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "link output is not a file",
+                ));
+            }
+            if output.destination.exists() && !output.destination.is_file() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "link destination is not a file: {}",
+                        output.destination.display()
+                    ),
+                ));
+            }
+        }
+        // Validate the entire set first, and retain replaced files until every
+        // rename has succeeded so publication errors can restore the old set.
+        let result: io::Result<()> = (|| {
+            for output in &mut self.outputs {
+                if !output.staged.exists() {
+                    continue;
+                }
+                if output.destination.exists() {
+                    fs::rename(&output.destination, &output.backup)?;
+                    output.backed_up = true;
+                }
+                fs::rename(&output.staged, &output.destination)?;
+                output.published = true;
+            }
+            Ok(())
+        })();
+        if let Err(error) = result {
+            for output in self.outputs.iter().rev() {
+                if output.published {
+                    if let Err(rollback) = fs::remove_file(&output.destination) {
+                        self.preserve_backups = true;
+                        return Err(io::Error::other(format!(
+                            "{error}; rollback failed: {rollback}; backups retained at {}",
+                            output.backup.display()
+                        )));
+                    }
+                }
+                if output.backed_up {
+                    if let Err(rollback) = fs::rename(&output.backup, &output.destination) {
+                        self.preserve_backups = true;
+                        return Err(io::Error::other(format!(
+                            "{error}; rollback failed: {rollback}; backups retained at {}",
+                            output.backup.display()
+                        )));
+                    }
+                }
+            }
+            return Err(error);
+        }
+        Ok(())
+    }
+}
+
+fn option_value<'a>(arg: &'a str, option: &str) -> Option<&'a str> {
+    let (name, value) = arg
+        .strip_prefix('/')
+        .or_else(|| arg.strip_prefix('-'))?
+        .split_once(':')?;
+    name.eq_ignore_ascii_case(option).then_some(value)
+}
+
+fn option_path(args: &[String], option: &str) -> Option<PathBuf> {
+    args.iter()
+        .rev()
+        .find_map(|arg| option_value(arg, option).map(PathBuf::from))
+}
+
+impl Drop for MsvcOutputs {
+    fn drop(&mut self) {
+        if !self.preserve_backups {
+            for (_, directory) in &self.directories {
+                let _ = fs::remove_dir_all(directory);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn directory(name: &str) -> PathBuf {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "wave-link-output-test-{name}-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn publication_error_restores_previously_replaced_companions() {
+        let root = directory("rollback");
+        let dll = root.join("answer.dll");
+        let library = root.join("answer.lib");
+        fs::write(&dll, b"old image").unwrap();
+        fs::write(&library, b"old import library").unwrap();
+        let mut args = vec![format!("/OUT:{}", dll.display())];
+        let pending = MsvcOutputs::prepare(&dll, &mut args).unwrap();
+        fs::write(&pending.outputs[0].staged, b"new image").unwrap();
+        fs::write(&pending.outputs[1].staged, b"new import library").unwrap();
+        // Force a filesystem failure after the first artifact was published.
+        fs::create_dir(&pending.outputs[1].backup).unwrap();
+        fs::write(pending.outputs[1].backup.join("occupied"), b"occupied").unwrap();
+        assert!(pending.commit().is_err());
+        assert_eq!(fs::read(&dll).unwrap(), b"old image");
+        assert_eq!(fs::read(&library).unwrap(), b"old import library");
+        assert_eq!(fs::read_dir(&root).unwrap().count(), 2);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn aliasing_output_paths_are_rejected_before_linking() {
+        let root = directory("alias");
+        let dll = root.join("answer.dll");
+        fs::write(&dll, b"old image").unwrap();
+        let mut args = vec![
+            format!("/OUT:{}", dll.display()),
+            format!("/IMPLIB:{}", dll.display()),
+        ];
+        assert!(MsvcOutputs::prepare(&dll, &mut args).is_err());
+        assert_eq!(fs::read(&dll).unwrap(), b"old image");
+        assert_eq!(fs::read_dir(&root).unwrap().count(), 1);
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/std/sys/macos/amd64/fs.wave
+++ b/std/sys/macos/amd64/fs.wave
@@ -99,7 +99,27 @@ pub fun dup(fd: i64) -> i64 {
 }
 
 pub fun pipe(fds: ptr<i32>) -> i64 {
-    return syscall1(42, fds as i64);
+    if (fds == null) {
+        return -14;
+    }
+    // Darwin's pipe syscall returns two descriptors in rax/rdx. It does not
+    // receive an output pointer; publish the pair only after a successful call.
+    var reader: i64;
+    var writer: i64;
+    var id: i64 = MACOS_SYSCALL_BASE + 42;
+    asm {
+        "syscall\njnc 1f\nneg rax\n1:"
+        in("rax") id
+        out("rax") reader
+        out("rdx") writer
+        clobber("rcx", "r11")
+    }
+    if (reader < 0) {
+        return reader;
+    }
+    deref fds[0] = reader as i32;
+    deref fds[1] = writer as i32;
+    return 0;
 }
 
 pub fun dup2(oldfd: i64, newfd: i64) -> i64 {

--- a/std/sys/macos/arm64/fs.wave
+++ b/std/sys/macos/arm64/fs.wave
@@ -98,7 +98,26 @@ pub fun dup(fd: i64) -> i64 {
 }
 
 pub fun pipe(fds: ptr<i32>) -> i64 {
-    return syscall1(42, fds as i64);
+    if (fds == null) {
+        return -14;
+    }
+    // Darwin's pipe syscall returns two descriptors in x0/x1. It does not
+    // receive an output pointer; publish the pair only after a successful call.
+    var reader: i64;
+    var writer: i64;
+    var id: i64 = 42;
+    asm {
+        "svc #0x80\ncneg x0, x0, cs"
+        in("x16") id
+        out("x0") reader
+        out("x1") writer
+    }
+    if (reader < 0) {
+        return reader;
+    }
+    deref fds[0] = reader as i32;
+    deref fds[1] = writer as i32;
+    return 0;
 }
 
 pub fun dup2(oldfd: i64, newfd: i64) -> i64 {

--- a/tests/cases/macos/arm64/test6.wave
+++ b/tests/cases/macos/arm64/test6.wave
@@ -71,18 +71,29 @@ fun consume(state: Decoder, octet: u8) -> Decoder {
 }
 
 fun exercise(resources: ptr<Resources>) -> i32 {
-    var descriptors: array<i32, 2> = [-1, -1];
-    if (io_pipe(&descriptors[0]) < 0) {
+    if (io_pipe(null) != -14) {
+        return 20;
+    }
+    var descriptors: array<i32, 4> = [173, -1, -1, 219];
+    if (io_pipe(&descriptors[1]) != 0) {
         return 1;
     }
-    resources.reader = descriptors[0] as i64;
-    resources.writer = descriptors[1] as i64;
+    resources.reader = descriptors[1] as i64;
+    resources.writer = descriptors[2] as i64;
+    if (resources.reader < 0 || resources.writer < 0 || resources.reader == resources.writer) {
+        return 21;
+    }
+    if (descriptors[0] != 173 || descriptors[3] != 219) {
+        return 22;
+    }
     resources.queue = event_create(1);
     if (resources.queue < 0) {
         return 2;
     }
     var token: u64 = 0x123456789ABCDE;
-    if (event_add(resources.queue, resources.reader, token, 1) < 0) {
+    var registered: i64 = event_add(resources.queue, resources.reader, token, 1);
+    if (registered < 0) {
+        println("kqueue registration failed: {}", registered);
         return 3;
     }
     // "12,-3,45,0,999,-128\n" deliberately splits signs and multi-digit numbers.

--- a/tests/codegen_regressions.rs
+++ b/tests/codegen_regressions.rs
@@ -6107,6 +6107,117 @@ fn run_shared_language_workloads(flag: &str, target: &str, runner: &str) {
 }
 
 #[test]
+fn msvc_link_companions_keep_final_names_and_survive_failed_replacement() {
+    let dir = temp_case_dir("msvc-link-companions");
+    let source = write_wave(
+        &dir,
+        "library.wave",
+        "export(c) fun answer() -> i32 { return 42; }\nfun main() -> i32 { return 0; }\n",
+    );
+    for target in ["x86_64-pc-windows-msvc", "aarch64-pc-windows-msvc"] {
+        if llvm::codegen::target::target_spec_for_triple(target).is_none() {
+            continue;
+        }
+        let output_dir = dir.join(target);
+        run_wavec([
+            OsStr::new("build"),
+            source.as_os_str(),
+            OsStr::new("--target"),
+            OsStr::new(target),
+            OsStr::new("--emit=obj"),
+            OsStr::new("--out-dir"),
+            output_dir.as_os_str(),
+        ]);
+        let object = output_dir.join("library.o");
+        let dll = output_dir.join("answer.dll");
+        let mut command = wavec_command();
+        command.args([
+            OsStr::new("build"),
+            object.as_os_str(),
+            OsStr::new("--target"),
+            OsStr::new(target),
+            OsStr::new("--shared"),
+            OsStr::new("-Cno-default-libs"),
+            OsStr::new("-Clink-arg=/NOENTRY"),
+            OsStr::new("-Clink-arg=/EXPORT:answer"),
+            OsStr::new("-Clink-arg=/DEBUG"),
+            OsStr::new("-o"),
+            dll.as_os_str(),
+        ]);
+        let output = command.output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        for extension in ["dll", "lib", "pdb"] {
+            assert!(
+                output_dir.join(format!("answer.{extension}")).is_file(),
+                "missing final {extension} for {target}"
+            );
+        }
+        let library = fs::read(output_dir.join("answer.lib")).unwrap();
+        assert!(library
+            .windows(b"answer.dll".len())
+            .any(|bytes| bytes == b"answer.dll"));
+        assert!(!library
+            .windows(b".wave-output-".len())
+            .any(|bytes| bytes == b".wave-output-"));
+        let custom_lib = output_dir.join("imports").join("public.lib");
+        let custom_pdb = output_dir.join("symbols").join("private.pdb");
+        command.arg(format!("-Clink-arg=/IMPLIB:{}", custom_lib.display()));
+        command.arg(format!("-Clink-arg=/PDB:{}", custom_pdb.display()));
+        let output = command.output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(fs::read(&custom_lib).unwrap(), library);
+        assert!(custom_pdb.is_file());
+        let consumer = write_wave(
+            &dir,
+            "consumer.wave",
+            r#"
+extern(c) fun answer() -> i32;
+export(c) fun entry() -> i32 { return answer(); }
+fun main() -> i32 { return 0; }
+"#,
+        );
+        let executable = output_dir.join("consumer.exe");
+        run_wavec([
+            OsStr::new("--link"),
+            custom_lib.as_os_str(),
+            OsStr::new("build"),
+            consumer.as_os_str(),
+            OsStr::new("--target"),
+            OsStr::new(target),
+            OsStr::new("--entry=entry"),
+            OsStr::new("-Cno-default-libs"),
+            OsStr::new("-o"),
+            executable.as_os_str(),
+        ]);
+        let image = fs::read(&executable).unwrap();
+        assert!(image
+            .windows(b"answer.dll".len())
+            .any(|bytes| bytes == b"answer.dll"));
+        let original_dll = fs::read(&dll).unwrap();
+        let original_pdb = fs::read(&custom_pdb).unwrap();
+        command.arg("-Clink-arg=/EXPORT:missing_symbol");
+        assert!(!command.output().unwrap().status.success());
+        assert_eq!(fs::read(&dll).unwrap(), original_dll);
+        assert_eq!(fs::read(output_dir.join("answer.lib")).unwrap(), library);
+        assert_eq!(fs::read(&custom_lib).unwrap(), library);
+        assert_eq!(fs::read(&custom_pdb).unwrap(), original_pdb);
+        assert!(!fs::read_dir(&output_dir).unwrap().any(|entry| entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".wave-")));
+    }
+}
+
+#[test]
 fn explicit_entry_uses_the_selected_linker_dialect_once() {
     let dir = temp_case_dir("entry-linker-dialect");
     let source = write_wave(&dir, "entry.wave", "fun main() -> i32 { return 0; }");

--- a/tests/codegen_regressions.rs
+++ b/tests/codegen_regressions.rs
@@ -6107,6 +6107,69 @@ fn run_shared_language_workloads(flag: &str, target: &str, runner: &str) {
 }
 
 #[test]
+fn explicit_entry_uses_the_selected_linker_dialect_once() {
+    let dir = temp_case_dir("entry-linker-dialect");
+    let source = write_wave(&dir, "entry.wave", "fun main() -> i32 { return 0; }");
+    let cases = [
+        ("x86_64-pc-windows-msvc", None, "\"/ENTRY:wave_start\""),
+        ("aarch64-pc-windows-msvc", None, "\"/ENTRY:wave_start\""),
+        ("x86_64-unknown-linux-gnu", None, "\"-e\",\"wave_start\""),
+        (
+            "x86_64-unknown-linux-gnu",
+            Some("ld.lld"),
+            "\"-e\",\"wave_start\"",
+        ),
+        (
+            "x86_64-unknown-linux-gnu",
+            Some("clang"),
+            "\"-Wl,-e,wave_start\"",
+        ),
+        (
+            "x86_64-pc-windows-gnu",
+            Some("gcc"),
+            "\"-Wl,-e,wave_start\"",
+        ),
+        ("aarch64-apple-darwin", None, "\"-e\",\"wave_start\""),
+        ("wasm32-unknown-unknown", None, "\"--entry=wave_start\""),
+    ];
+    for (target, linker, expected) in cases {
+        if llvm::codegen::target::target_spec_for_triple(target).is_none() {
+            continue;
+        }
+        let mut command = wavec_command();
+        command.args([
+            "--error-format=json",
+            "build",
+            source.to_str().unwrap(),
+            "--target",
+            target,
+            "--entry=wave_start",
+            "-Cno-default-libs",
+            "--dry-run",
+        ]);
+        if let Some(linker) = linker {
+            command.arg(format!("-Clinker={linker}"));
+        }
+        let output = command.output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let plan = String::from_utf8(output.stdout).unwrap();
+        let link_args = plan
+            .split("\"args\":[")
+            .nth(1)
+            .unwrap()
+            .split("],\"command\":")
+            .next()
+            .unwrap();
+        assert!(link_args.contains(expected), "{target}/{linker:?}: {plan}");
+        assert_eq!(link_args.matches("wave_start").count(), 1, "{plan}");
+    }
+}
+
+#[test]
 fn explicit_msvc_targets_emit_coff_and_link_without_mingw() {
     let dir = temp_case_dir("msvc-foundation");
     let source = write_wave(

--- a/tests/codegen_regressions.rs
+++ b/tests/codegen_regressions.rs
@@ -6455,3 +6455,67 @@ fn async_frames_emit_for_enabled_native_targets() {
     }
     fs::remove_dir_all(dir).unwrap();
 }
+
+#[test]
+fn darwin_pipe_captures_both_kernel_return_registers() {
+    let dir = temp_case_dir("darwin-pipe");
+    let home = dir.join("home");
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    copy_tree(&root.join("std"), &home.join(".wave/lib/wave/std"));
+    let source = root.join("tests/cases/macos/arm64/test6.wave");
+    let available = run_wavec_capture(["print", "target-list"]).0;
+    for (target, first, second, instruction) in [
+        ("aarch64-apple-darwin", "{x0}", "{x1}", "svc"),
+        ("x86_64-apple-darwin", "{rax}", "{rdx}", "syscall"),
+    ] {
+        if !available.lines().any(|t| t == target) {
+            continue;
+        }
+        for (emit, extension) in [("ir", "ll"), ("obj", "o")] {
+            let output_dir = dir.join(format!("{target}-{emit}"));
+            let output = output_dir.join(format!("test6.{extension}"));
+            let compiled = wavec_command()
+                .env("HOME", &home)
+                .env("USERPROFILE", &home)
+                .arg("build")
+                .arg(&source)
+                .args(["--target", target, "--emit", emit, "--out-dir"])
+                .arg(&output_dir)
+                .output()
+                .unwrap();
+            assert!(
+                compiled.status.success(),
+                "{target}: {}",
+                String::from_utf8_lossy(&compiled.stderr)
+            );
+            if emit == "ir" {
+                let ir = fs::read_to_string(output).unwrap();
+                assert!(
+                    ir.lines().any(|line| line.contains("call { i64, i64 }")
+                        && line.contains("asm sideeffect")
+                        && line.contains(instruction)
+                        && line.contains(first)
+                        && line.contains(second)),
+                    "{target}: pipe must capture both returned descriptors"
+                );
+            }
+        }
+        if cfg!(target_os = "macos") && target.starts_with(std::env::consts::ARCH) {
+            let result = wavec_command()
+                .env("HOME", &home)
+                .env("USERPROFILE", &home)
+                .arg("run")
+                .arg(&source)
+                .output()
+                .unwrap();
+            assert!(
+                result.status.success(),
+                "pipe/kqueue streaming test: {}\n{}\n{}",
+                result.status,
+                String::from_utf8_lossy(&result.stdout),
+                String::from_utf8_lossy(&result.stderr)
+            );
+        }
+    }
+    fs::remove_dir_all(dir).unwrap();
+}

--- a/tools/check_wave_corpus.py
+++ b/tools/check_wave_corpus.py
@@ -22,6 +22,11 @@ import subprocess
 import sys
 import tempfile
 
+try:
+    from tools.process_tree import run_process, timeout_output
+except ModuleNotFoundError:
+    from process_tree import run_process, timeout_output
+
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -90,7 +95,7 @@ def run_std_examples(
     for path in examples:
         relative = path.relative_to(ROOT)
         try:
-            result = subprocess.run(
+            result = run_process(
                 [str(wavec), "run", str(relative)],
                 cwd=ROOT,
                 env=compiler_env,
@@ -100,8 +105,9 @@ def run_std_examples(
                 timeout=timeout,
                 check=False,
             )
-        except subprocess.TimeoutExpired:
-            failures.append((relative, f"timed out after {timeout:g}s"))
+        except subprocess.TimeoutExpired as error:
+            detail = timeout_output(error)
+            failures.append((relative, f"timed out after {timeout:g}s" + (f"\n{detail}" if detail else "")))
             print(f"[RUN TIMEOUT] {relative}")
             continue
 
@@ -145,7 +151,7 @@ def main() -> int:
         for path in files:
             relative = path.relative_to(ROOT)
             try:
-                result = subprocess.run(
+                result = run_process(
                     [str(wavec), "check", str(relative)],
                     cwd=ROOT,
                     env=compiler_env,

--- a/tools/diagnose_windows_arm64.py
+++ b/tools/diagnose_windows_arm64.py
@@ -1,0 +1,103 @@
+# This file is part of the Wave language project.
+# Copyright (c) 2024–2026 Wave Foundation
+# Copyright (c) 2024–2026 LunaStev and contributors
+#
+# This Source Code Form is subject to the terms of the
+# Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+# AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+
+"""Reduce native Windows ARM64 compiler crashes and collect debugger evidence."""
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+try:
+    from tools.process_tree import run_process, timeout_output
+except ModuleNotFoundError:
+    from process_tree import run_process, timeout_output
+
+
+def probe(label, command, directory, environment, timeout=30):
+    command = [str(argument) for argument in command]
+    lines = [f"[{label}] {subprocess.list2cmdline(command)}"]
+    try:
+        result = run_process(command, capture_output=True, text=True,
+                             errors="replace", env=environment, timeout=timeout)
+        code = result.returncode
+        lines.extend([result.stdout, result.stderr,
+                      f"exit: {code} (0x{code & 0xffffffff:08X})"])
+    except subprocess.TimeoutExpired as error:
+        code = 1
+        lines.extend([timeout_output(error), f"timed out after {timeout}s"])
+    except OSError as error:
+        code = 1
+        lines.append(str(error))
+    text = "\n".join(line.rstrip() for line in lines if line) + "\n"
+    (directory / f"{label}.log").write_text(text, encoding="utf-8")
+    print(text, flush=True)
+    return code
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--wavec", type=Path, required=True)
+    parser.add_argument("--llvm-bin", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    options = parser.parse_args()
+    if os.name != "nt":
+        parser.error("this probe must run on native Windows ARM64")
+    image = options.wavec.read_bytes()
+    pe = int.from_bytes(image[0x3c:0x40], "little")
+    if image[:2] != b"MZ" or image[pe:pe+4] != b"PE\0\0" or image[pe+4:pe+6] != b"\x64\xaa":
+        parser.error("wavec must be a native ARM64 PE image")
+    directory = options.output.resolve()
+    directory.mkdir(parents=True, exist_ok=True)
+    environment = dict(os.environ, WAVE_CODEGEN_TRACE="1")
+    root = Path(__file__).resolve().parent.parent
+    probe_home = directory / "home"
+    shutil.copytree(root / "std", probe_home / ".wave/lib/wave/std", dirs_exist_ok=True)
+    environment.update(HOME=str(probe_home), USERPROFILE=str(probe_home))
+    compiler = options.wavec.resolve()
+    debugger = options.llvm_bin.resolve() / "lldb.exe"
+    for label, command in [
+        ("compiler-version", [compiler, "-V"]),
+        ("default-target", [compiler, "print", "default-target"]),
+        ("llvm-version", [options.llvm_bin / "llvm-config.exe", "--version"]),
+        ("debugger-version", [debugger, "--version"]),
+    ]:
+        probe(label, command, directory, environment)
+    minimal = directory / "minimal.wave"
+    minimal.write_text("fun main() -> i32 {\n    return 0;\n}\n", encoding="utf-8")
+    fixture = root / "tests/cases/windows/arm64/test1.wave"
+    failed = False
+    for source in [minimal, fixture]:
+        if probe(f"{source.stem}-check", [compiler, "check", source], directory, environment):
+            failed = True
+            continue
+        for abi in ["gnu", "msvc"]:
+            target = f"aarch64-pc-windows-{abi}"
+            for emit in ["ir", "obj"]:
+                label = f"{source.stem}-{abi}-{emit}"
+                command = [compiler, "build", source, f"--target={target}",
+                           f"--emit={emit}", "--out-dir", directory / label]
+                if probe(label, command, directory, environment):
+                    failed = True
+                    probe(f"{label}-debugger", [
+                        debugger, "--batch", "--no-lldbinit", "-o", "run",
+                        "-k", "thread backtrace all", "-k", "register read",
+                        "-k", "image list", "--", *command,
+                    ], directory, environment, timeout=90)
+                    break
+    return int(failed)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/process_tree.py
+++ b/tools/process_tree.py
@@ -1,0 +1,214 @@
+# This file is part of the Wave language project.
+# Copyright (c) 2024–2026 Wave Foundation
+# Copyright (c) 2024–2026 LunaStev and contributors
+#
+# This Source Code Form is subject to the terms of the
+# Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+# AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+
+"""Own compiler/program descendants for bounded test and example execution."""
+
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+
+class _WindowsJob:
+    def __init__(self):
+        import ctypes
+        from ctypes import wintypes
+
+        self.ctypes = ctypes
+        self.api = ctypes.WinDLL("kernel32", use_last_error=True)
+
+        class BasicLimits(ctypes.Structure):
+            _fields_ = [
+                ("process_time", ctypes.c_int64), ("job_time", ctypes.c_int64),
+                ("flags", wintypes.DWORD), ("minimum", ctypes.c_size_t),
+                ("maximum", ctypes.c_size_t), ("active_limit", wintypes.DWORD),
+                ("affinity", ctypes.c_size_t), ("priority", wintypes.DWORD),
+                ("scheduling", wintypes.DWORD),
+            ]
+
+        class ExtendedLimits(ctypes.Structure):
+            _fields_ = [
+                ("basic", BasicLimits), ("io_counters", ctypes.c_uint64 * 6),
+                ("process_memory", ctypes.c_size_t), ("job_memory", ctypes.c_size_t),
+                ("peak_process_memory", ctypes.c_size_t), ("peak_job_memory", ctypes.c_size_t),
+            ]
+
+        class Accounting(ctypes.Structure):
+            _fields_ = [
+                ("times", ctypes.c_int64 * 4), ("page_faults", wintypes.DWORD),
+                ("total_processes", wintypes.DWORD), ("active_processes", wintypes.DWORD),
+                ("terminated_processes", wintypes.DWORD),
+            ]
+
+        self.accounting_type = Accounting
+        declarations = {
+            "CreateJobObjectW": ([ctypes.c_void_p, wintypes.LPCWSTR], wintypes.HANDLE),
+            "SetInformationJobObject": ([wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, wintypes.DWORD], wintypes.BOOL),
+            "QueryInformationJobObject": ([wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, wintypes.DWORD, ctypes.c_void_p], wintypes.BOOL),
+            "AssignProcessToJobObject": ([wintypes.HANDLE, wintypes.HANDLE], wintypes.BOOL),
+            "OpenProcess": ([wintypes.DWORD, wintypes.BOOL, wintypes.DWORD], wintypes.HANDLE),
+            "TerminateJobObject": ([wintypes.HANDLE, wintypes.UINT], wintypes.BOOL),
+            "CloseHandle": ([wintypes.HANDLE], wintypes.BOOL),
+        }
+        for name, (arguments, result) in declarations.items():
+            function = getattr(self.api, name)
+            function.argtypes = arguments
+            function.restype = result
+        self.handle = self.api.CreateJobObjectW(None, None)
+        if not self.handle:
+            raise ctypes.WinError(ctypes.get_last_error())
+        limits = ExtendedLimits()
+        limits.basic.flags = 0x2000  # JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        if not self.api.SetInformationJobObject(self.handle, 9, ctypes.byref(limits), ctypes.sizeof(limits)):
+            error = ctypes.WinError(ctypes.get_last_error())
+            self.close()
+            raise error
+
+    def assign(self, pid):
+        handle = self.api.OpenProcess(0x0101, False, pid)  # SET_QUOTA | TERMINATE
+        if not handle:
+            raise self.ctypes.WinError(self.ctypes.get_last_error())
+        try:
+            if not self.api.AssignProcessToJobObject(self.handle, handle):
+                raise self.ctypes.WinError(self.ctypes.get_last_error())
+        finally:
+            self.api.CloseHandle(handle)
+
+    def terminate(self):
+        if not self.api.TerminateJobObject(self.handle, 1):
+            raise self.ctypes.WinError(self.ctypes.get_last_error())
+        deadline = time.monotonic() + 5
+        while True:
+            accounting = self.accounting_type()
+            if not self.api.QueryInformationJobObject(self.handle, 1, self.ctypes.byref(accounting), self.ctypes.sizeof(accounting), None):
+                raise self.ctypes.WinError(self.ctypes.get_last_error())
+            if accounting.active_processes == 0:
+                return
+            if time.monotonic() >= deadline:
+                raise TimeoutError("Windows test job did not finish terminating")
+            time.sleep(0.01)
+
+    def close(self):
+        if self.handle:
+            self.api.CloseHandle(self.handle)
+            self.handle = None
+
+
+class ProcessTree:
+    """A POSIX session or Windows job, confined to this test's processes."""
+
+    def __init__(self, args, **kwargs):
+        self.args = args
+        self.job = None
+        self.bootstrap = None
+        self.process = None
+        self.closed = False
+        try:
+            if os.name == "nt":
+                self.job = _WindowsJob()
+                self.bootstrap = tempfile.TemporaryDirectory(prefix="wave-process-job-")
+                ready = Path(self.bootstrap.name) / "ready"
+                # The supervisor must not launch the compiler until assignment.
+                # This removes the Popen/AssignProcessToJobObject child-spawn race.
+                command = [sys.executable, str(Path(__file__).resolve()), "--supervise", str(ready), *args]
+                self.process = subprocess.Popen(command, **kwargs)
+                self.job.assign(self.process.pid)
+                ready.touch()
+            else:
+                self.process = subprocess.Popen(args, start_new_session=True, **kwargs)
+        except BaseException:
+            if self.process is not None:
+                self.process.kill()
+                self.process.communicate()
+            if self.job is not None:
+                self.job.close()
+            if self.bootstrap is not None:
+                self.bootstrap.cleanup()
+            raise
+
+    def terminate(self):
+        if self.job is not None:
+            self.job.terminate()
+        else:
+            try:
+                os.killpg(self.process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+    def close(self):
+        if self.closed:
+            return
+        try:
+            self.terminate()
+        finally:
+            if self.job is not None:
+                self.job.close()
+            try:
+                self.process.communicate()
+            finally:
+                if self.bootstrap is not None:
+                    self.bootstrap.cleanup()
+                self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+
+
+def run_process(args, *, input=None, timeout=None, check=False, **kwargs):
+    if kwargs.pop("capture_output", False):
+        if "stdout" in kwargs or "stderr" in kwargs:
+            raise ValueError("capture_output cannot be combined with stdout/stderr")
+        kwargs.update(stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if input is not None:
+        if "stdin" in kwargs:
+            raise ValueError("stdin and input cannot be used together")
+        kwargs["stdin"] = subprocess.PIPE
+    with ProcessTree(args, **kwargs) as tree:
+        try:
+            stdout, stderr = tree.process.communicate(input=input, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            tree.terminate()
+            stdout, stderr = tree.process.communicate()
+            raise subprocess.TimeoutExpired(args, timeout, output=stdout, stderr=stderr) from None
+        result = subprocess.CompletedProcess(args, tree.process.returncode, stdout, stderr)
+        if check:
+            result.check_returncode()
+        return result
+
+
+def timeout_output(error):
+    def text(value):
+        return value.decode(errors="replace") if isinstance(value, bytes) else value or ""
+    return "\n".join(part.rstrip() for part in (text(error.output), text(error.stderr)) if part.strip())
+
+
+def _supervise(ready, command):
+    deadline = time.monotonic() + 30
+    while not Path(ready).exists():
+        if time.monotonic() >= deadline:
+            raise TimeoutError("test supervisor was not assigned to its Windows job")
+        time.sleep(0.01)
+    status = subprocess.call(command)
+    # Preserve all native Windows exit bits, including access-violation codes.
+    os._exit(status if status < 0x80000000 else status - 0x100000000)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 4 or sys.argv[1] != "--supervise":
+        raise SystemExit("process_tree.py is an internal test-runner helper")
+    _supervise(sys.argv[2], sys.argv[3:])

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -27,6 +27,7 @@ import errno
 from functools import cache
 
 try:
+    from tools.process_tree import ProcessTree, run_process, timeout_output
     from tools.case_manifest import load_case_manifest
     from tools.test_contracts import (
         normalize_arch,
@@ -34,6 +35,7 @@ try:
         validate_compiled_artifact,
     )
 except ModuleNotFoundError:
+    from process_tree import ProcessTree, run_process, timeout_output
     from case_manifest import load_case_manifest
     from test_contracts import (
         normalize_arch,
@@ -219,7 +221,7 @@ def parse_test_metadata(rel_path: str):
 
 @cache
 def compiler_default_target():
-    result = subprocess.run(
+    result = run_process(
         [str(WAVEC), "print", "default-target"], cwd=str(ROOT),
         capture_output=True, text=True, timeout=TIMEOUT_SEC, check=True,
     )
@@ -287,7 +289,7 @@ def send_udp_test_input():
         pass
 
 def run_server_test(cmd):
-    proc = subprocess.Popen(
+    tree = ProcessTree(
         cmd,
         cwd=str(ROOT),
         stdout=subprocess.PIPE,
@@ -329,11 +331,7 @@ def run_server_test(cmd):
         return 0, None
 
     finally:
-        proc.terminate()
-        try:
-            proc.wait(timeout=1)
-        except subprocess.TimeoutExpired:
-            proc.kill()
+        tree.close()
 
 def looks_like_fail(stderr: str) -> bool:
     if not stderr:
@@ -372,7 +370,7 @@ def run_and_classify(name, rel_path, cmd):
                 daemon=True
             ).start()
 
-        result = subprocess.run(
+        result = run_process(
             cmd,
             cwd=str(ROOT),
             input=stdin_data,
@@ -440,7 +438,10 @@ def run_and_classify(name, rel_path, cmd):
         print()
         return 0, None
 
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as error:
+        detail = timeout_output(error)
+        if detail:
+            print(detail)
         if name in KNOWN_TIMEOUT:
             print(f"{CYAN}→ SKIP (expected blocking / unimplemented){RESET}\n")
             return 2, "expected blocking / unimplemented"

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -217,6 +217,14 @@ def iter_test_entries():
 def parse_test_metadata(rel_path: str):
     return parse_test_metadata_file(ROOT / rel_path, rel_path)
 
+@cache
+def compiler_default_target():
+    result = subprocess.run(
+        [str(WAVEC), "print", "default-target"], cwd=str(ROOT),
+        capture_output=True, text=True, timeout=TIMEOUT_SEC, check=True,
+    )
+    return result.stdout.strip()
+
 def command_for_test(name: str, rel_path: str):
     meta = parse_test_metadata(rel_path)
     mode = meta.mode
@@ -402,11 +410,15 @@ def run_and_classify(name, rel_path, cmd):
                 return 3, None
             artifact_error = None
             if compile_target is None:
+                target = metadata.target
+                if not target and (metadata.asm_contains or metadata.asm_not_contains):
+                    target = compiler_default_target()
                 artifact_error = validate_compiled_artifact(
                     name,
                     ROOT / rel_path,
                     TEST_OUTPUT_DIR,
                     metadata,
+                    target=target,
                 )
             if artifact_error:
                 print(f"{RED}→ FAIL (artifact contract){RESET}")

--- a/tools/test_contracts.py
+++ b/tools/test_contracts.py
@@ -316,23 +316,34 @@ def read_elf_contract(path: Path):
     }, None
 
 
-def _assembly_code_lines(assembly: str):
+def _assembly_code_lines(assembly: str, target: str):
+    arch = normalize_arch(target.split("-", 1)[0])
+    comment = "#"
+    if arch == "aarch64":
+        comment = ";" if "apple" in target or "darwin" in target else "//"
+    assembly = re.sub(
+        r"/\*.*?\*/", lambda match: " " + "\n" * match[0].count("\n"),
+        assembly, flags=re.DOTALL,
+    )
     for raw_line in assembly.splitlines():
-        line = raw_line.split("#", 1)[0].strip()
+        line = raw_line.split(comment, 1)[0].strip()
+        if arch == "aarch64" and line.startswith("#"):
+            continue
         if not line or line.startswith(".") or line.endswith(":"):
             continue
         yield line
 
 
-def _assembly_contains(assembly: str, pattern: str) -> bool:
+def _assembly_contains(assembly: str, pattern: str, target: str) -> bool:
     token = re.compile(
         rf"(?<![A-Za-z0-9_.$]){re.escape(pattern)}(?![A-Za-z0-9_.$])"
     )
-    return any(token.search(line) for line in _assembly_code_lines(assembly))
+    return any(token.search(line) for line in _assembly_code_lines(assembly, target))
 
 
 def validate_compiled_artifact(
-    name: str, source_path: Path, output_root: Path, metadata: TestMetadata
+    name: str, source_path: Path, output_root: Path, metadata: TestMetadata,
+    *, target: str | None = None,
 ):
     if metadata.runner != "compile":
         return None
@@ -391,16 +402,19 @@ def validate_compiled_artifact(
                 )
 
     if metadata.asm_contains or metadata.asm_not_contains:
+        target = metadata.target or target
+        if not target:
+            return f"assembly artifact {artifact} requires the effective compiler target"
         try:
             assembly = artifact.read_text()
         except (OSError, UnicodeError) as error:
             return f"failed to read assembly artifact {artifact}: {error}"
 
         for pattern in metadata.asm_contains:
-            if not _assembly_contains(assembly, pattern):
+            if not _assembly_contains(assembly, pattern, target):
                 return f"assembly artifact {artifact} is missing instruction token '{pattern}'"
         for pattern in metadata.asm_not_contains:
-            if _assembly_contains(assembly, pattern):
+            if _assembly_contains(assembly, pattern, target):
                 return (
                     f"assembly artifact {artifact} unexpectedly contains "
                     f"instruction token '{pattern}'"

--- a/tools/test_process_tree.py
+++ b/tools/test_process_tree.py
@@ -1,0 +1,149 @@
+# This file is part of the Wave language project.
+# Copyright (c) 2024–2026 Wave Foundation
+# Copyright (c) 2024–2026 LunaStev and contributors
+#
+# This Source Code Form is subject to the terms of the
+# Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+# AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+
+import contextlib
+import io
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from unittest.mock import patch
+
+from tools import check_wave_corpus, run_tests
+from tools.process_tree import ProcessTree, run_process
+from tools.test_contracts import TestMetadata
+
+
+class ProcessTreeTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="wave-process-tree-test-")
+        self.root = Path(self.temporary.name)
+        self.ready = self.root / "ready"
+        self.release = self.root / "release"
+        self.marker = self.root / "escaped"
+        child = self.root / "child.py"
+        child.write_text(
+            "from pathlib import Path\nimport time\n"
+            f"Path({str(self.ready)!r}).touch()\n"
+            "deadline = time.monotonic() + 15\n"
+            f"while not Path({str(self.release)!r}).exists():\n"
+            "    if time.monotonic() > deadline: raise SystemExit(0)\n"
+            "    time.sleep(0.01)\n"
+            f"Path({str(self.marker)!r}).write_text('survived')\n"
+        )
+        self.compiler = self.root / "compiler.py"
+        self.compiler.write_text(
+            "from pathlib import Path\nimport subprocess,sys,time\n"
+            f"subprocess.Popen([sys.executable, {str(child)!r}], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)\n"
+            f"while not Path({str(self.ready)!r}).exists(): time.sleep(0.01)\n"
+            "print('child ready', flush=True)\n"
+            "print('compiler diagnostic', file=sys.stderr, flush=True)\n"
+            "if '--exit-parent' not in sys.argv: time.sleep(15)\n"
+        )
+        self.command = [sys.executable, str(self.compiler)]
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def assert_descendant_stopped(self):
+        self.assertTrue(self.ready.exists(), "reproducer never launched its child")
+        self.release.touch()
+        time.sleep(0.4)
+        self.assertFalse(self.marker.exists(), "child performed a side effect after cleanup")
+
+    def test_timeout_stops_descendants_and_preserves_diagnostics(self):
+        with self.assertRaises(subprocess.TimeoutExpired) as result:
+            run_process(self.command, capture_output=True, text=True, timeout=2)
+        self.assertIn("child ready", result.exception.output)
+        self.assertIn("compiler diagnostic", result.exception.stderr)
+        self.assert_descendant_stopped()
+
+    def test_cleanup_still_owns_children_after_the_compiler_exits(self):
+        result = run_process(self.command + ["--exit-parent"], capture_output=True, text=True, timeout=3)
+        self.assertEqual(result.returncode, 0)
+        self.assert_descendant_stopped()
+
+    def test_keyboard_interrupt_cleans_up_without_touching_unrelated_processes(self):
+        unrelated_marker = self.root / "unrelated"
+        other = subprocess.Popen([sys.executable, "-c",
+            f"import pathlib,time; time.sleep(1); pathlib.Path({str(unrelated_marker)!r}).touch()"])
+        try:
+            with self.assertRaises(KeyboardInterrupt):
+                with ProcessTree(self.command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True) as tree:
+                    self.assertEqual(tree.process.stdout.readline().strip(), "child ready")
+                    raise KeyboardInterrupt()
+            self.assert_descendant_stopped()
+            self.assertEqual(other.wait(timeout=5), 0)
+            self.assertTrue(unrelated_marker.is_file())
+        finally:
+            if other.poll() is None:
+                other.kill()
+            other.wait()
+
+    def test_std_example_runner_cleans_the_tree_and_reports_captured_output(self):
+        (self.root / "examples/std").mkdir(parents=True)
+        (self.root / "examples/std/case.wave").write_text("fun main() {}")
+        def python_compiler(args, **kwargs):
+            return run_process([sys.executable, *args], **kwargs)
+        with patch.object(check_wave_corpus, "ROOT", self.root), \
+             patch.object(check_wave_corpus, "run_process", side_effect=python_compiler), \
+             contextlib.redirect_stdout(io.StringIO()):
+            failures = check_wave_corpus.run_std_examples(self.compiler, dict(os.environ), 2)
+        self.assertEqual(len(failures), 1)
+        self.assertIn("timed out", failures[0][1])
+        self.assertIn("compiler diagnostic", failures[0][1])
+        self.assert_descendant_stopped()
+
+    def test_case_runner_keeps_timeout_classification_and_cleans_the_tree(self):
+        output = io.StringIO()
+        with patch.object(run_tests, "ROOT", self.root), \
+             patch.object(run_tests, "TIMEOUT_SEC", 2), \
+             patch.object(run_tests, "parse_test_metadata", return_value=TestMetadata()), \
+             patch.object(run_tests, "manifest_compile_target", return_value=None), \
+             contextlib.redirect_stdout(output):
+            status, detail = run_tests.run_and_classify("case", "case.wave", self.command)
+        self.assertEqual(status, -1)
+        self.assertIn("timed out", detail)
+        self.assertIn("compiler diagnostic", output.getvalue())
+        self.assert_descendant_stopped()
+
+    def test_server_cleanup_terminates_generated_server(self):
+        class Socket:
+            def settimeout(self, _): pass
+            def connect(self, _): pass
+            def sendall(self, _): pass
+            def recv(self, _): return b"Welcome to the Wave HTTP Server!"
+            def close(self): pass
+        with patch.object(run_tests.socket, "socket", return_value=Socket()), \
+             contextlib.redirect_stdout(io.StringIO()):
+            status, _ = run_tests.run_server_test(self.command)
+        self.assertEqual(status, 1)
+        self.assert_descendant_stopped()
+
+    def test_input_and_nonzero_status_are_preserved(self):
+        result = run_process([sys.executable, "-c",
+            "import sys; print(sys.stdin.read()); sys.exit(7)"],
+            input="hello", capture_output=True, text=True, timeout=3)
+        self.assertEqual(result.returncode, 7)
+        self.assertEqual(result.stdout.strip(), "hello")
+
+    @unittest.skipUnless(os.name == "nt", "native Windows exit-code contract")
+    def test_windows_crash_exit_code_is_not_truncated_by_supervisor(self):
+        result = run_process([sys.executable, "-c", "import os; os._exit(-1073741819)"], timeout=3)
+        self.assertEqual(result.returncode, 0xC0000005)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_test_contracts.py
+++ b/tools/test_test_contracts.py
@@ -160,9 +160,54 @@ class ArtifactContractTests(unittest.TestCase):
         artifact.write_bytes(make_elf(machine=258, flags=0x42))
         self.assertIn("LoongArch float ABI mismatch", self.validate(source, metadata))
 
+    def test_aarch64_immediates_survive_target_specific_comment_filtering(self):
+        for target, comment in (
+            ("aarch64-unknown-linux-gnu", "//"),
+            ("aarch64-pc-windows-msvc", "//"),
+            ("aarch64-apple-darwin", ";"),
+        ):
+            with self.subTest(target=target):
+                body = (
+                    f"mode=build, runner=compile, emit=asm, target={target}, "
+                    "asm-contains=#16, asm-not-contains=brk|#32"
+                )
+                source, metadata = self.prepare(body, ".s",
+                    f"{comment} brk #32\nlabel: {comment} brk\n"
+                    f".word 16 {comment} brk\nadd x0, x0, #16 {comment} brk #32\n"
+                    "/* brk #32\n continued comment */ ret\n")
+                self.assertIsNone(self.validate(source, metadata))
+                artifact = self.outputs / "case" / "case.s"
+                artifact.write_text("add x0, x0, #32\n")
+                self.assertIn("missing instruction token '#16'", self.validate(source, metadata))
+                artifact.write_text("add x0, x0, #16\nbrk #32\n")
+                self.assertIn("unexpectedly contains", self.validate(source, metadata))
+
+    def test_hash_comments_stay_comments_for_other_supported_architectures(self):
+        for target, instruction, immediate, forbidden in (
+            ("x86_64-unknown-linux-gnu", "addq $16, %rax", "$16", "int3"),
+            ("riscv64-unknown-linux-gnu", "addi a0, a0, 16", "16", "ebreak"),
+            ("loongarch64-unknown-linux-gnu", "addi.d $a0, $a0, 16", "16", "break"),
+        ):
+            with self.subTest(target=target):
+                body = (
+                    f"mode=build, runner=compile, emit=asm, target={target}, "
+                    f"asm-contains={immediate}, asm-not-contains={forbidden}"
+                )
+                source, metadata = self.prepare(body, ".s",
+                    f"# {forbidden}\n{instruction} # {forbidden}\n")
+                self.assertIsNone(self.validate(source, metadata))
+
+    def test_assembly_dialect_comes_from_effective_target(self):
+        source, metadata = self.prepare(
+            "mode=build, runner=compile, emit=asm, asm-contains=#16", ".s",
+            "add x0, x0, #16 // comment\n")
+        self.assertIsNone(validate_compiled_artifact(
+            "case", source, self.outputs, metadata, target="aarch64-unknown-linux-gnu"))
+        self.assertIn("target", self.validate(source, metadata))
+
     def test_assembly_patterns_ignore_comments_directives_and_labels(self):
         body = (
-            "mode=build, runner=compile, emit=asm, "
+            "mode=build, runner=compile, emit=asm, target=riscv64-unknown-linux-gnu, "
             "asm-contains=ecall|a7, asm-not-contains=ebreak"
         )
         source, metadata = self.prepare(


### PR DESCRIPTION
## Summary

Fix linker argument handling and companion output publication, preserve AArch64 assembly immediates in test contracts, clean up generated test processes, and collect both Darwin pipe return descriptors. The fixes are separated into issue-specific commits.

## Motivation

- MSVC entry points received GNU driver flags. Render the entry option once for the chosen linker. Closes #572.
- MSVC companion files retained temporary names or were not published with the final image. Preserve final DLL/import-library/PDB names and restore existing files when publication fails. Closes #536.
- Assembly contract matching treated AArch64 immediates as comments. Use the actual target's comment syntax. Closes #563.
- Timed-out tests could leave generated child processes running. Own each test's process tree and clean it up on timeout, interruption, and completion while retaining diagnostics. Closes #507.
- Darwin pipe wrappers never populated the caller's descriptor array. Capture both kernel return registers and strengthen the existing kqueue streaming regression. Closes #570.

For #493, add finer module-construction tracing, a minimal no-import input, explicit GNU/MSVC IR and object probes, and bounded native LLDB stack collection with release symbols. The native Windows ARM64 access violation still requires a runner trace before selecting a root-cause fix; this PR does not close that issue.

## Target and compatibility impact

Entry options follow the selected native, compiler-driver, MSVC, or WebAssembly linker dialect. MSVC images and companion outputs retain their final basenames. Test cleanup uses POSIX process groups or Windows Job Objects. Darwin ARM64 and amd64 pipe wrappers return zero and store both descriptors on success, or return a negative error without publishing a pair.

The existing macOS streaming workload remains enabled and is also exercised by the Rust regression on either native macOS architecture. No language syntax changes are introduced.

## Validation

Passed locally on Linux:

- `cargo fmt --all --check`
- `./tools/check_std_policy.sh`
- `cargo clippy --locked --workspace --all-targets --jobs 2 -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --no-deps --jobs 2`
- `cargo build --locked --release --jobs 2`
- `cargo test --locked --workspace --all-targets --jobs 2`: 191 passed.
- `python3 -m unittest tools.test_case_manifest tools.test_test_contracts tools.test_run_tests tools.test_process_tree`: 32 passed; one native Windows test excluded on Linux.
- `python3 tools/check_wave_corpus.py --wavec target/release/wavec --run-std-examples`: 276 corpus checks and 26 std example executions passed.
- Python syntax checks, workflow YAML parsing, and `git diff --check`.

Targeted regressions reproduced the entry, MSVC companion, assembly-immediate, descendant-cleanup, and Darwin return-register defects before their fixes. Both Darwin targets emit Mach-O objects. ARM64 GNU/MSVC IR and object probes pass when cross compiled on Linux. Native macOS and Windows verification is pending CI.

## Checklist

- [x] Commits include a DCO `Signed-off-by` line.
- [x] Tests cover new behavior or the PR explains why no test is needed.
- [x] User-facing changes include documentation or diagnostics updates.
- [x] The change preserves the license boundary between the compiler and `std/`.
