### PR TITLE
fix: recognize all ASCII whitespace

### DIFF
--- a/std/string/ascii.wave
+++ b/std/string/ascii.wave
@@ -77,6 +77,10 @@ pub fun is_space(c: u8) -> bool {
         return true;
     }
 
+    if (c == 11 || c == 12) {
+        return true;
+    }
+
     if (c == 13) {
         return true;
     }

--- a/std/string/trim.wave
+++ b/std/string/trim.wave
@@ -16,13 +16,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import("std::string::ascii")::{is_space};
+
 pub fun trim_left_index(s: str) -> i32 {
     var i: i32 = 0;
 
     while (s[i] != 0) {
         var c: u8 = s[i];
 
-        if (c == 32 || c == 9 || c == 10 || c == 13) {
+        if (is_space(c)) {
             i += 1;
         } else {
             return i;
@@ -48,7 +50,7 @@ pub fun trim_right_index(s: str) -> i32 {
     while (i >= 0) {
         var c: u8 = s[i];
 
-        if (c == 32 || c == 9 || c == 10 || c == 13) {
+        if (is_space(c)) {
             i -= 1;
         } else {
             return i + 1;

--- a/tests/cases/shared/test81.wave
+++ b/tests/cases/shared/test81.wave
@@ -29,9 +29,11 @@ fun main() -> i32 {
     if (!starts_with("wave-lang", "wave") || !ends_with("main.wave", ".wave")) { failed += 1; }
     if (find_char("banana", 97) != 1 || rfind_char("banana", 97) != 5) { failed += 1; }
     if (!contains_char("wave", 118) || count_char("banana", 97) != 3) { failed += 1; }
-    if (!is_alpha(87) || !is_digit(55) || !is_space(10)) { failed += 1; }
+    if (!is_alpha(87) || !is_digit(55)) { failed += 1; }
+    if (!is_space(9) || !is_space(10) || !is_space(11) || !is_space(12) || !is_space(13) || !is_space(32) || is_space(8)) { failed += 1; }
     if (to_lower(87) != 119 || to_upper(119) != 87) { failed += 1; }
     if (trim_left_index("  wave \n") != 2 || trim_right_index("  wave \n") != 6) { failed += 1; }
+    if (trim_left_index("\x0b\x0cwave") != 2 || trim_right_index("wave\x0b\x0c") != 4) { failed += 1; }
     if (djb2_32("wave") == 0 || fnv1a_64("wave") == 0) { failed += 1; }
 
     return failed;


### PR DESCRIPTION
## Summary

Complete ASCII whitespace classification with vertical tab and form feed, and reuse it from trimming.

## Motivation

Fixes #591.

## Target and compatibility impact

All targets now consistently recognize the six ASCII whitespace bytes.

## Validation

- `target/debug/wavec check tests/cases/shared/test81.wave`
- `git diff --check`
- The full run was attempted but this macOS environment lacks `ld64.lld`.

## Checklist

- [x] Commits include a DCO `Signed-off-by` line.
- [x] Tests cover new behavior or the PR explains why no test is needed.
- [x] User-facing changes include documentation or diagnostics updates.
- [x] The change preserves the license boundary between the compiler and `std/`.
