### PR TITLE
fix: reject non-launchable wavec paths

### DIFF
--- a/tools/check_wave_corpus.py
+++ b/tools/check_wave_corpus.py
@@ -83,18 +83,24 @@ def _resolve_compiler_path(candidate: Path | str) -> Path | None:
     return None
 
 
+def _require_launchable(path: Path) -> Path:
+    if os.name != "nt" and not os.access(path, os.X_OK):
+        raise PermissionError(f"wavec executable is not launchable: {path}")
+    return path
+
+
 def resolve_wavec(explicit: Path | None) -> Path:
     if explicit is not None:
         resolved = _resolve_compiler_path(explicit)
         if resolved is not None:
-            return resolved
+            return _require_launchable(resolved)
         raise FileNotFoundError(f"wavec executable not found at {explicit}")
 
     env_wavec = os.environ.get("WAVEC")
     if env_wavec and env_wavec.strip():
         resolved = _resolve_compiler_path(env_wavec)
         if resolved is not None:
-            return resolved
+            return _require_launchable(resolved)
         raise FileNotFoundError(f"wavec executable specified by WAVEC not found: {env_wavec}")
 
     candidates = [
@@ -108,7 +114,7 @@ def resolve_wavec(explicit: Path | None) -> Path:
 
     for candidate in candidates:
         if candidate.is_file():
-            return candidate
+            return _require_launchable(candidate)
 
     raise FileNotFoundError("wavec not found; build it or pass --wavec")
 
@@ -168,7 +174,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     try:
         wavec = resolve_wavec(args.wavec)
-    except FileNotFoundError as error:
+    except OSError as error:
         print(error, file=sys.stderr)
         return 2
 

--- a/tools/test_check_wave_corpus.py
+++ b/tools/test_check_wave_corpus.py
@@ -129,7 +129,7 @@ class TestResolveWavec(unittest.TestCase):
             root = Path(td)
             custom = root / "bin" / "custom_wavec"
             custom.parent.mkdir(parents=True)
-            custom.touch()
+            custom.touch(mode=0o700)
 
             fallback = root / "target" / "release" / "wavec"
             fallback.parent.mkdir(parents=True)
@@ -147,11 +147,11 @@ class TestResolveWavec(unittest.TestCase):
             root = Path(td)
             custom = root / "bin" / "custom_wavec"
             custom.parent.mkdir(parents=True)
-            custom.touch()
+            custom.touch(mode=0o700)
 
             fallback = root / "target" / "release" / "wavec"
             fallback.parent.mkdir(parents=True)
-            fallback.touch()
+            fallback.touch(mode=0o700)
 
             with patch.object(check_wave_corpus, "ROOT", root):
                 with patch.dict(os.environ, {"WAVEC": str(custom)}, clear=False):
@@ -162,7 +162,7 @@ class TestResolveWavec(unittest.TestCase):
             root = Path(td)
             fallback = root / "target" / "release" / "wavec"
             fallback.parent.mkdir(parents=True)
-            fallback.touch()
+            fallback.touch(mode=0o700)
 
             with patch.object(check_wave_corpus, "ROOT", root):
                 env = os.environ.copy()
@@ -175,7 +175,7 @@ class TestResolveWavec(unittest.TestCase):
             root = Path(td)
             fallback = root / "target" / "release" / "wavec"
             fallback.parent.mkdir(parents=True)
-            fallback.touch()
+            fallback.touch(mode=0o700)
 
             with patch.object(check_wave_corpus, "ROOT", root):
                 with patch.dict(os.environ, {"WAVEC": "   "}, clear=False):
@@ -192,6 +192,19 @@ class TestResolveWavec(unittest.TestCase):
                         resolve_wavec(None)
 
                     self.assertIn("wavec not found; build it or pass --wavec", str(cm.exception))
+
+    @unittest.skipIf(os.name == "nt", "POSIX executable bits do not apply")
+    def test_main_rejects_non_executable_compiler_without_traceback(self):
+        with tempfile.TemporaryDirectory() as td:
+            compiler = Path(td) / "wavec"
+            compiler.touch(mode=0o600)
+            stderr = io.StringIO()
+            with patch("sys.stderr", stderr):
+                self.assertEqual(main(["--wavec", str(compiler)]), 2)
+
+        self.assertIn(str(compiler), stderr.getvalue())
+        self.assertIn("not launchable", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Reject non-executable compiler files on POSIX before attempting corpus checks.

## Motivation

Fixes #594.

## Target and compatibility impact

POSIX gains an executable-bit check; Windows behavior is unchanged.

## Validation

- `python3 -m unittest tools.test_check_wave_corpus` (13 passed)
- `python3 -m ruff check tools/check_wave_corpus.py tools/test_check_wave_corpus.py`
- `git diff --check`

## Checklist

- [x] Commits include a DCO `Signed-off-by` line.
- [x] Tests cover new behavior or the PR explains why no test is needed.
- [x] User-facing changes include documentation or diagnostics updates.
- [x] The change preserves the license boundary between the compiler and `std/`.
