### PR TITLE
fix(tools): read test metadata as UTF-8 with path-aware decode errors

### DIFF
--- a/tools/test_contracts.py
+++ b/tools/test_contracts.py
@@ -104,8 +104,8 @@ def parse_test_metadata(path: Path, display_path: str | None = None) -> TestMeta
     marker = "// wave-test:"
 
     try:
-        lines = path.read_text().splitlines()
-    except OSError as error:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as error:
         raise ValueError(f"failed to read wave-test metadata from {display}: {error}") from error
 
     for line in lines:

--- a/tools/test_test_contracts.py
+++ b/tools/test_test_contracts.py
@@ -10,7 +10,10 @@
 # SPDX-License-Identifier: MPL-2.0
 # AI TRAINING NOTICE: Prohibited without prior written permission. No use for machine learning or generative AI training, fine-tuning, distillation, embedding, or dataset creation.
 
+import os
 from pathlib import Path
+import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -98,6 +101,59 @@ class MetadataContractTests(unittest.TestCase):
                 with self.subTest(body=body):
                     with self.assertRaises(ValueError):
                         self.parse(directory, body)
+
+    def test_utf8_metadata_read_with_non_ascii_comments(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "case.wave"
+            source.write_bytes(
+                "// wave-test: mode=check\n// non-ascii comment: 測試 é\nfun main() {}\n".encode(
+                    "utf-8"
+                )
+            )
+            metadata = parse_test_metadata(source, "cases/shared/test1.wave")
+            self.assertEqual(metadata.mode, "check")
+
+    def test_utf8_metadata_read_independent_of_ascii_host_locale(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "case.wave"
+            source.write_bytes(
+                "// wave-test: mode=check\n// non-ascii comment: 測試 é\nfun main() {}\n".encode(
+                    "utf-8"
+                )
+            )
+            command = [
+                sys.executable,
+                "-c",
+                "import sys; from pathlib import Path; "
+                "from tools.test_contracts import parse_test_metadata; "
+                "meta = parse_test_metadata(Path(sys.argv[1]), 'case.wave'); "
+                "sys.stdout.write(meta.mode)",
+                str(source),
+            ]
+            env = {**os.environ, "LC_ALL": "C", "PYTHONUTF8": "0"}
+            process = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            self.assertEqual(process.returncode, 0, process.stderr)
+            self.assertEqual(process.stdout, "check")
+
+    def test_invalid_utf8_bytes_reports_display_path_in_value_error(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "case.wave"
+            source.write_bytes(b"// wave-test: mode=check\n// \xff\n")
+            with self.assertRaises(ValueError) as context:
+                parse_test_metadata(source, "shared/case.wave")
+            self.assertIn("failed to read wave-test metadata from shared/case.wave:", str(context.exception))
+            self.assertIsInstance(context.exception.__cause__, UnicodeDecodeError)
+
+            # Also verify fallback to str(source) when display_path is omitted
+            with self.assertRaises(ValueError) as context_default:
+                parse_test_metadata(source)
+            self.assertIn(f"failed to read wave-test metadata from {source}:", str(context_default.exception))
+            self.assertIsInstance(context_default.exception.__cause__, UnicodeDecodeError)
 
 
 class ArtifactContractTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Explicitly read Wave source files as UTF-8 in `parse_test_metadata` and catch decoding errors (`UnicodeDecodeError`) alongside `OSError`, wrapping them in `ValueError` with the case display path (or source path when omitted).

## Motivation

Fixes #584.
Previously, `parse_test_metadata` in `tools/test_contracts.py` invoked `Path.read_text()` without specifying an encoding. Under an ASCII host locale, non-ASCII comments in UTF-8 Wave sources caused metadata discovery failures. Furthermore, decoding errors escaped the display path wrapper, resulting in error messages without case context.

## Target and compatibility impact

None. This only affects Python test metadata parsing across platforms and locales.

## Validation

- Added unit test `test_utf8_metadata_read_with_non_ascii_comments` verifying UTF-8 non-ASCII comments parse cleanly.
- Added unit test `test_utf8_metadata_read_independent_of_ascii_host_locale` exercising metadata discovery under simulated ASCII host locale (`LC_ALL=C`, `PYTHONUTF8=0`).
- Added unit test `test_invalid_utf8_bytes_reports_display_path_in_value_error` checking that malformed UTF-8 wraps into `ValueError` with display path (and fallback source path) and preserves the `UnicodeDecodeError` cause.
- Verified `python3 -m py_compile tools/test_contracts.py tools/test_test_contracts.py`.
- Verified all unit tests pass with `python3 -m unittest tools.test_case_manifest tools.test_test_contracts tools.test_process_tree`.

## Checklist

- [x] Commits include a DCO `Signed-off-by` line.
- [x] Tests cover new behavior or the PR explains why no test is needed.
- [ ] User-facing changes include documentation or diagnostics updates.
- [ ] The change preserves the license boundary between the compiler and `std/`.
