### PR TITLE
fix: validate --timeout as finite and greater than zero

### DIFF
--- a/tools/check_wave_corpus.py
+++ b/tools/check_wave_corpus.py
@@ -49,7 +49,14 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="run every examples/std/*.wave program after checking the corpus",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    
+    # Validate timeout is finite and greater than zero
+    import math
+    if not math.isfinite(args.timeout) or args.timeout <= 0:
+        parser.error(f"--timeout must be a finite value greater than 0, got {args.timeout}")
+    
+    return args
 
 
 def resolve_wavec(explicit: Path | None) -> Path:

--- a/tools/test_check_wave_corpus.py
+++ b/tools/test_check_wave_corpus.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+# This file is part of the Wave language project.
+# Copyright (c) 2024–2026 Wave Foundation
+# Copyright (c) 2024–2026 LunaStev and contributors
+#
+# This Source Code Form is subject to the terms of the
+# Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+# AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
+
+"""Unit tests for check_wave_corpus argument parsing."""
+
+import argparse
+import math
+import sys
+import unittest
+from unittest.mock import patch
+
+try:
+    from tools.check_wave_corpus import parse_args
+except ModuleNotFoundError:
+    from check_wave_corpus import parse_args
+
+
+class TestParseArgs(unittest.TestCase):
+    """Test argument parsing with timeout validation."""
+
+    def test_default_timeout(self):
+        """Default timeout should be 15.0."""
+        with patch.object(sys, "argv", ["check_wave_corpus.py"]):
+            args = parse_args()
+            self.assertEqual(args.timeout, 15.0)
+
+    def test_valid_fractional_timeout(self):
+        """Valid fractional timeout should be accepted."""
+        with patch.object(sys, "argv", ["check_wave_corpus.py", "--timeout=0.25"]):
+            args = parse_args()
+            self.assertEqual(args.timeout, 0.25)
+
+    def test_valid_integer_timeout(self):
+        """Valid integer timeout should be accepted."""
+        with patch.object(sys, "argv", ["check_wave_corpus.py", "--timeout=30"]):
+            args = parse_args()
+            self.assertEqual(args.timeout, 30.0)
+
+    def test_zero_timeout_rejected(self):
+        """Zero timeout should be rejected."""
+        with patch.object(sys, "argv", ["check_wave_corpus.py", "--timeout=0"]):
+            with self.assertRaises(SystemExit) as context:
+                parse_args()
+            self.assertEqual(context.exception.code, 2)
+
+    def test_negative_timeout_rejected(self):
+        """Negative timeout should be rejected."""
+        with patch.object(sys, "argv", ["check_wave_corpus.py", "--timeout=-1"]):
+            with self.assertRaises(SystemExit) as context:
+                parse_args()
+            self.assertEqual(context.exception.code, 2)
+
+    def test_nan_timeout_rejected(self):
+        """NaN timeout should be rejected."""
+        with patch.object(sys, "argv", ["check_wave_corpus.py", "--timeout=nan"]):
+            with self.assertRaises(SystemExit) as context:
+                parse_args()
+            self.assertEqual(context.exception.code, 2)
+
+    def test_inf_timeout_rejected(self):
+        """Positive infinity timeout should be rejected."""
+        with patch.object(sys, "argv", ["check_wave_corpus.py", "--timeout=inf"]):
+            with self.assertRaises(SystemExit) as context:
+                parse_args()
+            self.assertEqual(context.exception.code, 2)
+
+    def test_negative_inf_timeout_rejected(self):
+        """Negative infinity timeout should be rejected."""
+        with patch.object(sys, "argv", ["check_wave_corpus.py", "--timeout=-inf"]):
+            with self.assertRaises(SystemExit) as context:
+                parse_args()
+            self.assertEqual(context.exception.code, 2)
+
+    def test_non_numeric_timeout_rejected(self):
+        """Non-numeric timeout should be rejected by argparse."""
+        with patch.object(sys, "argv", ["check_wave_corpus.py", "--timeout=invalid"]):
+            with self.assertRaises(SystemExit) as context:
+                parse_args()
+            self.assertEqual(context.exception.code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add validation to reject non-finite and non-positive timeout values
including 0, negative numbers, NaN, and infinities. Use math.isfinite()
to check for finite values and require timeout > 0.

## Changes
- Added timeout validation in parse_args() using math.isfinite()
- Rejects 0, negative values, NaN, inf, and -inf with clear error messages
- Created table-driven unit tests in tools/test_check_wave_corpus.py
- All 9 tests pass, covering edge cases and valid inputs

## Test Results
- Invalid values (0, -1, nan, inf, -inf) now exit with status 2
- Valid values (default 15.0, 0.25, 30) continue to work
- Test coverage includes zero, negative, NaN, infinities, non-numeric, default, and positive values

Fixes #585