### PR TITLE
fix(tools): treat explicit wavec overrides as authoritative in corpus checker

### DIFF
--- a/tools/check_wave_corpus.py
+++ b/tools/check_wave_corpus.py
@@ -67,27 +67,48 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _resolve_compiler_path(candidate: Path | str) -> Path | None:
+    raw = Path(candidate)
+    if not str(raw).strip():
+        return None
+    if raw.is_file():
+        return raw
+    if not raw.is_absolute():
+        rel = ROOT / raw
+        if rel.is_file():
+            return rel
+    which = shutil.which(str(candidate))
+    if which:
+        return Path(which)
+    return None
+
+
 def resolve_wavec(explicit: Path | None) -> Path:
-    candidates = []
     if explicit is not None:
-        candidates.append(explicit)
-    if os.environ.get("WAVEC"):
-        candidates.append(Path(os.environ["WAVEC"]))
-    candidates.extend(
-        [
-            ROOT / "target" / "release" / "wavec.exe",
-            ROOT / "target" / "release" / "wavec",
-            ROOT / "target" / "debug" / "wavec.exe",
-            ROOT / "target" / "debug" / "wavec",
-            ROOT / "target" / "x86_64-pc-windows-gnu" / "release" / "wavec.exe",
-            ROOT / "target" / "x86_64-pc-windows-gnu" / "debug" / "wavec.exe",
-        ]
-    )
+        resolved = _resolve_compiler_path(explicit)
+        if resolved is not None:
+            return resolved
+        raise FileNotFoundError(f"wavec executable not found at {explicit}")
+
+    env_wavec = os.environ.get("WAVEC")
+    if env_wavec and env_wavec.strip():
+        resolved = _resolve_compiler_path(env_wavec)
+        if resolved is not None:
+            return resolved
+        raise FileNotFoundError(f"wavec executable specified by WAVEC not found: {env_wavec}")
+
+    candidates = [
+        ROOT / "target" / "release" / "wavec.exe",
+        ROOT / "target" / "release" / "wavec",
+        ROOT / "target" / "debug" / "wavec.exe",
+        ROOT / "target" / "debug" / "wavec",
+        ROOT / "target" / "x86_64-pc-windows-gnu" / "release" / "wavec.exe",
+        ROOT / "target" / "x86_64-pc-windows-gnu" / "debug" / "wavec.exe",
+    ]
 
     for candidate in candidates:
-        path = candidate if candidate.is_absolute() else ROOT / candidate
-        if path.is_file():
-            return path
+        if candidate.is_file():
+            return candidate
 
     raise FileNotFoundError("wavec not found; build it or pass --wavec")
 

--- a/tools/test_check_wave_corpus.py
+++ b/tools/test_check_wave_corpus.py
@@ -1,8 +1,12 @@
 ﻿import io
+import os
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
-from tools.check_wave_corpus import parse_args, main
+from tools.check_wave_corpus import parse_args, resolve_wavec, main
+import tools.check_wave_corpus as check_wave_corpus
 
 
 class TestCheckWaveCorpusCLI(unittest.TestCase):
@@ -90,6 +94,104 @@ class TestCheckWaveCorpusCLI(unittest.TestCase):
         output = stdout.getvalue()
         self.assertIn("--timeout TIMEOUT", output)
         self.assertIn("per-file timeout in seconds (default: 15)", output)
+
+
+class TestResolveWavec(unittest.TestCase):
+    def test_invalid_explicit_path_fails_without_selecting_existing_fallback(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            fallback = root / "target" / "release" / "wavec"
+            fallback.parent.mkdir(parents=True)
+            fallback.touch()
+
+            with patch.object(check_wave_corpus, "ROOT", root):
+                with self.assertRaises(FileNotFoundError) as cm:
+                    resolve_wavec(Path("missing/wavec"))
+
+                self.assertIn("missing/wavec", str(cm.exception))
+
+    def test_invalid_explicit_wavec_env_fails_without_selecting_fallback(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            fallback = root / "target" / "release" / "wavec"
+            fallback.parent.mkdir(parents=True)
+            fallback.touch()
+
+            with patch.object(check_wave_corpus, "ROOT", root):
+                with patch.dict(os.environ, {"WAVEC": "missing_env_wavec"}, clear=False):
+                    with self.assertRaises(FileNotFoundError) as cm:
+                        resolve_wavec(None)
+
+                    self.assertIn("missing_env_wavec", str(cm.exception))
+
+    def test_valid_explicit_path_selected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            custom = root / "bin" / "custom_wavec"
+            custom.parent.mkdir(parents=True)
+            custom.touch()
+
+            fallback = root / "target" / "release" / "wavec"
+            fallback.parent.mkdir(parents=True)
+            fallback.touch()
+
+            with patch.object(check_wave_corpus, "ROOT", root):
+                self.assertEqual(resolve_wavec(custom), custom)
+                self.assertEqual(
+                    resolve_wavec(Path("bin/custom_wavec")),
+                    custom,
+                )
+
+    def test_valid_wavec_env_selected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            custom = root / "bin" / "custom_wavec"
+            custom.parent.mkdir(parents=True)
+            custom.touch()
+
+            fallback = root / "target" / "release" / "wavec"
+            fallback.parent.mkdir(parents=True)
+            fallback.touch()
+
+            with patch.object(check_wave_corpus, "ROOT", root):
+                with patch.dict(os.environ, {"WAVEC": str(custom)}, clear=False):
+                    self.assertEqual(resolve_wavec(None), custom)
+
+    def test_no_override_falls_back_to_discovery(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            fallback = root / "target" / "release" / "wavec"
+            fallback.parent.mkdir(parents=True)
+            fallback.touch()
+
+            with patch.object(check_wave_corpus, "ROOT", root):
+                env = os.environ.copy()
+                env.pop("WAVEC", None)
+                with patch.dict(os.environ, env, clear=True):
+                    self.assertEqual(resolve_wavec(None), fallback)
+
+    def test_empty_wavec_env_falls_back_to_discovery(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            fallback = root / "target" / "release" / "wavec"
+            fallback.parent.mkdir(parents=True)
+            fallback.touch()
+
+            with patch.object(check_wave_corpus, "ROOT", root):
+                with patch.dict(os.environ, {"WAVEC": "   "}, clear=False):
+                    self.assertEqual(resolve_wavec(None), fallback)
+
+    def test_no_override_and_no_binary_raises_file_not_found(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            with patch.object(check_wave_corpus, "ROOT", root):
+                env = os.environ.copy()
+                env.pop("WAVEC", None)
+                with patch.dict(os.environ, env, clear=True):
+                    with self.assertRaises(FileNotFoundError) as cm:
+                        resolve_wavec(None)
+
+                    self.assertIn("wavec not found; build it or pass --wavec", str(cm.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Treat explicit `--wavec` arguments and non-empty `WAVEC` environment variables as authoritative in `tools/check_wave_corpus.py`, immediately raising `FileNotFoundError` if the specified binary cannot be found or resolved rather than silently falling back to local build discovery.

## Motivation

Resolves #564. Previously, `resolve_wavec` combined explicit `--wavec`, `WAVEC`, and local build candidate paths into a single candidate list. If the user provided an invalid or misspelled `--wavec` path (or `WAVEC` env variable), the corpus checker fell back to local build paths, potentially validating a stale or unrelated binary.

## Target and compatibility impact

None. Discovery fallback is retained when neither `--wavec` nor `WAVEC` is provided or when `WAVEC` is empty.

## Validation

- Added unit tests in `tools/test_check_wave_corpus.py` covering:
  - Invalid explicit `--wavec` path fails immediately without falling back to existing build outputs.
  - Invalid explicit `WAVEC` environment variable fails immediately without selecting fallback.
  - Valid explicit `--wavec` path is selected.
  - Valid `WAVEC` environment variable is selected.
  - No override falls back to local build discovery.
  - Empty `WAVEC` environment variable falls back to discovery.
  - No override and missing binary raises `FileNotFoundError`.
- Validated test suites:
  - `python3 -m unittest tools.test_case_manifest tools.test_test_contracts tools.test_process_tree tools.test_check_wave_corpus`
  - `python3 -m unittest discover -s tools -p "test_*.py"`
  - `python3 -m py_compile x.py tools/*.py`

## Checklist

- [x] Commits include a DCO `Signed-off-by` line.
- [x] Tests cover new behavior or the PR explains why no test is needed.
- [x] User-facing changes include documentation or diagnostics updates.
- [x] The change preserves the license boundary between the compiler and `std/`.