### PR TITLE
fix: preserve corpus timeout output

### DIFF
--- a/tools/check_wave_corpus.py
+++ b/tools/check_wave_corpus.py
@@ -197,8 +197,11 @@ def main(argv: list[str] | None = None) -> int:
                     timeout=args.timeout,
                     check=False,
                 )
-            except subprocess.TimeoutExpired:
-                failures.append((relative, f"timed out after {args.timeout:g}s"))
+            except subprocess.TimeoutExpired as error:
+                detail = timeout_output(error)
+                failures.append(
+                    (relative, f"timed out after {args.timeout:g}s" + (f"\n{detail}" if detail else ""))
+                )
                 print(f"[TIMEOUT] {relative}")
                 continue
 

--- a/tools/test_check_wave_corpus.py
+++ b/tools/test_check_wave_corpus.py
@@ -1,5 +1,6 @@
 ﻿import io
 import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -192,6 +193,30 @@ class TestResolveWavec(unittest.TestCase):
                         resolve_wavec(None)
 
                     self.assertIn("wavec not found; build it or pass --wavec", str(cm.exception))
+
+
+class TestCorpusTimeout(unittest.TestCase):
+    def test_main_preserves_partial_timeout_output(self):
+        error = subprocess.TimeoutExpired(
+            ["wavec", "check"], 0.1, output="partial stdout", stderr="partial stderr"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            source = root / "std" / "sample.wave"
+            source.parent.mkdir(parents=True)
+            source.write_text("fun main() -> i32 { return 0; }")
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with patch.object(check_wave_corpus, "ROOT", root):
+                with patch.object(check_wave_corpus, "resolve_wavec", return_value=Path("wavec")):
+                    with patch.object(check_wave_corpus, "corpus_files", return_value=[source]):
+                        with patch.object(check_wave_corpus, "run_process", side_effect=error):
+                            with patch("sys.stdout", stdout), patch("sys.stderr", stderr):
+                                self.assertEqual(main(["--timeout=0.1"]), 1)
+
+        self.assertIn("timed out after 0.1s", stderr.getvalue())
+        self.assertIn("partial stdout", stderr.getvalue())
+        self.assertIn("partial stderr", stderr.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Preserve compiler stdout and stderr when a corpus check times out.

## Motivation

Fixes #593.

## Target and compatibility impact

None; diagnostics now match the existing runnable-example timeout behavior.

## Validation

- `python3 -m unittest tools.test_check_wave_corpus` (13 passed)
- `python3 -m ruff check tools/check_wave_corpus.py tools/test_check_wave_corpus.py`
- `git diff --check`

## Checklist

- [x] Commits include a DCO `Signed-off-by` line.
- [x] Tests cover new behavior or the PR explains why no test is needed.
- [x] User-facing changes include documentation or diagnostics updates.
- [x] The change preserves the license boundary between the compiler and `std/`.
