### PR TITLE
fix(tools): validate corpus checker timeout as finite positive float (#585)

### DIFF
--- a/tools/check_wave_corpus.py
+++ b/tools/check_wave_corpus.py
@@ -15,6 +15,7 @@
 """Check every maintained Wave example and standard-library source file."""
 
 import argparse
+import math
 import os
 from pathlib import Path
 import shutil
@@ -31,7 +32,21 @@ except ModuleNotFoundError:
 ROOT = Path(__file__).resolve().parent.parent
 
 
-def parse_args() -> argparse.Namespace:
+def _parse_timeout(value: str) -> float:
+    try:
+        timeout = float(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"timeout must be a finite positive number, got {value!r}"
+        ) from None
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise argparse.ArgumentTypeError(
+            f"timeout must be a finite positive number, got {value!r}"
+        )
+    return timeout
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--wavec",
@@ -40,7 +55,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--timeout",
-        type=float,
+        type=_parse_timeout,
         default=15.0,
         help="per-file timeout in seconds (default: 15)",
     )
@@ -49,7 +64,7 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="run every examples/std/*.wave program after checking the corpus",
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def resolve_wavec(explicit: Path | None) -> Path:
@@ -128,8 +143,8 @@ def run_std_examples(
     return failures
 
 
-def main() -> int:
-    args = parse_args()
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
     try:
         wavec = resolve_wavec(args.wavec)
     except FileNotFoundError as error:

--- a/tools/test_check_wave_corpus.py
+++ b/tools/test_check_wave_corpus.py
@@ -1,0 +1,96 @@
+﻿import io
+import unittest
+from unittest.mock import patch
+
+from tools.check_wave_corpus import parse_args, main
+
+
+class TestCheckWaveCorpusCLI(unittest.TestCase):
+    def test_default_timeout(self):
+        args = parse_args([])
+        self.assertEqual(args.timeout, 15.0)
+
+    def test_valid_positive_timeouts(self):
+        cases = [
+            ("0.25", 0.25),
+            ("1", 1.0),
+            ("15", 15.0),
+            ("30.5", 30.5),
+            ("1e2", 100.0),
+        ]
+        for arg_str, expected in cases:
+            with self.subTest(arg=arg_str):
+                args = parse_args(["--timeout", arg_str])
+                self.assertEqual(args.timeout, expected)
+
+                args_eq = parse_args([f"--timeout={arg_str}"])
+                self.assertEqual(args_eq.timeout, expected)
+
+    def test_invalid_timeouts_table_driven(self):
+        invalid_values = [
+            # Zero
+            "0",
+            "0.0",
+            "-0.0",
+            # Negative
+            "-1",
+            "-0.001",
+            "-15",
+            # NaN
+            "nan",
+            "NaN",
+            "NAN",
+            "-nan",
+            # Infinities
+            "inf",
+            "-inf",
+            "Infinity",
+            "-Infinity",
+            "+inf",
+            # Non-numeric
+            "abc",
+            "",
+            "15s",
+            "None",
+        ]
+        for value in invalid_values:
+            with self.subTest(value=value):
+                stderr = io.StringIO()
+                with patch("sys.stderr", stderr):
+                    with self.assertRaises(SystemExit) as cm:
+                        parse_args([f"--timeout={value}"])
+
+                self.assertEqual(cm.exception.code, 2)
+                err_output = stderr.getvalue()
+                self.assertIn("--timeout", err_output)
+                self.assertIn("timeout must be a finite positive number", err_output)
+                self.assertNotIn("Traceback", err_output)
+
+    def test_main_rejects_invalid_timeout_before_compiler_discovery(self):
+        stderr = io.StringIO()
+        with patch("sys.stderr", stderr):
+            with patch("tools.check_wave_corpus.resolve_wavec") as mock_resolve:
+                with self.assertRaises(SystemExit) as cm:
+                    main(["--timeout=0"])
+
+                self.assertEqual(cm.exception.code, 2)
+                mock_resolve.assert_not_called()
+                err_output = stderr.getvalue()
+                self.assertIn("--timeout", err_output)
+                self.assertIn("timeout must be a finite positive number", err_output)
+                self.assertNotIn("Traceback", err_output)
+
+    def test_help_flag(self):
+        stdout = io.StringIO()
+        with patch("sys.stdout", stdout):
+            with self.assertRaises(SystemExit) as cm:
+                parse_args(["--help"])
+
+        self.assertEqual(cm.exception.code, 0)
+        output = stdout.getvalue()
+        self.assertIn("--timeout TIMEOUT", output)
+        self.assertIn("per-file timeout in seconds (default: 15)", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Validate the `--timeout` CLI option in `tools/check_wave_corpus.py` to ensure it receives a finite positive floating-point number (`> 0`), producing a concise argparse usage error upon invalid input.

Fixes #585.

## Motivation

Previously, `check_wave_corpus.py` used `type=float` without validation for `--timeout`, accepting `0`, negative values, `nan`, `inf`, and `-inf`. These non-positive or non-finite values fail to provide a finite positive per-file budget and were forwarded down to subprocess execution. Validating at the CLI boundary ensures actionable diagnostic errors before process creation or compiler discovery.

## Target and compatibility impact

- `check_wave_corpus.py` rejects non-positive (`<= 0`) and non-finite (`nan`, `inf`, `-inf`) timeouts with exit status 2 and an error message naming `--timeout`.
- Valid finite positive float inputs (including fractional numbers like `0.25`) and the 15.0-second default remain unchanged.

## Validation

- Added table-driven tests in `tools/test_check_wave_corpus.py` covering:
  - Default timeout value (15.0s).
  - Valid positive values (integer and fractional float).
  - Rejection of zero (`0`, `0.0`, `-0.0`), negative values (`-1`, `-0.001`), NaN (`nan`, `NaN`, `-nan`), infinities (`inf`, `-inf`, `Infinity`), and non-numeric strings with exit code 2 and no tracebacks.
  - Rejection of invalid timeouts in `main()` before `resolve_wavec` is invoked.
  - Verification of `--help` output.
- All test suites passed:
  - `python3 -m unittest tools.test_check_wave_corpus` (5 passed).
  - `python3 -m unittest discover -s tools -p "test_*.py"` (38 passed).

## Checklist

- [x] Commits include a DCO `Signed-off-by` line.
- [x] Tests cover new behavior or the PR explains why no test is needed.
- [x] User-facing changes include documentation or diagnostics updates.
- [x] The change preserves the license boundary between the compiler and `std/`.
