### PR TITLE
test(msvc): inspect linker arguments in independence assertion

### DIFF
--- a/tests/codegen_regressions.rs
+++ b/tests/codegen_regressions.rs
@@ -6331,7 +6331,10 @@ fun main() -> i32 { return 0; }
             "{plan}"
         );
         assert!(
-            !plan.contains("mingw") && !plan.contains("-lmsvcrt"),
+            !plan.contains("-Wl,")
+                && !plan.contains("-lmingw")
+                && !plan.contains("-lgcc")
+                && !plan.contains("-lmsvcrt"),
             "{plan}"
         );
         // This verifies a PE image, not execution on a Windows host.


### PR DESCRIPTION
## Summary

Refines the MSVC independence regression test assertion in `explicit_msvc_targets_emit_coff_and_link_without_mingw` to inspect specific linker flags (`-Wl,`, `-lmingw`, `-lgcc`, `-lmsvcrt`) rather than rejecting the substring `mingw` anywhere in the rendered plan string.

This prevents false rejections when `lld-link` is installed under host directories containing `mingw` (such as in MSYS2/MinGW Windows CI environments).

Fixes #571