### PR TITLE
fix: resolve maintainers from repository root

### DIFF
--- a/tools/get_maintainer.py
+++ b/tools/get_maintainer.py
@@ -27,11 +27,12 @@ Example:
 
 import sys
 import os
+from pathlib import Path
 
-MAINTAINERS_FILE = "MAINTAINERS"
+MAINTAINERS_FILE = Path(__file__).resolve().parent.parent / "MAINTAINERS"
 
 if not os.path.exists(MAINTAINERS_FILE):
-    print("Error: MAINTAINERS file not found.")
+    print(f"Error: MAINTAINERS file not found at {MAINTAINERS_FILE}.")
     sys.exit(1)
 
 if len(sys.argv) < 2:

--- a/tools/test_get_maintainer.py
+++ b/tools/test_get_maintainer.py
@@ -1,0 +1,29 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "tools" / "get_maintainer.py"
+
+
+class TestGetMaintainer(unittest.TestCase):
+    def test_invocation_outside_repository_root(self):
+        with tempfile.TemporaryDirectory() as cwd:
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "front/parser/ast.rs"],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Maintainers to CC:", result.stdout)
+        self.assertNotIn("MAINTAINERS file not found", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Resolve the MAINTAINERS file relative to the script's repository location.

## Motivation

Fixes #595.

## Target and compatibility impact

None; absolute and repository-root invocations now behave consistently.

## Validation

- `python3 -m unittest tools.test_get_maintainer` (1 passed)
- `python3 -m ruff check tools/get_maintainer.py tools/test_get_maintainer.py`
- `git diff --check`

## Checklist

- [x] Commits include a DCO `Signed-off-by` line.
- [x] Tests cover new behavior or the PR explains why no test is needed.
- [x] User-facing changes include documentation or diagnostics updates.
- [x] The change preserves the license boundary between the compiler and `std/`.
